### PR TITLE
fix: add build steps to release workflow before VSIX packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,9 +125,17 @@ jobs:
           echo "✓ vss-extension.json matches: $VERSION"
           echo "✓ task.json Minor.Patch matches: $TASK_MINOR.$TASK_PATCH (Major preserved at $TASK_MAJOR)"
 
-      - name: Install task dependencies
-        working-directory: extension/tasks/extract-prs
-        run: npm install
+      - name: Install extension dependencies
+        working-directory: extension
+        run: npm ci
+
+      - name: Build extension (tsc + esbuild)
+        working-directory: extension
+        run: npm run build
+
+      - name: Stage task dependencies
+        working-directory: extension
+        run: npm run stage:tasks
 
       - name: Create extension package
         working-directory: extension


### PR DESCRIPTION
The release workflow's build-extension job was missing:
- npm ci (install extension dependencies)
- npm run build (creates dist/ui via tsc + esbuild)
- npm run stage:tasks (stages task dependencies)

These steps were present in the CI build-extension job but not in release. Without them, tfx extension create fails with ENOENT dist/ui.