### PR TITLE
fix(extension): add queryOrder to all getDefinitions calls

### DIFF
--- a/extension/tests/api-patterns.test.js
+++ b/extension/tests/api-patterns.test.js
@@ -4,15 +4,27 @@
  * These tests ensure correct API call patterns are used to prevent
  * Azure DevOps API errors like "Continuation token timestamp without
  * query order is ambiguous".
+ *
+ * CRITICAL: Azure DevOps Build API requires queryOrder parameter on ALL
+ * getDefinitions calls, not just bulk fetches.
  */
+
+const fs = require('fs');
+const path = require('path');
 
 describe('Build API Call Patterns', () => {
     describe('getDefinitions queryOrder requirement', () => {
         /**
-         * When fetching multiple pipeline definitions (without specific IDs),
-         * the Azure DevOps API requires a queryOrder parameter for pagination.
-         * Without it, the API returns:
-         * "Continuation token timestamp without query order is ambiguous"
+         * Azure DevOps Build API getDefinitions signature:
+         * 1. project (string) - required
+         * 2. name (string) - optional
+         * 3. repositoryId (string) - optional
+         * 4. repositoryType (string) - optional
+         * 5. queryOrder (DefinitionQueryOrder) - REQUIRED to avoid pagination errors
+         * 6. top (number) - optional
+         * 7. continuationToken (string) - optional
+         * 8. minMetricsTime (Date) - optional
+         * 9. definitionIds (number[]) - optional
          *
          * Valid queryOrder values:
          * - 1 = definitionNameDescending
@@ -20,95 +32,93 @@ describe('Build API Call Patterns', () => {
          * - 3 = lastModifiedDescending
          * - 4 = lastModifiedAscending
          */
-        it('should document the queryOrder requirement for bulk definition fetches', () => {
-            // This is a documentation test - the actual implementation is in dashboard.js
-            // The key insight is: when fetching definitions without a specific ID filter,
-            // always pass queryOrder to avoid pagination errors
 
-            const requiredPattern = {
-                // Parameters for getDefinitions when fetching multiple definitions:
-                project: 'required',
-                name: 'optional',
-                repositoryId: 'optional',
-                repositoryType: 'optional',
-                top: 'optional - but if >25, need queryOrder',
-                continuationToken: 'optional',
-                minMetricsTime: 'optional',
-                definitionIds: 'optional - if provided, queryOrder not needed',
-                queryOrder: 'REQUIRED when fetching bulk definitions without definitionIds'
-            };
-
-            expect(requiredPattern.queryOrder).toContain('REQUIRED');
-        });
-
-        it('should verify dashboard.js uses queryOrder for discoverInsightsPipelines', async () => {
-            // Read the dashboard.js file and verify the pattern
-            const fs = require('fs');
-            const path = require('path');
+        it('should verify ALL getDefinitions calls in dashboard.js have queryOrder at position 5', () => {
             const dashboardPath = path.join(__dirname, '../ui/dashboard.js');
             const dashboardCode = fs.readFileSync(dashboardPath, 'utf8');
 
-            // Find the discoverInsightsPipelines function's getDefinitions call
-            // queryOrder should be the 5th parameter (after project, name, repositoryId, repositoryType)
-            const functionMatch = dashboardCode.match(
-                /async function discoverInsightsPipelines[\s\S]*?getDefinitions\([^)]+\)/
-            );
+            // Find all getDefinitions calls
+            const getDefinitionsCalls = dashboardCode.match(/getDefinitions\([^)]+\)/g);
+            expect(getDefinitionsCalls).not.toBeNull();
+            expect(getDefinitionsCalls.length).toBeGreaterThan(0);
 
-            expect(functionMatch).not.toBeNull();
+            for (const call of getDefinitionsCalls) {
+                const args = call.match(/getDefinitions\(([^)]+)\)/)[1].split(',').map(a => a.trim());
 
-            // The getDefinitions call should have queryOrder as 5th parameter
-            // Pattern: getDefinitions(projectId, null, null, null, 2, 50)
-            // Parameters: project, name, repositoryId, repositoryType, queryOrder, top
-            const callPattern = functionMatch[0].match(/getDefinitions\(([^)]+)\)/);
-            expect(callPattern).not.toBeNull();
-
-            const args = callPattern[1].split(',').map(a => a.trim());
-
-            // Should have at least 6 parameters (project + 4 nulls + queryOrder + top)
-            expect(args.length).toBeGreaterThanOrEqual(6);
-
-            // 5th argument (index 4) should be queryOrder (value 2 = definitionNameAscending)
-            const queryOrderArg = args[4];
-            expect(queryOrderArg).toBe('2');
-
-            // 6th argument (index 5) should be top (value 50)
-            const topArg = args[5];
-            expect(topArg).toBe('50');
+                // Position 5 (index 4) should be queryOrder = 2
+                expect(args.length).toBeGreaterThanOrEqual(5);
+                expect(args[4]).toBe('2');
+            }
         });
 
-        it('should verify specific pipeline ID lookups do NOT need queryOrder', () => {
-            // When fetching a specific pipeline by ID, queryOrder is not needed
-            // because there's no pagination involved
-            const specificIdPattern = {
-                scenario: 'Fetching definitions with definitionIds filter',
-                needsQueryOrder: false,
-                reason: 'Single or specific IDs do not trigger pagination'
+        it('should verify ALL getDefinitions calls in settings.js have queryOrder at position 5', () => {
+            const settingsPath = path.join(__dirname, '../ui/settings.js');
+            const settingsCode = fs.readFileSync(settingsPath, 'utf8');
+
+            // Find all getDefinitions calls (handle multi-line)
+            const normalizedCode = settingsCode.replace(/\s+/g, ' ');
+            const getDefinitionsCalls = normalizedCode.match(/getDefinitions\([^)]+\)/g);
+
+            if (getDefinitionsCalls) {
+                for (const call of getDefinitionsCalls) {
+                    const argsMatch = call.match(/getDefinitions\(([^)]+)\)/);
+                    if (argsMatch) {
+                        const args = argsMatch[1].split(',').map(a => a.trim());
+
+                        // Position 5 (index 4) should be queryOrder = 2
+                        expect(args.length).toBeGreaterThanOrEqual(5);
+                        expect(args[4]).toBe('2');
+                    }
+                }
+            }
+        });
+
+        it('should have at least 3 getDefinitions calls in dashboard.js with correct pattern', () => {
+            const dashboardPath = path.join(__dirname, '../ui/dashboard.js');
+            const dashboardCode = fs.readFileSync(dashboardPath, 'utf8');
+
+            const getDefinitionsCalls = dashboardCode.match(/getDefinitions\([^)]+\)/g);
+            expect(getDefinitionsCalls).not.toBeNull();
+
+            // We expect 3 calls: 2 in resolveFromPipelineId, 1 in discoverInsightsPipelines
+            expect(getDefinitionsCalls.length).toBe(3);
+        });
+
+        it('should document the API parameter signature for reference', () => {
+            const parameterSignature = {
+                1: { name: 'project', type: 'string', required: true },
+                2: { name: 'name', type: 'string', required: false },
+                3: { name: 'repositoryId', type: 'string', required: false },
+                4: { name: 'repositoryType', type: 'string', required: false },
+                5: { name: 'queryOrder', type: 'DefinitionQueryOrder', required: 'ALWAYS (to avoid pagination errors)' },
+                6: { name: 'top', type: 'number', required: false },
+                7: { name: 'continuationToken', type: 'string', required: false },
+                8: { name: 'minMetricsTime', type: 'Date', required: false },
+                9: { name: 'definitionIds', type: 'number[]', required: false }
             };
 
-            expect(specificIdPattern.needsQueryOrder).toBe(false);
+            expect(parameterSignature[5].name).toBe('queryOrder');
+            expect(parameterSignature[5].required).toBe('ALWAYS (to avoid pagination errors)');
         });
     });
 
     describe('DefinitionQueryOrder enum values', () => {
-        // Document the valid queryOrder values for reference
         const DefinitionQueryOrder = {
-            definitionNameDescending: 1,
+            none: 0,
             definitionNameAscending: 2,
-            lastModifiedDescending: 3,
-            lastModifiedAscending: 4
+            definitionNameDescending: 1,
+            lastModifiedAscending: 4,
+            lastModifiedDescending: 3
         };
 
         it('should have definitionNameAscending = 2', () => {
             expect(DefinitionQueryOrder.definitionNameAscending).toBe(2);
         });
 
-        it('should document all valid queryOrder values', () => {
-            expect(Object.keys(DefinitionQueryOrder)).toEqual([
-                'definitionNameDescending',
-                'definitionNameAscending',
-                'lastModifiedDescending',
-                'lastModifiedAscending'
-            ]);
+        it('should use definitionNameAscending (2) as the standard queryOrder value', () => {
+            // This is the value we use in all getDefinitions calls
+            const standardQueryOrder = 2;
+            expect(standardQueryOrder).toBe(DefinitionQueryOrder.definitionNameAscending);
         });
     });
 });

