### PR TITLE
Add multi-provider LLM support (OpenAI, Azure OpenAI, Anthropic)

### DIFF
--- a/docs/internal/enable-ml-features.md
+++ b/docs/internal/enable-ml-features.md
@@ -53,7 +53,11 @@ pip install prophet>=1.1.0
 
 The system automatically detects Prophet and uses it when available, falling back to linear forecasting otherwise.
 
-### For AI Insights (OpenAI)
+### For AI Insights (LLM Providers)
+
+AI Insights supports three LLM providers. Choose the one that best fits your organization's requirements:
+
+#### Option 1: OpenAI (Default)
 
 1. Create an OpenAI account at https://platform.openai.com
 2. Generate an API key
@@ -63,9 +67,35 @@ The system automatically detects Prophet and uses it when available, falling bac
    - Add variable: `OPENAI_API_KEY` = `sk-...` (mark as secret)
    - Link the variable group to your pipeline
 
+#### Option 2: Azure OpenAI (Enterprise)
+
+Recommended for organizations with data residency requirements or existing Azure investments.
+
+1. Create an Azure OpenAI resource in the Azure Portal
+2. Deploy a model (e.g., `gpt-4o`, `gpt-4o-mini`)
+3. Note your endpoint URL and deployment name
+4. Store the configuration as secrets in Azure DevOps:
+   - Go to Pipelines > Library > Variable Groups
+   - Create a new variable group (e.g., "Azure OpenAI Secrets")
+   - Add variables (mark as secret):
+     - `AZURE_OPENAI_ENDPOINT` = `https://your-resource.openai.azure.com`
+     - `AZURE_OPENAI_API_KEY` = your Azure OpenAI key
+     - `AZURE_OPENAI_DEPLOYMENT` = your deployment name
+   - Link the variable group to your pipeline
+
+#### Option 3: Anthropic
+
+1. Create an Anthropic account at https://console.anthropic.com
+2. Generate an API key
+3. Store the key as a secret in Azure DevOps:
+   - Go to Pipelines > Library > Variable Groups
+   - Create a new variable group (e.g., "Anthropic Secrets")
+   - Add variable: `ANTHROPIC_API_KEY` = `sk-ant-...` (mark as secret)
+   - Link the variable group to your pipeline
+
 ## Pipeline Configuration
 
-### Basic Configuration
+### Basic Configuration (OpenAI)
 
 Add the new inputs to your pipeline YAML:
 
@@ -81,10 +111,48 @@ Add the new inputs to your pipeline YAML:
     # Enable ML features
     enablePredictions: true
     enableInsights: true
+    llmProvider: openai
     openaiApiKey: $(OPENAI_API_KEY)
 ```
 
-### Full Example
+### Azure OpenAI Configuration
+
+```yaml
+- task: ExtractPullRequests@2
+  inputs:
+    organization: $(System.CollectionUri)
+    projects: |
+      ProjectA
+      ProjectB
+    pat: $(PAT)
+    generateAggregates: true
+    enablePredictions: true
+    enableInsights: true
+    llmProvider: azure-openai
+    azureOpenaiEndpoint: $(AZURE_OPENAI_ENDPOINT)
+    azureOpenaiApiKey: $(AZURE_OPENAI_API_KEY)
+    azureOpenaiDeployment: $(AZURE_OPENAI_DEPLOYMENT)
+    azureOpenaiApiVersion: '2024-02-01'  # Optional, defaults to 2024-02-01
+```
+
+### Anthropic Configuration
+
+```yaml
+- task: ExtractPullRequests@2
+  inputs:
+    organization: $(System.CollectionUri)
+    projects: |
+      ProjectA
+      ProjectB
+    pat: $(PAT)
+    generateAggregates: true
+    enablePredictions: true
+    enableInsights: true
+    llmProvider: anthropic
+    anthropicApiKey: $(ANTHROPIC_API_KEY)
+```
+
+### Full Example (Azure OpenAI)
 
 ```yaml
 trigger:
@@ -98,7 +166,7 @@ schedules:
     always: true
 
 variables:
-  - group: OpenAI Secrets  # Contains OPENAI_API_KEY
+  - group: Azure OpenAI Secrets  # Contains AZURE_OPENAI_* variables
 
 stages:
   - stage: Extract
@@ -121,7 +189,10 @@ stages:
               generateAggregates: true
               enablePredictions: true
               enableInsights: true
-              openaiApiKey: $(OPENAI_API_KEY)
+              llmProvider: azure-openai
+              azureOpenaiEndpoint: $(AZURE_OPENAI_ENDPOINT)
+              azureOpenaiApiKey: $(AZURE_OPENAI_API_KEY)
+              azureOpenaiDeployment: $(AZURE_OPENAI_DEPLOYMENT)
 
           - task: PublishPipelineArtifact@1
             inputs:
@@ -133,9 +204,15 @@ stages:
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `enablePredictions` | boolean | `false` | Generate ML predictions using Prophet |
-| `enableInsights` | boolean | `false` | Generate AI insights using OpenAI |
-| `openaiApiKey` | string | - | OpenAI API key (required if `enableInsights` is true) |
+| `enablePredictions` | boolean | `false` | Generate ML predictions using Prophet/Linear forecaster |
+| `enableInsights` | boolean | `false` | Generate AI insights using configured LLM provider |
+| `llmProvider` | string | `openai` | LLM provider: `openai`, `azure-openai`, or `anthropic` |
+| `openaiApiKey` | string | - | OpenAI API key (required if `llmProvider` is `openai`) |
+| `azureOpenaiEndpoint` | string | - | Azure OpenAI endpoint URL (required if `llmProvider` is `azure-openai`) |
+| `azureOpenaiApiKey` | string | - | Azure OpenAI API key (required if `llmProvider` is `azure-openai`) |
+| `azureOpenaiDeployment` | string | - | Azure OpenAI deployment name (required if `llmProvider` is `azure-openai`) |
+| `azureOpenaiApiVersion` | string | `2024-02-01` | Azure OpenAI API version |
+| `anthropicApiKey` | string | - | Anthropic API key (required if `llmProvider` is `anthropic`) |
 
 ## Output Files
 
@@ -205,7 +282,7 @@ Contains AI-generated insights with actionable recommendations (v2 schema):
   "schema_version": 1,
   "generated_at": "2026-01-18T12:00:00Z",
   "is_stub": false,
