### PR TITLE
fix(ui): correct hub target and settings API call

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "ado-git-repo-insights-extension",
             "version": "1.0.0",
+            "hasInstallScript": true,
             "dependencies": {
                 "vss-web-extension-sdk": "^5.141.0"
             },

--- a/extension/ui/settings.js
+++ b/extension/ui/settings.js
@@ -175,6 +175,7 @@ async function getPipelineName(pipelineId) {
                 const definitions = await client.getDefinitions(
                     webContext.project.id,
                     null, null, null, null, null,
+                    null, null,
                     [pipelineId]
                 );
 

--- a/extension/vss-extension.json
+++ b/extension/vss-extension.json
@@ -49,7 +49,7 @@
             "id": "pr-insights-hub",
             "type": "ms.vss-web.hub",
             "targets": [
-                "ms.vss-web.project-hub"
+                "ms.vss-code-web.code-hub-group"
             ],
             "properties": {
                 "name": "PR Insights",


### PR DESCRIPTION
- Change hub target from invalid 'ms.vss-web.project-hub' to 'ms.vss-code-web.code-hub-group' so dashboard appears under Repos
- Fix getDefinitions() call in settings.js: pass pipelineId as 9th parameter (definitionIds) instead of 7th (continuationToken)

The dashboard hub was not appearing because 'ms.vss-web.project-hub' is not a valid Azure DevOps hub group target. The settings page was showing "Could not verify pipeline" because the API call was passing the pipeline ID to the wrong parameter position, causing a 400 error.