--- a/extension/ui/dashboard.js
+++ b/extension/ui/dashboard.js
@@ -264,7 +264,8 @@ async function resolveFromPipelineId(pipelineId, projectId) {
 
     if (!builds || builds.length === 0) {
         // Get pipeline name for better error message
-        const definitions = await buildClient.getDefinitions(projectId, null, null, null, null, null, [pipelineId]);
+        // queryOrder (5th param): 2 = definitionNameAscending (required by Azure DevOps API)
+        const definitions = await buildClient.getDefinitions(projectId, null, null, null, 2, null, null, null, [pipelineId]);
         const name = definitions?.[0]?.name || `ID ${pipelineId}`;
         throw createNoSuccessfulBuildsError(name);
     }
@@ -276,7 +277,8 @@ async function resolveFromPipelineId(pipelineId, projectId) {
     const hasAggregates = artifacts.some(a => a.name === 'aggregates');
 
     if (!hasAggregates) {
-        const definitions = await buildClient.getDefinitions(projectId, null, null, null, null, null, [pipelineId]);
+        // queryOrder (5th param): 2 = definitionNameAscending (required by Azure DevOps API)
+        const definitions = await buildClient.getDefinitions(projectId, null, null, null, 2, null, null, null, [pipelineId]);
         const name = definitions?.[0]?.name || `ID ${pipelineId}`;
         throw createArtifactsMissingError(name, latestBuild.id);
     }

--- a/extension/ui/settings.js
+++ b/extension/ui/settings.js
@@ -172,10 +172,12 @@ async function getPipelineName(pipelineId) {
             try {
                 const client = BuildRestClient.getClient();
                 const webContext = VSS.getWebContext();
+                // queryOrder (5th param): 2 = definitionNameAscending (required by Azure DevOps API)
                 const definitions = await client.getDefinitions(
                     webContext.project.id,
-                    null, null, null, null, null,
-                    null, null,
+                    null, null, null,
+                    2,    // queryOrder: definitionNameAscending
+                    null, null, null,
                     [pipelineId]
                 );
 


### PR DESCRIPTION
Azure DevOps Build API requires queryOrder parameter on ALL getDefinitions calls, not just bulk fetches. Without it, the API returns: 'Continuation token timestamp without query order is ambiguous'

Added queryOrder=2 (definitionNameAscending) at position 5 to:
- dashboard.js: resolveFromPipelineId (2 calls)
- dashboard.js: discoverInsightsPipelines (already had it)
- settings.js: getPipelineName

Added regression tests to verify ALL getDefinitions calls have queryOrder=2 at position 5.