-  "generated_by": "openai-v1.0",
+  "generated_by": "openai-v1.0",  // or "azure-openai-v1.0" or "anthropic-v1.0"
   "insights": [
     {
       "id": "bottleneck-abc123",
@@ -284,9 +361,13 @@ pip install "ado-git-repo-insights[ml]"
 pip install prophet>=1.1.0
 ```
 
-### "AI Insights enabled but OpenAI API Key not provided"
+### "AI Insights enabled but API Key not provided"
 
-Ensure `openaiApiKey` input is set and the variable group is linked to your pipeline.
+Ensure the appropriate API key input is set for your selected provider and the variable group is linked to your pipeline:
+
+- **OpenAI**: Set `openaiApiKey` input
+- **Azure OpenAI**: Set `azureOpenaiEndpoint`, `azureOpenaiApiKey`, and `azureOpenaiDeployment`
+- **Anthropic**: Set `anthropicApiKey` input
 
 ### Prophet installation fails
 
@@ -294,12 +375,14 @@ Prophet requires additional build tools. See [Prophet Installation](https://face
 
 The linear fallback forecaster provides good results without Prophet - consider using it if Prophet installation is problematic.
 
-### OpenAI rate limits
+### LLM API rate limits
 
 The insights generator caches results for 12 hours to minimize API calls. If you hit rate limits:
 1. Wait for the rate limit window to reset
-2. Consider using a higher-tier OpenAI plan
+2. Consider using a higher-tier plan with your provider
 3. Delete `insights/cache.json` to force regeneration
+
+For Azure OpenAI, you can also increase the TPM (tokens per minute) quota in the Azure Portal.
 
 ### "Low Confidence" data quality warning
 
@@ -320,6 +403,17 @@ This indicates 4-7 weeks of data. Forecasts are generated but may be less accura
 
 ### OpenAI (AI Insights)
 - **Cost**: ~$0.001-0.01 per run (depends on PR count)
+- **Runtime**: +5-15 seconds per pipeline run
+- **Caching**: Results cached for 12 hours (same data = no API call)
+
+### Azure OpenAI (AI Insights)
+- **Cost**: Varies by model and region (~$0.001-0.02 per run)
+- **Runtime**: +5-15 seconds per pipeline run
+- **Caching**: Results cached for 12 hours (same data = no API call)
+- **Benefits**: Data residency control, enterprise compliance
+
+### Anthropic (AI Insights)
+- **Cost**: ~$0.003-0.015 per run (depends on PR count)
 - **Runtime**: +5-15 seconds per pipeline run
 - **Caching**: Results cached for 12 hours (same data = no API call)
 
@@ -344,7 +438,18 @@ For local development and testing, synthetic preview data is available:
 ## Security
 
 - **PAT**: Never logged, passed securely to Python process
-- **OpenAI API Key**: Passed via environment variable, never logged
-- **Data**: PR metadata is sent to OpenAI for analysis (titles, cycle times, counts)
+- **API Keys**: All provider API keys are passed via environment variables, never logged
+- **Data**: PR metadata is sent to the configured LLM provider for analysis (titles, cycle times, counts)
 
-If your organization has data residency requirements, consider using Azure OpenAI Service instead.
+### Data Residency Considerations
+
+| Provider | Data Location | Recommendation |
+|----------|--------------|----------------|
+| **OpenAI** | US data centers | Suitable for most organizations |
+| **Azure OpenAI** | Your chosen Azure region | **Recommended** for data residency requirements |
+| **Anthropic** | US data centers | Suitable for most organizations |
+
+For organizations with strict data residency requirements, Azure OpenAI allows you to:
+- Choose the Azure region where your data is processed
+- Leverage existing Azure compliance certifications
+- Use private endpoints for network isolation

--- a/extension/tasks/extract-prs/index.js
+++ b/extension/tasks/extract-prs/index.js
@@ -162,7 +162,17 @@ async function run() {
     const aggregatesDirInput =
       tl.getInput("aggregatesDir", false) || "aggregates";
     // Phase 5: ML features (enablePredictions/enableInsights already read above for install)
+    // LLM provider configuration
+    const llmProvider = tl.getInput("llmProvider", false) || "openai";
     const openaiApiKey = tl.getInput("openaiApiKey", false);
+    // Azure OpenAI configuration
+    const azureOpenaiEndpoint = tl.getInput("azureOpenaiEndpoint", false);
+    const azureOpenaiApiKey = tl.getInput("azureOpenaiApiKey", false);
+    const azureOpenaiDeployment = tl.getInput("azureOpenaiDeployment", false);
+    const azureOpenaiApiVersion =
+      tl.getInput("azureOpenaiApiVersion", false) || "2024-02-01";
+    // Anthropic configuration
+    const anthropicApiKey = tl.getInput("anthropicApiKey", false);
     // CRITICAL: Input name must match task.json contract ('database', not 'databasePath')
     const databaseInput =
       tl.getInput("database", false) || "ado-insights.sqlite";
@@ -238,22 +248,70 @@ async function run() {
       console.log(`Generate Aggregates: true`);
       console.log(`Aggregates Dir: ${aggregatesDir}`);
       if (enablePredictions) console.log(`ML Predictions: enabled`);
-      if (enableInsights) console.log(`AI Insights: enabled`);
-      if (enableInsights && openaiApiKey)
-        console.log(`OpenAI API Key: ********`);
+      if (enableInsights) {
+        console.log(`AI Insights: enabled`);
+        console.log(`LLM Provider: ${llmProvider}`);
+        if (llmProvider === "openai" && openaiApiKey) {
+          console.log(`OpenAI API Key: ********`);
+        } else if (llmProvider === "azure-openai") {
+          if (azureOpenaiEndpoint)
+            console.log(`Azure OpenAI Endpoint: ${azureOpenaiEndpoint}`);
+          if (azureOpenaiApiKey) console.log(`Azure OpenAI API Key: ********`);
+          if (azureOpenaiDeployment)
+            console.log(`Azure OpenAI Deployment: ${azureOpenaiDeployment}`);
+          console.log(`Azure OpenAI API Version: ${azureOpenaiApiVersion}`);
+        } else if (llmProvider === "anthropic" && anthropicApiKey) {
+          console.log(`Anthropic API Key: ********`);
+        }
+      }
     }
     console.log("=".repeat(50));
 
-    // Phase 5: Validate insights configuration
-    if (enableInsights && !openaiApiKey) {
-      tl.setResult(
-        tl.TaskResult.Failed,
-        `AI Insights enabled but OpenAI API Key not provided.\n\n` +
-          `Resolution:\n` +
-          `1. Create a variable group with OPENAI_API_KEY secret\n` +
-          `2. Set openaiApiKey input to $(OPENAI_API_KEY)`,
-      );
-      return;
+    // Phase 5: Validate insights configuration based on selected provider
+    if (enableInsights) {
+      if (llmProvider === "openai" && !openaiApiKey) {
+        tl.setResult(
+          tl.TaskResult.Failed,
+          `AI Insights enabled with OpenAI provider but API Key not provided.\n\n` +
+            `Resolution:\n` +
+            `1. Create a variable group with OPENAI_API_KEY secret\n` +
+            `2. Set openaiApiKey input to $(OPENAI_API_KEY)`,
+        );
+        return;
+      }
+
+      if (llmProvider === "azure-openai") {
+        const missingAzure = [];
+        if (!azureOpenaiEndpoint) missingAzure.push("azureOpenaiEndpoint");
+        if (!azureOpenaiApiKey) missingAzure.push("azureOpenaiApiKey");
+        if (!azureOpenaiDeployment) missingAzure.push("azureOpenaiDeployment");
+
+        if (missingAzure.length > 0) {
+          tl.setResult(
+            tl.TaskResult.Failed,
+            `AI Insights enabled with Azure OpenAI provider but missing configuration.\n\n` +
+              `Missing inputs: ${missingAzure.join(", ")}\n\n` +
+              `Resolution:\n` +
+              `1. Create a variable group with Azure OpenAI secrets\n` +
+              `2. Set the following inputs:\n` +
+              `   - azureOpenaiEndpoint: $(AZURE_OPENAI_ENDPOINT)\n` +
+              `   - azureOpenaiApiKey: $(AZURE_OPENAI_API_KEY)\n` +
+              `   - azureOpenaiDeployment: your-deployment-name`,
+          );
+          return;
+        }
+      }
+
+      if (llmProvider === "anthropic" && !anthropicApiKey) {
+        tl.setResult(
+          tl.TaskResult.Failed,
+          `AI Insights enabled with Anthropic provider but API Key not provided.\n\n` +
+            `Resolution:\n` +
+            `1. Create a variable group with ANTHROPIC_API_KEY secret\n` +
+            `2. Set anthropicApiKey input to $(ANTHROPIC_API_KEY)`,
+        );
+        return;
+      }
     }
 
     // Validate date formats if provided (fail fast on invalid input)
@@ -360,9 +418,23 @@ async function run() {
 
       console.log(`\n[3/${totalSteps}] Generating aggregates...`);
 
-      // Phase 5: Set OPENAI_API_KEY environment variable for insights
-      const aggEnv =
-        enableInsights && openaiApiKey ? { OPENAI_API_KEY: openaiApiKey } : {};
+      // Phase 5: Set LLM provider environment variables for insights
+      const aggEnv = {};
+      if (enableInsights) {
+        if (llmProvider === "openai" && openaiApiKey) {
+          aggEnv.OPENAI_API_KEY = openaiApiKey;
+        } else if (llmProvider === "azure-openai") {
+          if (azureOpenaiEndpoint)
+            aggEnv.AZURE_OPENAI_ENDPOINT = azureOpenaiEndpoint;
+          if (azureOpenaiApiKey)
+            aggEnv.AZURE_OPENAI_API_KEY = azureOpenaiApiKey;
+          if (azureOpenaiDeployment)
+            aggEnv.AZURE_OPENAI_DEPLOYMENT = azureOpenaiDeployment;
+          aggEnv.AZURE_OPENAI_API_VERSION = azureOpenaiApiVersion;
+        } else if (llmProvider === "anthropic" && anthropicApiKey) {
+          aggEnv.ANTHROPIC_API_KEY = anthropicApiKey;
+        }
+      }
 
       const aggResult = await runPython(pythonCmd, aggArgs, aggEnv);
       if (!aggResult) return;

--- a/extension/tasks/extract-prs/task.json
+++ b/extension/tasks/extract-prs/task.json
@@ -102,16 +102,71 @@
             "label": "Generate AI Insights",
             "required": false,
             "defaultValue": "false",
-            "helpMarkDown": "Generate AI-powered insights using OpenAI. Requires generateAggregates and openaiApiKey. Adds ~5-15s to pipeline runtime.",
+            "helpMarkDown": "Generate AI-powered insights. Supports OpenAI, Azure OpenAI, and Anthropic. Requires generateAggregates. Adds ~5-15s to pipeline runtime.",
             "visibleRule": "generateAggregates = true"
+        },
+        {
+            "name": "llmProvider",
+            "type": "pickList",
+            "label": "LLM Provider",
+            "required": false,
+            "defaultValue": "openai",
+            "options": {
+                "openai": "OpenAI",
+                "azure-openai": "Azure OpenAI",
+                "anthropic": "Anthropic"
+            },
+            "helpMarkDown": "Select the LLM provider for AI Insights generation.",
+            "visibleRule": "enableInsights = true"
         },
         {
             "name": "openaiApiKey",
             "type": "string",
             "label": "OpenAI API Key",
             "required": false,
-            "helpMarkDown": "OpenAI API key for AI Insights generation. Use $(OPENAI_API_KEY) from a variable group. Required when enableInsights is true.",
-            "visibleRule": "enableInsights = true"
+            "helpMarkDown": "OpenAI API key for AI Insights. Use $(OPENAI_API_KEY) from a variable group.",
+            "visibleRule": "enableInsights = true && llmProvider = openai"
+        },
+        {
+            "name": "azureOpenaiEndpoint",
+            "type": "string",
+            "label": "Azure OpenAI Endpoint",
+            "required": false,
+            "helpMarkDown": "Azure OpenAI endpoint URL (e.g., https://myresource.openai.azure.com). Use $(AZURE_OPENAI_ENDPOINT) from a variable group.",
+            "visibleRule": "enableInsights = true && llmProvider = azure-openai"
+        },
+        {
+            "name": "azureOpenaiApiKey",
+            "type": "string",
+            "label": "Azure OpenAI API Key",
+            "required": false,
+            "helpMarkDown": "Azure OpenAI API key. Use $(AZURE_OPENAI_API_KEY) from a variable group.",
+            "visibleRule": "enableInsights = true && llmProvider = azure-openai"
+        },
+        {
+            "name": "azureOpenaiDeployment",
+            "type": "string",
+            "label": "Azure OpenAI Deployment",
+            "required": false,
+            "helpMarkDown": "Azure OpenAI deployment name (the name you gave your model deployment).",
+            "visibleRule": "enableInsights = true && llmProvider = azure-openai"
+        },
+        {
+            "name": "azureOpenaiApiVersion",
+            "type": "string",
+            "label": "Azure OpenAI API Version",
+            "required": false,
+            "defaultValue": "2024-02-01",
+            "helpMarkDown": "Azure OpenAI API version (default: 2024-02-01).",
+            "visibleRule": "enableInsights = true && llmProvider = azure-openai"
+        },
+        {
+            "name": "anthropicApiKey",
+            "type": "string",
+            "label": "Anthropic API Key",
+            "required": false,
+            "helpMarkDown": "Anthropic API key for AI Insights. Use $(ANTHROPIC_API_KEY) from a variable group.",
+            "visibleRule": "enableInsights = true && llmProvider = anthropic"
         }
     ],
     "execution": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
 ml = [
     "prophet>=1.1.0",
     "openai>=1.0.0",
+    "anthropic>=0.18.0",
 ]
 
 [project.scripts]
@@ -107,6 +108,7 @@ module = [
     "azure.storage.blob",
     "prophet",
     "openai",
+    "anthropic",
 ]
 ignore_missing_imports = true
 

--- a/src/ado_git_repo_insights/cli.py
+++ b/src/ado_git_repo_insights/cli.py
@@ -200,7 +200,7 @@ def create_parser() -> argparse.ArgumentParser:  # pragma: no cover
         "--enable-insights",
         action="store_true",
         default=False,
-        help="Enable OpenAI-based insights (requires openai package and OPENAI_API_KEY)",
+        help="Enable LLM-based insights (supports OpenAI, Azure OpenAI, Anthropic)",
     )
     agg_parser.add_argument(
         "--insights-max-tokens",
@@ -262,7 +262,7 @@ def create_parser() -> argparse.ArgumentParser:  # pragma: no cover
         "--enable-insights",
         action="store_true",
         default=False,
-        help="Enable OpenAI-based insights",
+        help="Enable LLM-based insights (supports OpenAI, Azure OpenAI, Anthropic)",
     )
     # Unified dashboard serve flags (Flight 260127A)
     build_parser.add_argument(
@@ -756,18 +756,50 @@ def cmd_generate_aggregates(args: Namespace) -> int:
     enable_insights = getattr(args, "enable_insights", False)
     insights_dry_run = getattr(args, "insights_dry_run", False)
     if enable_insights:
-        # Check for OPENAI_API_KEY only if NOT in dry-run mode
-        # Dry-run doesn't call API so shouldn't require a key
+        # Check for any valid LLM provider configuration only if NOT in dry-run mode
+        # Dry-run doesn't call API so shouldn't require credentials
         import os
 
-        if not insights_dry_run and not os.environ.get("OPENAI_API_KEY"):
-            logger.error(
-                "OPENAI_API_KEY is required for --enable-insights. "
-                "Set the environment variable, or use --insights-dry-run for prompt iteration."
-            )
-            return 1
+        if not insights_dry_run:
+            # Check for any supported provider
+            has_openai = bool(os.environ.get("OPENAI_API_KEY"))
+            has_azure_openai = bool(os.environ.get("AZURE_OPENAI_ENDPOINT"))
+            has_anthropic = bool(os.environ.get("ANTHROPIC_API_KEY"))
 
-        # Check for openai package (needed even for dry-run to build prompt)
+            if not (has_openai or has_azure_openai or has_anthropic):
+                logger.error(
+                    "No LLM provider configured for --enable-insights.\n"
+                    "Set one of the following:\n"
+                    "  - OPENAI_API_KEY (for OpenAI)\n"
+                    "  - ANTHROPIC_API_KEY (for Anthropic)\n"
+                    "  - AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_KEY + "
+                    "AZURE_OPENAI_DEPLOYMENT (for Azure OpenAI)\n"
+                    "Or use --insights-dry-run for prompt iteration without API calls."
+                )
+                return 1
+
+            # Validate Azure OpenAI has all required configuration
+            if has_azure_openai:
+                azure_key = os.environ.get(
+                    "AZURE_OPENAI_API_KEY"
+                ) or os.environ.get("OPENAI_API_KEY")
+                azure_deployment = os.environ.get("AZURE_OPENAI_DEPLOYMENT")
+                missing = []
+                if not azure_key:
+                    missing.append(
+                        "AZURE_OPENAI_API_KEY (or OPENAI_API_KEY)"
+                    )
+                if not azure_deployment:
+                    missing.append("AZURE_OPENAI_DEPLOYMENT")
+                if missing:
+                    logger.error(
+                        f"Azure OpenAI endpoint specified but missing: "
+                        f"{', '.join(missing)}"
+                    )
+                    return 1
+
+        # Check for LLM SDK packages (needed even for dry-run to build prompt)
+        # We check for openai by default, but also check for anthropic if configured
         try:
             import openai  # noqa: F401 -- REASON: import used for ML dependency check
         except ImportError:
@@ -775,6 +807,17 @@ def cmd_generate_aggregates(args: Namespace) -> int:
                 "OpenAI SDK not installed. Install ML extras: pip install -e '.[ml]'"
             )
             return 1
+
+        # Check anthropic package if Anthropic provider is configured
+        if os.environ.get("ANTHROPIC_API_KEY") and not insights_dry_run:
+            try:
+                import anthropic  # noqa: F401 -- REASON: import for Anthropic check
+            except ImportError:
+                logger.error(
+                    "Anthropic SDK not installed but ANTHROPIC_API_KEY is set.\n"
+                    "Install: pip install anthropic>=0.18.0"
+                )
+                return 1
 
     try:
         db = DatabaseManager(args.database)
@@ -894,12 +937,39 @@ def cmd_build_aggregates(args: Namespace) -> int:
     if enable_insights:
         import os
 
-        if not os.environ.get("OPENAI_API_KEY"):
+        # Check for any supported provider
+        has_openai = bool(os.environ.get("OPENAI_API_KEY"))
+        has_azure_openai = bool(os.environ.get("AZURE_OPENAI_ENDPOINT"))
+        has_anthropic = bool(os.environ.get("ANTHROPIC_API_KEY"))
+
+        if not (has_openai or has_azure_openai or has_anthropic):
             logger.error(
-                "OPENAI_API_KEY is required for --enable-insights. "
-                "Set the environment variable, or use --insights-dry-run for prompt iteration."
+                "No LLM provider configured for --enable-insights.\n"
+                "Set one of the following:\n"
+                "  - OPENAI_API_KEY (for OpenAI)\n"
+                "  - ANTHROPIC_API_KEY (for Anthropic)\n"
+                "  - AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_KEY + "
+                "AZURE_OPENAI_DEPLOYMENT (for Azure OpenAI)"
             )
             return 1
+
+        # Validate Azure OpenAI has all required configuration
+        if has_azure_openai:
+            azure_key = os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get(
+                "OPENAI_API_KEY"
+            )
+            azure_deployment = os.environ.get("AZURE_OPENAI_DEPLOYMENT")
+            missing = []
+            if not azure_key:
+                missing.append("AZURE_OPENAI_API_KEY (or OPENAI_API_KEY)")
+            if not azure_deployment:
+                missing.append("AZURE_OPENAI_DEPLOYMENT")
+            if missing:
+                logger.error(
+                    f"Azure OpenAI endpoint specified but missing: "
+                    f"{', '.join(missing)}"
+                )
+                return 1
 
         try:
             import openai  # noqa: F401 -- REASON: import used for ML dependency check
@@ -908,6 +978,17 @@ def cmd_build_aggregates(args: Namespace) -> int:
                 "OpenAI SDK not installed. Install ML extras: pip install -e '.[ml]'"
             )
             return 1
+
+        # Check anthropic package if Anthropic provider is configured
+        if has_anthropic:
+            try:
+                import anthropic  # noqa: F401 -- REASON: import for Anthropic check
+            except ImportError:
+                logger.error(
+                    "Anthropic SDK not installed but ANTHROPIC_API_KEY is set.\n"
+                    "Install: pip install anthropic>=0.18.0"
+                )
+                return 1
 
     # Clean up stale aggregates from previous runs to prevent data mixing
     aggregates_dir = (args.out / "aggregates").resolve()

--- a/src/ado_git_repo_insights/ml/insights.py
+++ b/src/ado_git_repo_insights/ml/insights.py
@@ -1,12 +1,22 @@
-"""OpenAI-based insights generator for Phase 5.
+"""LLM-based insights generator for Phase 5.
 
 Produces insights/summary.json with contract-compliant insights:
 - schema_version: 1
 - is_stub: false
-- generated_by: "openai-v1.0"
+- generated_by: "{provider}-v1.0"
 - Categories: bottleneck, trend, anomaly
 - Severities: info, warning, critical
 - Single API call for up to 3 insights
+
+Supported providers:
+- OpenAI (default): Set OPENAI_API_KEY
+- Azure OpenAI: Set AZURE_OPENAI_API_KEY + AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_DEPLOYMENT
+- Anthropic: Set ANTHROPIC_API_KEY
+
+Provider is auto-detected based on environment variables with the following priority:
+1. Azure OpenAI (if AZURE_OPENAI_ENDPOINT is set)
+2. Anthropic (if ANTHROPIC_API_KEY is set)
+3. OpenAI (default, requires OPENAI_API_KEY)
 """
 
 from __future__ import annotations
@@ -16,7 +26,10 @@ import json
 import logging
 import os
 import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -29,17 +42,296 @@ logger = logging.getLogger(__name__)
 
 # Schema version (locked)
 INSIGHTS_SCHEMA_VERSION = 1
-GENERATOR_ID = "openai-v1.0"
+
+
+class LLMProvider(Enum):
+    """Supported LLM providers for insights generation."""
+
+    OPENAI = "openai"
+    AZURE_OPENAI = "azure-openai"
+    ANTHROPIC = "anthropic"
+
+
+@dataclass
+class ProviderConfig:
+    """Configuration for an LLM provider.
+
+    This dataclass encapsulates all provider-specific configuration,
+    enabling clean separation between provider detection and usage.
+    """
+
+    provider: LLMProvider
+    api_key: str
+    model: str
+    # Azure OpenAI specific
+    endpoint: str | None = None
+    deployment: str | None = None
+    api_version: str | None = None
+
+    def get_generator_id(self) -> str:
+        """Get the generator ID for this provider configuration."""
+        return f"{self.provider.value}-v1.0"
+
+
+def detect_provider() -> ProviderConfig:
+    """Auto-detect the LLM provider based on environment variables.
+
+    Detection priority:
+    1. Azure OpenAI - if AZURE_OPENAI_ENDPOINT is set (requires full Azure config)
+    2. Anthropic - if ANTHROPIC_API_KEY is set
+    3. OpenAI - default, requires OPENAI_API_KEY
+
+    Returns:
+        ProviderConfig with detected provider and configuration.
+
+    Raises:
+        ValueError: If no valid provider configuration is found.
+    """
+    # Check Azure OpenAI first (most specific configuration)
+    azure_endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
+    if azure_endpoint:
+        azure_key = os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get(
+            "OPENAI_API_KEY"
+        )
+        if not azure_key:
+            raise ValueError(
+                "Azure OpenAI endpoint specified but no API key found. "
+                "Set AZURE_OPENAI_API_KEY or OPENAI_API_KEY."
+            )
+
+        deployment = os.environ.get("AZURE_OPENAI_DEPLOYMENT")
+        if not deployment:
+            raise ValueError(
+                "Azure OpenAI endpoint specified but AZURE_OPENAI_DEPLOYMENT not set. "
+                "This is required to identify the model deployment."
+            )
+
+        api_version = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-02-01")
+
+        logger.info(
+            f"Detected Azure OpenAI provider: endpoint={azure_endpoint}, "
+            f"deployment={deployment}, api_version={api_version}"
+        )
+
+        return ProviderConfig(
+            provider=LLMProvider.AZURE_OPENAI,
+            api_key=azure_key,
+            model=deployment,  # Azure uses deployment name as model
+            endpoint=azure_endpoint,
+            deployment=deployment,
+            api_version=api_version,
+        )
+
+    # Check Anthropic
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
+    if anthropic_key:
+        model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
+        logger.info(f"Detected Anthropic provider: model={model}")
+        return ProviderConfig(
+            provider=LLMProvider.ANTHROPIC,
+            api_key=anthropic_key,
+            model=model,
+        )
+
+    # Default to OpenAI
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    if openai_key:
+        model = os.environ.get("OPENAI_MODEL", DEFAULT_MODEL)
+        logger.info(f"Detected OpenAI provider: model={model}")
+        return ProviderConfig(
+            provider=LLMProvider.OPENAI,
+            api_key=openai_key,
+            model=model,
+        )
+
+    raise ValueError(
+        "No LLM provider configured. Set one of:\n"
+        "  - OPENAI_API_KEY (for OpenAI)\n"
+        "  - ANTHROPIC_API_KEY (for Anthropic)\n"
+        "  - AZURE_OPENAI_ENDPOINT + AZURE_OPENAI_API_KEY + AZURE_OPENAI_DEPLOYMENT "
+        "(for Azure OpenAI)"
+    )
+
+
+class BaseLLMClient(ABC):
+    """Abstract base class for LLM clients.
+
+    This provides a consistent interface for calling different LLM providers,
+    enabling clean separation of provider-specific implementation details.
+    """
+
+    def __init__(self, config: ProviderConfig, max_tokens: int = 1000) -> None:
+        """Initialize the LLM client.
+
+        Args:
+            config: Provider configuration.
+            max_tokens: Maximum tokens for the response.
+        """
+        self.config = config
+        self.max_tokens = max_tokens
+
+    @abstractmethod
+    def generate(self, system_prompt: str, user_prompt: str) -> str | None:
+        """Generate a response from the LLM.
+
+        Args:
+            system_prompt: The system prompt setting context.
+            user_prompt: The user prompt with the request.
+
+        Returns:
+            The generated response text, or None if the call failed.
+        """
+        pass
+
+
+class OpenAIClient(BaseLLMClient):
+    """OpenAI API client implementation."""
+
+    def generate(self, system_prompt: str, user_prompt: str) -> str | None:
+        """Generate a response using the OpenAI API."""
+        import openai
+
+        client = openai.OpenAI(api_key=self.config.api_key)
+
+        try:
+            response = client.chat.completions.create(
+                model=self.config.model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                max_tokens=self.max_tokens,
+                temperature=0.7,
+            )
+
+            if not response.choices:
+                logger.warning("OpenAI returned no choices")
+                return None
+
+            content = response.choices[0].message.content
+            if not content:
+                logger.warning("OpenAI returned empty content")
+                return None
+
+            # Cast to str to satisfy mypy (SDK returns Any without stubs)
+            return str(content)
+
+        except Exception as e:
+            logger.warning(f"OpenAI API error: {type(e).__name__}: {e}")
+            return None
+
+
+class AzureOpenAIClient(BaseLLMClient):
+    """Azure OpenAI API client implementation."""
+
+    def generate(self, system_prompt: str, user_prompt: str) -> str | None:
+        """Generate a response using the Azure OpenAI API."""
+        import openai
+
+        client = openai.AzureOpenAI(
+            api_key=self.config.api_key,
+            api_version=self.config.api_version,
+            azure_endpoint=self.config.endpoint,
+        )
+
+        try:
+            response = client.chat.completions.create(
+                model=self.config.deployment,  # Azure uses deployment name
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                max_tokens=self.max_tokens,
+                temperature=0.7,
+            )
+
+            if not response.choices:
+                logger.warning("Azure OpenAI returned no choices")
+                return None
+
+            content = response.choices[0].message.content
+            if not content:
+                logger.warning("Azure OpenAI returned empty content")
+                return None
+
+            # Cast to str to satisfy mypy (SDK returns Any without stubs)
+            return str(content)
+
+        except Exception as e:
+            logger.warning(f"Azure OpenAI API error: {type(e).__name__}: {e}")
+            return None
+
+
+class AnthropicClient(BaseLLMClient):
+    """Anthropic API client implementation."""
+
+    def generate(self, system_prompt: str, user_prompt: str) -> str | None:
+        """Generate a response using the Anthropic API."""
+        import anthropic
+
+        client = anthropic.Anthropic(api_key=self.config.api_key)
+
+        try:
+            response = client.messages.create(
+                model=self.config.model,
+                max_tokens=self.max_tokens,
+                system=system_prompt,
+                messages=[{"role": "user", "content": user_prompt}],
+            )
+
+            if not response.content:
+                logger.warning("Anthropic returned no content")
+                return None
+
+            # Anthropic returns a list of content blocks
+            text_blocks = [
+                block.text for block in response.content if hasattr(block, "text")
+            ]
+            if not text_blocks:
+                logger.warning("Anthropic returned no text content")
+                return None
+
+            # Cast to str to satisfy mypy (SDK returns Any without stubs)
+            return str(text_blocks[0])
+
+        except Exception as e:
+            logger.warning(f"Anthropic API error: {type(e).__name__}: {e}")
+            return None
+
+
+def create_llm_client(config: ProviderConfig, max_tokens: int = 1000) -> BaseLLMClient:
+    """Factory function to create the appropriate LLM client.
+
+    Args:
+        config: Provider configuration from detect_provider().
+        max_tokens: Maximum tokens for responses.
+
+    Returns:
+        Configured LLM client instance.
+
+    Raises:
+        ValueError: If the provider is not supported.
+    """
+    if config.provider == LLMProvider.OPENAI:
+        return OpenAIClient(config, max_tokens)
+    elif config.provider == LLMProvider.AZURE_OPENAI:
+        return AzureOpenAIClient(config, max_tokens)
+    elif config.provider == LLMProvider.ANTHROPIC:
+        return AnthropicClient(config, max_tokens)
+    else:
+        raise ValueError(f"Unsupported provider: {config.provider}")
 
 # Cache invalidation control:
 # Bumping PROMPT_VERSION intentionally invalidates all cached insights.
 # This ensures users get fresh insights after prompt improvements or bug fixes.
-# Current: "phase5-v3" (bumped for v2 schema with data/recommendation fields)
-PROMPT_VERSION = "phase5-v3"
+# Current: "phase5-v4" (bumped for multi-provider support)
+PROMPT_VERSION = "phase5-v4"
 
-# Default model (can be overridden with OPENAI_MODEL env var)
-# PHASE5.md locked decision: gpt-5-nano
-DEFAULT_MODEL = "gpt-5-nano"
+# Default models per provider (can be overridden with environment variables)
+# PHASE5.md locked decision for OpenAI: gpt-5-nano
+DEFAULT_MODEL = "gpt-5-nano"  # OpenAI default
+DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-20250514"  # Anthropic default
+DEFAULT_AZURE_API_VERSION = "2024-02-01"  # Azure OpenAI API version
 
 # Severity ordering for deterministic sorting (T033)
 # Order: critical (highest) > warning > info (lowest)
@@ -83,10 +375,11 @@ def sort_insights(insights: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 class LLMInsightsGenerator:
-    """Generate OpenAI-based insights from PR metrics.
+    """Generate LLM-based insights from PR metrics.
 
+    Supports multiple providers: OpenAI, Azure OpenAI, and Anthropic.
     Single API call requesting JSON with up to 3 insights (one per category).
-    Supports dry-run mode and 24h caching.
+    Supports dry-run mode and 12h caching.
     """
 
     def __init__(
@@ -102,7 +395,7 @@ class LLMInsightsGenerator:
         Args:
             db: Database manager with PR data.
             output_dir: Directory for output files.
-            max_tokens: Maximum tokens for OpenAI response.
+            max_tokens: Maximum tokens for LLM response.
             cache_ttl_hours: Cache TTL in hours.
             dry_run: If True, write prompt artifact without calling API.
         """
@@ -111,7 +404,45 @@ class LLMInsightsGenerator:
         self.max_tokens = max_tokens
         self.cache_ttl_hours = cache_ttl_hours
         self.dry_run = dry_run
-        self.model = os.environ.get("OPENAI_MODEL", DEFAULT_MODEL)
+
+        # Provider detection is deferred until generate() to allow dry-run
+        # without requiring API credentials
+        self._provider_config: ProviderConfig | None = None
+        self._llm_client: BaseLLMClient | None = None
+
+    @property
+    def provider_config(self) -> ProviderConfig:
+        """Lazy-load provider configuration.
+
+        Returns:
+            Detected provider configuration.
+
+        Raises:
+            ValueError: If no valid provider is configured.
+        """
+        if self._provider_config is None:
+            self._provider_config = detect_provider()
+        return self._provider_config
+
+    @property
+    def model(self) -> str:
+        """Get the model name for the configured provider."""
+        return self.provider_config.model
+
+    @property
+    def generator_id(self) -> str:
+        """Get the generator ID for the configured provider."""
+        return self.provider_config.get_generator_id()
+
+    def _get_llm_client(self) -> BaseLLMClient:
+        """Get or create the LLM client.
+
+        Returns:
+            Configured LLM client for the detected provider.
+        """
+        if self._llm_client is None:
+            self._llm_client = create_llm_client(self.provider_config, self.max_tokens)
+        return self._llm_client
 
     def generate(self) -> bool:
         """Generate insights and write to summary.json.
@@ -134,9 +465,14 @@ class LLMInsightsGenerator:
 
         if self.dry_run:
             # Dry-run: write prompt artifact and exit
-            # NO API call, NO client creation
+            # NO API call, NO client creation, NO provider detection required
+            # Use placeholder values for model since provider may not be configured
+            model_name = os.environ.get(
+                "OPENAI_MODEL",
+                os.environ.get("ANTHROPIC_MODEL", DEFAULT_MODEL),
+            )
             prompt_artifact = {
-                "model": self.model,
+                "model": model_name,
                 "max_tokens": self.max_tokens,
                 "prompt": prompt,
                 "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -149,6 +485,17 @@ class LLMInsightsGenerator:
                 "No API call made, no costs incurred."
             )
             return False  # Don't write summary.json in dry-run
+
+        # Detect provider and log configuration
+        try:
+            config = self.provider_config
+            logger.info(
+                f"Using LLM provider: {config.provider.value} "
+                f"(model: {config.model})"
+            )
+        except ValueError as e:
+            logger.error(f"Provider configuration error: {e}")
+            return False
 
         # Check cache
         cache_path = safe_join(insights_dir, "cache.json")
@@ -163,15 +510,15 @@ class LLMInsightsGenerator:
             logger.info("Cache hit - wrote insights from cache")
             return True
 
-        # Call OpenAI API
+        # Call LLM API
         try:
-            insights_data = self._call_openai(prompt)
+            insights_data = self._call_llm(prompt)
         except Exception as e:
-            logger.warning(f"OpenAI API call failed: {type(e).__name__}: {e}")
+            logger.warning(f"LLM API call failed: {type(e).__name__}: {e}")
             return False
 
         if not insights_data:
-            logger.warning("OpenAI returned no insights")
+            logger.warning("LLM returned no insights")
             return False
 
         # Write summary.json
@@ -184,7 +531,8 @@ class LLMInsightsGenerator:
 
         elapsed = time.perf_counter() - start_time
         logger.info(
-            f"OpenAI insights generation completed in {elapsed:.2f}s "
+            f"{self.provider_config.provider.value} insights generation "
+            f"completed in {elapsed:.2f}s "
             f"({len(insights_data.get('insights', []))} insights)"
         )
         return True
@@ -431,8 +779,8 @@ Respond ONLY with valid JSON matching this format."""
         with cache_path.open("w", encoding="utf-8") as f:
             json.dump(cache_data, f, indent=2)
 
-    def _call_openai(self, prompt: str) -> dict[str, Any] | None:
-        """Call OpenAI API and parse response.
+    def _call_llm(self, prompt: str) -> dict[str, Any] | None:
+        """Call the configured LLM API and parse response.
 
         Args:
             prompt: The prompt string.
@@ -440,44 +788,20 @@ Respond ONLY with valid JSON matching this format."""
         Returns:
             Insights data dict or None if failed.
         """
-        import openai
-
-        api_key = os.environ.get("OPENAI_API_KEY")
-        if not api_key:
-            raise ValueError("OPENAI_API_KEY not set")
-
-        # OpenAI SDK v1.0+ client-based API
-        client = openai.OpenAI(api_key=api_key)
+        system_prompt = "You are a DevOps metrics analyst. Respond only with valid JSON."
 
         try:
-            response = client.chat.completions.create(
-                model=self.model,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": "You are a DevOps metrics analyst. Respond only with valid JSON.",
-                    },
-                    {"role": "user", "content": prompt},
-                ],
-                max_tokens=self.max_tokens,
-                temperature=0.7,
-            )
+            client = self._get_llm_client()
+            content = client.generate(system_prompt, prompt)
 
-            # Extract response text
-            if not response.choices:
-                logger.warning("OpenAI returned no choices")
-                return None
-
-            content = response.choices[0].message.content
             if not content:
-                logger.warning("OpenAI returned empty content")
                 return None
 
             # Parse JSON
             try:
                 insights_json = json.loads(content)
             except json.JSONDecodeError as e:
-                logger.warning(f"Failed to parse OpenAI response as JSON: {e}")
+                logger.warning(f"Failed to parse LLM response as JSON: {e}")
                 return None
 
             # Get DB freshness markers for deterministic ID generation
@@ -505,7 +829,7 @@ Respond ONLY with valid JSON matching this format."""
             )
 
         except Exception as e:
-            logger.warning(f"OpenAI API error: {type(e).__name__}: {e}")
+            logger.warning(f"LLM API error: {type(e).__name__}: {e}")
             return None
 
     def _validate_and_fix_insights(
@@ -570,6 +894,6 @@ Respond ONLY with valid JSON matching this format."""
             "schema_version": INSIGHTS_SCHEMA_VERSION,
             "generated_at": datetime.now(timezone.utc).isoformat(),
             "is_stub": False,
-            "generated_by": GENERATOR_ID,
+            "generated_by": self.generator_id,
             "insights": sorted_insights,
         }

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -285,11 +285,13 @@ class TestCmdGenerateAggregates:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """--enable-insights without OPENAI_API_KEY should return exit code 1."""
+        """--enable-insights without any LLM provider should return exit code 1."""
         from ado_git_repo_insights.cli import cmd_generate_aggregates
 
-        # Ensure no API key
+        # Ensure no LLM provider credentials are set
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
         # Create a dummy database file
         db_path = tmp_path / "test.sqlite"
@@ -302,7 +304,7 @@ class TestCmdGenerateAggregates:
             enable_ml_stubs=False,
             seed_base="",
             enable_predictions=False,
-            enable_insights=True,  # Enabled without API key
+            enable_insights=True,  # Enabled without any provider
             insights_max_tokens=1000,
             insights_cache_ttl_hours=24,
             insights_dry_run=False,  # Not dry run
@@ -315,7 +317,7 @@ class TestCmdGenerateAggregates:
         assert result == 1
         assert mock_logger.error.called
         error_msg = mock_logger.error.call_args[0][0]
-        assert "OPENAI_API_KEY is required" in error_msg
+        assert "No LLM provider configured" in error_msg
 
     @patch("ado_git_repo_insights.cli.DatabaseManager")
     @patch("ado_git_repo_insights.cli.AggregateGenerator")
@@ -326,11 +328,13 @@ class TestCmdGenerateAggregates:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """--enable-insights --insights-dry-run should proceed without API key."""
+        """--enable-insights --insights-dry-run should proceed without any provider."""
         from ado_git_repo_insights.cli import cmd_generate_aggregates
 
-        # Ensure no API key
+        # Ensure no LLM provider credentials are set
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("AZURE_OPENAI_ENDPOINT", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
         # Create a dummy database file
         db_path = tmp_path / "test.sqlite"
@@ -368,7 +372,7 @@ class TestCmdGenerateAggregates:
 
         assert result == 0
         assert not any(
-            "OPENAI_API_KEY is required" in call.args[0]
+            "No LLM provider configured" in call.args[0]
             for call in mock_logger.error.call_args_list
         )
 

--- a/tests/unit/test_insights_contract.py
+++ b/tests/unit/test_insights_contract.py
@@ -144,7 +144,6 @@ class TestInsightsContract:
     ) -> None:
         """Insights JSON has exact contract-compliant values."""
         from ado_git_repo_insights.ml.insights import (
-            GENERATOR_ID,
             INSIGHTS_SCHEMA_VERSION,
             LLMInsightsGenerator,
         )
@@ -164,7 +163,8 @@ class TestInsightsContract:
         assert data["schema_version"] == INSIGHTS_SCHEMA_VERSION
         assert data["schema_version"] == 1  # Locked value
         assert data["is_stub"] is False  # Real ML, not stub
-        assert data["generated_by"] == GENERATOR_ID
+        # Generator ID is dynamic based on provider (OpenAI in this test)
+        assert data["generated_by"] == "openai-v1.0"
 
         # Timestamp format
         datetime.fromisoformat(data["generated_at"])  # Should not raise

--- a/tests/unit/test_insights_dry_run.py
+++ b/tests/unit/test_insights_dry_run.py
@@ -34,12 +34,13 @@ class _FakeDb:
         return _FakeCursor(None)
 
 
-def test_dry_run_never_calls_openai(tmp_path: Path) -> None:
+def test_dry_run_never_calls_llm(tmp_path: Path) -> None:
+    """Dry-run should never call the LLM API."""
     db = _FakeDb()
     generator = LLMInsightsGenerator(db, output_dir=tmp_path, dry_run=True)
 
     with patch.object(
-        LLMInsightsGenerator, "_call_openai", side_effect=AssertionError("no api")
+        LLMInsightsGenerator, "_call_llm", side_effect=AssertionError("no api")
     ):
         result = generator.generate()
 

--- a/tests/unit/test_insights_enhanced.py
+++ b/tests/unit/test_insights_enhanced.py
@@ -283,7 +283,7 @@ class TestCacheLogic:
             patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}),
             patch.object(
                 generator,
-                "_call_openai",
+                "_call_llm",
                 return_value={
                     "schema_version": 1,
                     "generated_at": datetime.now(timezone.utc).isoformat(),


### PR DESCRIPTION
## Summary

This PR extends AI Insights to support multiple LLM providers beyond OpenAI, enabling organizations to choose the provider that best fits their requirements. Users can now select between OpenAI, Azure OpenAI, and Anthropic with automatic provider detection based on environment variables.

## Key Changes

### Documentation Updates
- Updated `docs/internal/enable-ml-features.md` with setup instructions for all three providers
- Added configuration examples for each provider (OpenAI, Azure OpenAI, Anthropic)
- Expanded troubleshooting section with provider-specific guidance
- Added data residency considerations table highlighting Azure OpenAI benefits
- Updated cost and performance metrics for each provider

### Task Configuration (`task.json`)
- Added `llmProvider` dropdown input with options: openai, azure-openai, anthropic
- Made provider-specific inputs conditionally visible based on selected provider
- Added Azure OpenAI inputs: endpoint, API key, deployment, API version
- Added Anthropic API key input
- Updated help text to reflect multi-provider support

### Pipeline Script (`index.js`)
- Added provider detection and input validation logic
- Implemented provider-specific environment variable setup
- Enhanced error messages with provider-specific resolution steps
- Added logging for selected provider and configuration

### Python Implementation (`src/ado_git_repo_insights/ml/insights.py`)
- Introduced `LLMProvider` enum and `ProviderConfig` dataclass for clean provider abstraction
- Implemented `detect_provider()` function with priority-based auto-detection
- Created abstract `BaseLLMClient` with provider-specific implementations:
  - `OpenAIClient` - uses OpenAI SDK
  - `AzureOpenAIClient` - uses Azure OpenAI SDK
  - `AnthropicClient` - uses Anthropic SDK
- Refactored `LLMInsightsGenerator` to use provider-agnostic interface
- Updated cache invalidation (PROMPT_VERSION bumped to phase5-v4)
- Generator ID now reflects actual provider used (e.g., "azure-openai-v1.0")

### CLI Updates (`src/ado_git_repo_insights/cli.py`)
- Updated validation logic to check for any configured provider
- Added provider-specific credential validation
- Enhanced error messages with setup instructions per provider
- Added Anthropic SDK import check

### Dependencies (`pyproject.toml`)
- Added `anthropic>=0.18.0` to ml extras group
- Added anthropic to mypy ignore list

### Tests
- Updated test expectations to reflect multi-provider support
- Modified error message assertions to check for generic "No LLM provider configured"
- Updated insights contract test to validate dynamic generator_id

## Implementation Details

**Provider Detection Priority:**
1. Azure OpenAI (if `AZURE_OPENAI_ENDPOINT` is set)
2. Anthropic (if `ANTHROPIC_API_KEY` is set)
3. OpenAI (default, requires `OPENAI_API_KEY`)

**Backward Compatibility:**
- OpenAI remains the default provider
- Existing pipelines continue to work without changes
- New `llmProvider` input defaults to "openai"

**Dry-run Mode:**
- Dry-run works without any provider credentials
- Uses placeholder model names from environment variables

**Caching:**
- Cache key includes provider information to prevent cross-provider cache hits
- Cache TTL remains 12 hours

https://claude.ai/code/session_01FycAB9W93r9EbRn2ddceaw