### PR TITLE
fix: use undefined instead of null for optional VSS REST client params

### DIFF
--- a/extension/ui/settings.ts
+++ b/extension/ui/settings.ts
@@ -706,7 +706,7 @@ async function discoverPipelines(
 
         // Get pipeline definitions (limit for performance)
         client
-          .getDefinitions(projectId, null, null, null, 2, 50)
+          .getDefinitions(projectId, undefined, undefined, undefined, 2, 50)
           .then(async (definitions: VSSBuildDefinition[]) => {
             for (const def of definitions) {
               // Get latest successful/partially-succeeded build
@@ -714,16 +714,16 @@ async function discoverPipelines(
                 const builds = await client.getBuilds(
                   projectId,
                   [def.id],
-                  null,
-                  null,
-                  null,
-                  null,
-                  null,
-                  null,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
                   2,
                   6,
-                  null,
-                  null,
+                  undefined,
+                  undefined,
                   1,
                 );
 

--- a/src/ado_git_repo_insights/ui_bundle/settings.js
+++ b/src/ado_git_repo_insights/ui_bundle/settings.js
@@ -1028,22 +1028,22 @@ var PRInsightsSettings = (() => {
             return;
           }
           const matches = [];
-          client.getDefinitions(projectId, null, null, null, 2, 50).then(async (definitions) => {
+          client.getDefinitions(projectId, void 0, void 0, void 0, 2, 50).then(async (definitions) => {
             for (const def of definitions) {
               try {
                 const builds = await client.getBuilds(
                   projectId,
                   [def.id],
-                  null,
-                  null,
-                  null,
-                  null,
-                  null,
-                  null,
+                  void 0,
+                  void 0,
+                  void 0,
+                  void 0,
+                  void 0,
+                  void 0,
                   2,
                   6,
-                  null,
-                  null,
+                  void 0,
+                  void 0,
                   1
                 );
                 if (!builds || builds.length === 0) continue;


### PR DESCRIPTION
discoverPipelines() passed null for optional parameters to the VSS Build REST client's getDefinitions() and getBuilds() methods. The VSS SDK serializes null values into query parameters (e.g. ?name=null) while undefined values are omitted, matching the dashboard's working discoverInsightsPipelines() pattern. This caused discovery to silently return empty results, keeping the download button disabled.