### PR TITLE
ci: use tokenless codecov uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,7 +395,6 @@ jobs:
         uses: codecov/codecov-action@v5
         if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: python
           fail_ci_if_error: false
@@ -676,7 +675,6 @@ jobs:
         uses: codecov/codecov-action@v5
         if: success()
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./extension/coverage/lcov.info
           flags: typescript
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Remove `CODECOV_TOKEN` from codecov-action@v5 uploads
- Public repos use GitHub OIDC for tokenless authentication

## Why
Badges weren't working because `CODECOV_TOKEN` secret wasn't set. Tokenless auth is simpler for public repos.

🤖 Generated with [Claude Code](https://claude.ai/code)