### PR TITLE
fix(ci): enable coverage in test:ci for badge artifacts

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -22,7 +22,7 @@
     "test:watch": "jest --watch --testPathIgnorePatterns=python-integration",
     "test:coverage": "jest --coverage --testPathIgnorePatterns=python-integration",
     "pretest:ci": "pnpm run build:ui",
-    "test:ci": "jest --ci --reporters=default --reporters=jest-junit --testPathIgnorePatterns=vsix-artifact-inspection",
+    "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit --testPathIgnorePatterns=vsix-artifact-inspection",
     "test:vsix": "jest --ci --testPathPatterns vsix-artifact-inspection",
     "perf:update-baseline": "npx ts-node scripts/update-perf-baseline.ts",
     "copy-sdk": "node scripts/copy-vss-sdk.mjs",


### PR DESCRIPTION
## Summary
- The `test:ci` script was missing `--coverage` flag
- This caused `extension/coverage/lcov.info` to not be generated
- The badge-publish job failed because it depends on this artifact

## Fix
Added `--coverage` to the `test:ci` script in `extension/package.json`

## Test plan
- [x] Verified locally that `pnpm run test:ci` now generates `extension/coverage/lcov.info`
- [x] CI should pass and badge-publish should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)