### PR TITLE
fix: remove deprecated Node16 handler to fix EOL warning

### DIFF
--- a/extension/tasks/extract-prs/task.json
+++ b/extension/tasks/extract-prs/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 2,
-        "Patch": 0
+        "Patch": 1
     },
     "instanceNameFormat": "Extract PR Metrics",
     "inputs": [
@@ -116,9 +116,6 @@
     ],
     "execution": {
         "Node20": {
-            "target": "index.js"
-        },
-        "Node16": {
             "target": "index.js"
         }
     }

--- a/extension/tests/task-node-handler.test.ts
+++ b/extension/tests/task-node-handler.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Task Node Handler Configuration Tests
+ *
+ * Ensures the Azure DevOps task uses only supported Node.js runners.
+ * This prevents regression to deprecated handlers (Node16, Node10, Node6).
+ *
+ * Reference: https://aka.ms/node-runner-guidance
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+describe("Task Node Handler Configuration", () => {
+    const taskJsonPath = path.join(
+        __dirname,
+        "..",
+        "tasks",
+        "extract-prs",
+        "task.json",
+    );
+    let taskConfig: any;
+
+    beforeAll(() => {
+        taskConfig = JSON.parse(fs.readFileSync(taskJsonPath, "utf-8"));
+    });
+
+    describe("Supported Handlers", () => {
+        it("must have Node20 execution handler", () => {
+            expect(taskConfig.execution.Node20).toBeDefined();
+            expect(taskConfig.execution.Node20.target).toBe("index.js");
+        });
+    });
+
+    describe("Deprecated Handlers (must NOT exist)", () => {
+        it("must NOT have deprecated Node16 handler", () => {
+            expect(taskConfig.execution.Node16).toBeUndefined();
+        });
+
+        it("must NOT have deprecated Node10 handler", () => {
+            expect(taskConfig.execution.Node10).toBeUndefined();
+        });
+
+        it("must NOT have deprecated Node handler (Node6)", () => {
+            // Legacy Node handler was for Node 6
+            expect(taskConfig.execution.Node).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
- Remove Node16 fallback execution handler from task.json
- Bump task version to 2.2.1
- Add contract test preventing regression to deprecated handlers

Fixes Azure DevOps warning about Node 16 end-of-life.