### PR TITLE
fix: add managed-features target so feature flags appear in Preview F…

### DIFF
--- a/extension/tests/manifest/feature-flags.test.ts
+++ b/extension/tests/manifest/feature-flags.test.ts
@@ -60,6 +60,16 @@ describe("Manifest Contract: Feature Flags", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // (1b) All feature flags target ms.vss-web.managed-features
+  // ---------------------------------------------------------------------------
+  it("all feature flags target ms.vss-web.managed-features", () => {
+    for (const flag of featureFlags) {
+      expect(flag.targets).toBeDefined();
+      expect(flag.targets).toContain("ms.vss-web.managed-features");
+    }
+  });
+
+  // ---------------------------------------------------------------------------
   // (2) FR-010: All feature flag IDs start with gri.
   // ---------------------------------------------------------------------------
   it("all feature flag IDs start with gri. prefix", () => {

--- a/extension/vss-extension.json
+++ b/extension/vss-extension.json
@@ -49,6 +49,9 @@
         {
             "id": "gri.dashboard-hub",
             "type": "ms.vss-web.feature",
+            "targets": [
+                "ms.vss-web.managed-features"
+            ],
             "description": "Controls visibility of the PR Insights dashboard hub",
             "properties": {
                 "name": "[GRI] PR Insights Dashboard",

--- a/specs/026-discovery-refactor-ff-prefix/contracts/vss-extension-feature-flags.json
+++ b/specs/026-discovery-refactor-ff-prefix/contracts/vss-extension-feature-flags.json
@@ -6,6 +6,7 @@
     {
       "id": "gri.dashboard-hub",
       "type": "ms.vss-web.feature",
+      "targets": ["ms.vss-web.managed-features"],
       "description": "Controls visibility of the PR Insights dashboard hub in the Repos navigation",
       "properties": {
         "name": "[GRI] PR Insights Dashboard",


### PR DESCRIPTION
…eatures dropdown

The feature flag contribution was missing `targets: ["ms.vss-web.managed-features"]`, which prevented it from registering in the Azure DevOps "Preview Features" panel. The dashboard was correctly hidden by default but admins had no UI toggle to enable it.

Also adds a contract test to enforce the target is present on all feature flags.