### PR TITLE
fix: add NodeTaskRunnerInstaller@0 for self-hosted agent compatibility

### DIFF
--- a/extension-verification-test.yml
+++ b/extension-verification-test.yml
@@ -35,6 +35,12 @@ stages:
             inputs:
               version: '20.x'
 
+          # Step 1.6: Install Node20 runner for pipeline tasks (self-hosted agents may not have it)
+          - task: NodeTaskRunnerInstaller@0
+            displayName: 'Install Node 20 Task Runner'
+            inputs:
+              runnerVersion: '20'
+
           # Step 2: Download previous DB (branch-isolated, first run will fail - OK)
           - task: DownloadPipelineArtifact@2
             displayName: 'Download Previous Database (Golden)'


### PR DESCRIPTION
Self-hosted agents may not have Node20 runner pre-installed. This ensures the ExtractPullRequests@2 task can execute after removing the deprecated Node16 fallback handler.