### PR TITLE
Prevent global value leakage in filtered rollups and improve JSON safety

### DIFF
--- a/extension/tests/modules/metrics.test.ts
+++ b/extension/tests/modules/metrics.test.ts
@@ -239,11 +239,11 @@ describe("metrics module", () => {
         teams: [],
       });
 
-      // Legacy: only pr_count available, cycle time preserved from rollup
+      // Legacy: only pr_count available, cycle time nulled to prevent
+      // global values leaking through for a filtered subset
       expect(result[0].pr_count).toBe(30);
-      // No per-repo cycle time -> hasPerRepoCycleTime is false -> original values preserved
-      expect(result[0].cycle_time_p50).toBe(60);
-      expect(result[0].cycle_time_p90).toBe(120);
+      expect(result[0].cycle_time_p50).toBeNull();
+      expect(result[0].cycle_time_p90).toBeNull();
     });
 
     it("filters by team", () => {
@@ -639,8 +639,8 @@ describe("applyFiltersToRollups coverage: uncovered paths", () => {
 
     // Proportional intersection: 50/100 * 40/100 = 0.2 → 100 * 0.2 = 20
     expect(result[0].pr_count).toBe(20);
-    // No cycle times in breakdown entries → no cycle time in result
-    expect(result[0].cycle_time_p50).toBeUndefined();
+    // No cycle times in breakdown entries → null (not global leak-through)
+    expect(result[0].cycle_time_p50).toBeNull();
   });
 
   it("combined filter with no cycle time data in either slice", () => {
@@ -664,8 +664,10 @@ describe("applyFiltersToRollups coverage: uncovered paths", () => {
 
     // 30/100 * 40/100 = 0.12 → pr_count = round(100 * 0.12) = 12
     expect(result[0].pr_count).toBe(12);
-    // No cycle_time in breakdown entries → p50s empty → no cycle time spread
-    expect(result[0]).not.toHaveProperty("cycle_time_p50");
+    // No cycle_time in breakdown entries → p50s empty → null
+    // (explicit null prevents global values leaking through)
+    expect(result[0].cycle_time_p50).toBeNull();
+    expect(result[0].cycle_time_p90).toBeNull();
     // authors: round(10 * 0.12) = 1, reviewers: round(5 * 0.12) = 1
     expect(result[0].authors_count).toBe(1);
     expect(result[0].reviewers_count).toBe(1);
@@ -1456,5 +1458,167 @@ describe("zero-leakage regression", () => {
     expect(result[0].reviewers_count).toBe(0);
     expect(result[0].cycle_time_p50).toBeNull();
     expect(result[0].cycle_time_p90).toBeNull();
+  });
+});
+
+/**
+ * Global value leakage prevention tests.
+ *
+ * Validates that buildFilteredRollup and the proportional path never leak
+ * global rollup values (authors_count, reviewers_count, cycle_time) through
+ * the ...rollup spread when the filtered slice produces zero or null for
+ * those fields but has non-zero pr_count.
+ *
+ * Bug: When slice.authors_count === 0 but slice.pr_count > 0, the previous
+ * code used a conditional spread `...(slice.authors_count > 0 ? ... : {})`
+ * which left the global value from `...rollup` intact. The fix always
+ * overrides these fields explicitly.
+ */
+describe("global value leakage prevention", () => {
+  it("buildFilteredRollup does not leak global authors_count when slice has 0 authors", () => {
+    const rollup = {
+      week: "2026-W01",
+      pr_count: 100,
+      cycle_time_p50: 60,
+      cycle_time_p90: 120,
+      authors_count: 15,
+      reviewers_count: 8,
+      by_repository: {
+        "auto-repo": {
+          pr_count: 5,
+          cycle_time_p50: 40,
+          cycle_time_p90: 80,
+          authors_count: 0,
+          reviewers_count: 0,
+        },
+      },
+    } as unknown as Rollup;
+
+    const result = applyFiltersToRollups([rollup], {
+      repos: ["auto-repo"],
+      teams: [],
+    });
+
+    // pr_count is 5, but authors/reviewers are 0 — must NOT show global 15/8
+    expect(result[0].pr_count).toBe(5);
+    expect(result[0].authors_count).toBe(0);
+    expect(result[0].reviewers_count).toBe(0);
+  });
+
+  it("buildFilteredRollup does not leak global cycle_time when slice has no cycle data", () => {
+    const rollup = {
+      week: "2026-W01",
+      pr_count: 100,
+      cycle_time_p50: 60,
+      cycle_time_p90: 120,
+      authors_count: 15,
+      reviewers_count: 8,
+      by_repository: {
+        "no-ct-repo": {
+          pr_count: 10,
+          authors_count: 3,
+          reviewers_count: 2,
+          // No cycle_time fields
+        },
+      },
+    } as unknown as Rollup;
+
+    const result = applyFiltersToRollups([rollup], {
+      repos: ["no-ct-repo"],
+      teams: [],
+    });
+
+    // pr_count is 10, but cycle times should be null — must NOT show global 60/120
+    expect(result[0].pr_count).toBe(10);
+    expect(result[0].cycle_time_p50).toBeNull();
+    expect(result[0].cycle_time_p90).toBeNull();
+  });
+
+  it("proportional path does not leak global authors/reviewers when proportional rounds to 0", () => {
+    const rollup = {
+      week: "2026-W01",
+      pr_count: 200,
+      cycle_time_p50: 80,
+      cycle_time_p90: 160,
+      authors_count: 20,
+      reviewers_count: 10,
+      by_repository: {
+        "repo-a": { pr_count: 20, cycle_time_p50: 50, cycle_time_p90: 100, authors_count: 2, reviewers_count: 1 },
+      },
+      by_team: {
+        "team-x": { pr_count: 20, cycle_time_p50: 55, cycle_time_p90: 110, authors_count: 2, reviewers_count: 1 },
+      },
+    } as unknown as Rollup;
+
+    const result = applyFiltersToRollups([rollup], {
+      repos: ["repo-a"],
+      teams: ["team-x"],
+    });
+
+    // repoShare=20/200=0.1, teamShare=20/200=0.1, ratio=0.01
+    // combinedPrCount=round(200*0.01)=2
+    // combinedAuthors=round(20*0.01)=0, combinedReviewers=round(10*0.01)=0
+    expect(result[0].pr_count).toBe(2);
+    // Must NOT leak global 20/10 through
+    expect(result[0].authors_count).toBe(0);
+    expect(result[0].reviewers_count).toBe(0);
+  });
+
+  it("proportional path does not leak global cycle_time when slices have no cycle data", () => {
+    const rollup = {
+      week: "2026-W01",
+      pr_count: 100,
+      cycle_time_p50: 80,
+      cycle_time_p90: 160,
+      authors_count: 10,
+      reviewers_count: 5,
+      by_repository: {
+        "repo-a": { pr_count: 30, authors_count: 3, reviewers_count: 1 },
+      },
+      by_team: {
+        "team-x": { pr_count: 40, authors_count: 4, reviewers_count: 2 },
+      },
+    } as unknown as Rollup;
+
+    const result = applyFiltersToRollups([rollup], {
+      repos: ["repo-a"],
+      teams: ["team-x"],
+    });
+
+    // combinedPrCount=round(100*0.3*0.4)=12
+    expect(result[0].pr_count).toBe(12);
+    // No cycle time in either slice → null, not global 80/160
+    expect(result[0].cycle_time_p50).toBeNull();
+    expect(result[0].cycle_time_p90).toBeNull();
+  });
+
+  it("repoShare and teamShare are clamped to [0, 1] range", () => {
+    // Simulate overlapping teams where sum exceeds total
+    const rollup = {
+      week: "2026-W01",
+      pr_count: 100,
+      cycle_time_p50: 60,
+      cycle_time_p90: 120,
+      authors_count: 10,
+      reviewers_count: 5,
+      by_repository: {
+        "repo-a": { pr_count: 50, cycle_time_p50: 55, cycle_time_p90: 110, authors_count: 5, reviewers_count: 3 },
+      },
+      by_team: {
+        // team-x has 120 PRs due to multi-team overlap (exceeds total 100)
+        "team-x": { pr_count: 120, cycle_time_p50: 58, cycle_time_p90: 115, authors_count: 8, reviewers_count: 4 },
+      },
+    } as unknown as Rollup;
+
+    const result = applyFiltersToRollups([rollup], {
+      repos: ["repo-a"],
+      teams: ["team-x"],
+    });
+
+    // teamShare = min(1, 120/100) = 1.0 (clamped), repoShare = 50/100 = 0.5
+    // combinedPrCount = round(100 * 0.5 * 1.0) = 50
+    expect(result[0].pr_count).toBe(50);
+    // Must not exceed repo total
+    expect(result[0].pr_count).toBeLessThanOrEqual(100);
   });
 });

--- a/extension/tests/python-integration/synthetic-fixtures.test.ts
+++ b/extension/tests/python-integration/synthetic-fixtures.test.ts
@@ -113,7 +113,7 @@ describe("Synthetic Fixture Consumer Validation", () => {
 
     expect(manifest.manifest_schema_version).toBe(1);
     expect(manifest.dataset_schema_version).toBe(1);
-    expect(manifest.aggregates_schema_version).toBe(1);
+    expect(manifest.aggregates_schema_version).toBe(2);
   });
 
   test("generated rollups load successfully", async () => {

--- a/extension/ui/dashboard.ts
+++ b/extension/ui/dashboard.ts
@@ -1300,7 +1300,7 @@ function removeFilter(type: string, value: string): void {
     const repoFilter = elements["repo-filter"] as HTMLSelectElement | null;
     if (repoFilter) {
       const option = repoFilter.querySelector(
-        `option[value="${value}"]`,
+        `option[value="${CSS.escape(value)}"]`,
       ) as HTMLOptionElement | null;
       if (option) option.selected = false;
     }
@@ -1309,7 +1309,7 @@ function removeFilter(type: string, value: string): void {
     const teamFilter = elements["team-filter"] as HTMLSelectElement | null;
     if (teamFilter) {
       const option = teamFilter.querySelector(
-        `option[value="${value}"]`,
+        `option[value="${CSS.escape(value)}"]`,
       ) as HTMLOptionElement | null;
       if (option) option.selected = false;
     }
@@ -1380,12 +1380,16 @@ function renderFilterChips(): void {
 function getFilterLabel(type: string, value: string): string {
   if (type === "repo") {
     const repoFilter = elements["repo-filter"] as HTMLSelectElement | null;
-    const option = repoFilter?.querySelector(`option[value="${value}"]`);
+    const option = repoFilter?.querySelector(
+      `option[value="${CSS.escape(value)}"]`,
+    );
     return option?.textContent || value;
   }
   if (type === "team") {
     const teamFilter = elements["team-filter"] as HTMLSelectElement | null;
-    const option = teamFilter?.querySelector(`option[value="${value}"]`);
+    const option = teamFilter?.querySelector(
+      `option[value="${CSS.escape(value)}"]`,
+    );
     return option?.textContent || value;
   }
   return value;
@@ -1420,7 +1424,7 @@ function restoreFiltersFromUrl(): void {
     if (repoFilter) {
       currentFilters.repos.forEach((value) => {
         const option = repoFilter.querySelector(
-          `option[value="${value}"]`,
+          `option[value="${CSS.escape(value)}"]`,
         ) as HTMLOptionElement | null;
         if (option) option.selected = true;
       });
@@ -1433,7 +1437,7 @@ function restoreFiltersFromUrl(): void {
     if (teamFilter) {
       currentFilters.teams.forEach((value) => {
         const option = teamFilter.querySelector(
-          `option[value="${value}"]`,
+          `option[value="${CSS.escape(value)}"]`,
         ) as HTMLOptionElement | null;
         if (option) option.selected = true;
       });

--- a/extension/ui/modules/metrics.ts
+++ b/extension/ui/modules/metrics.ts
@@ -244,18 +244,14 @@ function buildFilteredRollup(
   return {
     ...rollup,
     pr_count: slice.pr_count,
-    ...(slice.cycle_time_p50 !== null
-      ? {
-          cycle_time_p50: slice.cycle_time_p50,
-          cycle_time_p90: slice.cycle_time_p90,
-        }
-      : {}),
-    ...(slice.authors_count > 0
-      ? { authors_count: slice.authors_count }
-      : {}),
-    ...(slice.reviewers_count > 0
-      ? { reviewers_count: slice.reviewers_count }
-      : {}),
+    // Always override cycle times: use slice values when available,
+    // otherwise null to prevent global values leaking through.
+    cycle_time_p50: slice.cycle_time_p50,
+    cycle_time_p90: slice.cycle_time_p90,
+    // Always override counts to prevent global values leaking through
+    // when the slice legitimately has 0 authors/reviewers.
+    authors_count: slice.authors_count,
+    reviewers_count: slice.reviewers_count,
   } as Rollup;
 }
 
@@ -357,8 +353,8 @@ export function applyFiltersToRollups(
     // The intersection is estimated as: total * (repoShare * teamShare).
     if (repoSlice && teamSlice) {
       const total = rollup.pr_count || 1;
-      const repoShare = Math.min(1, repoSlice.pr_count / total);
-      const teamShare = Math.min(1, teamSlice.pr_count / total);
+      const repoShare = Math.max(0, Math.min(1, repoSlice.pr_count / total));
+      const teamShare = Math.max(0, Math.min(1, teamSlice.pr_count / total));
       const combinedRatio = repoShare * teamShare;
 
       const combinedPrCount = Math.round(rollup.pr_count * combinedRatio);
@@ -388,19 +384,20 @@ export function applyFiltersToRollups(
       return {
         ...rollup,
         pr_count: combinedPrCount,
-        ...(p50s.length > 0
-          ? {
-              cycle_time_p50: p50s.reduce((a, b) => a + b, 0) / p50s.length,
-              cycle_time_p90:
-                p90s.length > 0
-                  ? p90s.reduce((a, b) => a + b, 0) / p90s.length
-                  : null,
-            }
-          : {}),
-        ...(combinedAuthors > 0 ? { authors_count: combinedAuthors } : {}),
-        ...(combinedReviewers > 0
-          ? { reviewers_count: combinedReviewers }
-          : {}),
+        // Always override cycle times: use averaged slice estimates when
+        // available, otherwise null to prevent global values leaking through.
+        cycle_time_p50:
+          p50s.length > 0
+            ? p50s.reduce((a, b) => a + b, 0) / p50s.length
+            : null,
+        cycle_time_p90:
+          p90s.length > 0
+            ? p90s.reduce((a, b) => a + b, 0) / p90s.length
+            : null,
+        // Always override counts to prevent global values leaking through
+        // when the proportional estimate rounds to 0.
+        authors_count: combinedAuthors,
+        reviewers_count: combinedReviewers,
       } as Rollup;
     }
 

--- a/src/ado_git_repo_insights/transform/aggregators.py
+++ b/src/ado_git_repo_insights/transform/aggregators.py
@@ -21,12 +21,32 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
 import pandas as pd
 
 if TYPE_CHECKING:
     from ..persistence.database import DatabaseManager
 
 logger = logging.getLogger(__name__)
+
+
+class _NumpySafeEncoder(json.JSONEncoder):
+    """JSON encoder that converts numpy types to native Python types.
+
+    Pandas quantile/nunique return numpy.float64/numpy.int64 which are
+    technically JSON-serializable (subclasses of float/int) but can carry
+    NaN/Inf values that violate the JSON spec. This encoder converts them
+    to native Python types and raises on NaN/Inf via allow_nan=False.
+    """
+
+    def default(self, o: Any) -> Any:  # noqa: ANN401
+        if isinstance(o, np.integer):
+            return int(o)
+        if isinstance(o, np.floating):
+            return float(o)
+        if isinstance(o, np.ndarray):
+            return o.tolist()
+        return super().default(o)
 
 # Schema versions (Phase 3 locked)
 MANIFEST_SCHEMA_VERSION = 1
@@ -786,9 +806,13 @@ class AggregateGenerator:
             if pr_count == 0:
                 continue
 
-            # Compute cycle time percentiles with minimum sample size guard
-            has_cycle_times = not grp["cycle_time_minutes"].isna().all()
-            if has_cycle_times and pr_count >= self._CROSS_DIM_MIN_SAMPLE:
+            # Compute cycle time percentiles with minimum sample size guard.
+            # Count non-NaN cycle times (not total rows) so the guard reflects
+            # the actual number of data points feeding the percentile.
+            cycle_time_valid_count = int(
+                grp["cycle_time_minutes"].notna().sum()
+            )
+            if cycle_time_valid_count >= self._CROSS_DIM_MIN_SAMPLE:
                 cycle_time_p50 = grp["cycle_time_minutes"].quantile(0.5)
                 cycle_time_p90 = grp["cycle_time_minutes"].quantile(0.9)
             else:
@@ -1043,9 +1067,19 @@ class AggregateGenerator:
         }
 
     def _write_json(self, path: Path, data: dict[str, Any]) -> None:
-        """Write JSON file with deterministic formatting."""
+        """Write JSON file with deterministic formatting.
+
+        Uses allow_nan=False to reject NaN/Infinity values that would
+        produce invalid JSON (not part of the JSON spec). If a NaN
+        value slips through the aggregation guards, this will raise
+        ValueError at write time rather than producing silently invalid
+        output that breaks downstream consumers.
+        """
         with path.open("w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2, sort_keys=True)
+            json.dump(
+                data, f, indent=2, sort_keys=True,
+                allow_nan=False, cls=_NumpySafeEncoder,
+            )
 
 
 class StubGenerationError(Exception):

--- a/tests/unit/test_aggregators.py
+++ b/tests/unit/test_aggregators.py
@@ -2397,3 +2397,145 @@ class TestFileSizeValidation:
             f"SC-004 WARNING: max cross-dim overhead is {max_increase_pct:.1f}%, "
             f"which is significant. Verify this is acceptable for the org profile."
         )
+
+
+class TestMinSampleSizeNonNanGuard:
+    """Tests for FR-019 MIN_SAMPLE_SIZE counting non-NaN cycle times.
+
+    Validates that the _CROSS_DIM_MIN_SAMPLE guard counts actual non-NaN
+    cycle_time_minutes values, not total rows. A cross-dim intersection
+    with 6 total PRs but only 2 non-NaN cycle times should produce null
+    cycle_time percentiles.
+    """
+
+    @pytest.fixture
+    def db_with_sparse_cycle_times(
+        self, tmp_path: Path
+    ) -> tuple[DatabaseManager, Path]:
+        """Create DB where a cross-dim intersection has many rows but few cycle times.
+
+        Team Alpha has user1-user3. Backend-Repo has PRs from user1 (6 PRs).
+        Only 2 of those PRs have non-null cycle_time_minutes.
+        Total rows for (Team Alpha, Backend-Repo) = 6, non-NaN cycle times = 2.
+        MIN_SAMPLE_SIZE = 5, so cycle_time should be null.
+        """
+        db_path = tmp_path / "test_min_sample.sqlite"
+        db = DatabaseManager(db_path)
+        db.connect()
+
+        db.execute(
+            "INSERT INTO organizations (organization_name) VALUES (?)", ("org1",)
+        )
+        db.execute(
+            "INSERT INTO projects (organization_name, project_name) VALUES (?, ?)",
+            ("org1", "proj1"),
+        )
+        db.execute(
+            "INSERT INTO repositories (repository_id, repository_name, project_name, organization_name) VALUES (?, ?, ?, ?)",
+            ("repo-be", "Backend-Repo", "proj1", "org1"),
+        )
+
+        for i in range(1, 4):
+            db.execute(
+                "INSERT INTO users (user_id, display_name, email) VALUES (?, ?, ?)",
+                (f"user{i}", f"User {i}", f"user{i}@example.com"),
+            )
+
+        db.execute(
+            "INSERT INTO teams (team_id, team_name, project_name, organization_name, last_updated) VALUES (?, ?, ?, ?, ?)",
+            ("team-alpha", "Team Alpha", "proj1", "org1", "2026-01-01T00:00:00Z"),
+        )
+        for uid in ["user1", "user2", "user3"]:
+            db.execute(
+                "INSERT INTO team_members (team_id, user_id) VALUES (?, ?)",
+                ("team-alpha", uid),
+            )
+
+        # 6 PRs from user1 in Backend-Repo, only 2 with cycle_time
+        prs = [
+            ("be-1", 1, "org1", "proj1", "repo-be", "user1", "PR1", "completed", None, "2026-01-05", "2026-01-07", 120.0),
+            ("be-2", 2, "org1", "proj1", "repo-be", "user1", "PR2", "completed", None, "2026-01-05", "2026-01-08", 180.0),
+            ("be-3", 3, "org1", "proj1", "repo-be", "user1", "PR3", "completed", None, "2026-01-06", "2026-01-09", None),
+            ("be-4", 4, "org1", "proj1", "repo-be", "user1", "PR4", "completed", None, "2026-01-06", "2026-01-10", None),
+            ("be-5", 5, "org1", "proj1", "repo-be", "user1", "PR5", "completed", None, "2026-01-07", "2026-01-10", None),
+            ("be-6", 6, "org1", "proj1", "repo-be", "user1", "PR6", "completed", None, "2026-01-07", "2026-01-11", None),
+        ]
+        for pr in prs:
+            db.execute(
+                """INSERT INTO pull_requests (
+                    pull_request_uid, pull_request_id, organization_name, project_name,
+                    repository_id, user_id, title, status, description,
+                    creation_date, closed_date, cycle_time_minutes
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                pr,
+            )
+
+        db.connection.commit()
+        yield db, db_path
+        db.close()
+
+    def test_cross_dim_nulls_cycle_time_when_fewer_than_5_non_nan(
+        self,
+        db_with_sparse_cycle_times: tuple[DatabaseManager, Path],
+        tmp_path: Path,
+    ) -> None:
+        """Cross-dim intersection with <5 non-NaN cycle times should have null percentiles."""
+        db, _ = db_with_sparse_cycle_times
+        output_dir = tmp_path / "output"
+
+        generator = AggregateGenerator(db, output_dir)
+        generator.generate_all()
+
+        week_file = output_dir / "aggregates" / "weekly_rollups" / "2026-W02.json"
+        with week_file.open() as f:
+            week_data = json.load(f)
+
+        # Should have by_team_and_repo
+        assert "by_team_and_repo" in week_data
+        alpha_be = week_data["by_team_and_repo"]["Team Alpha"]["Backend-Repo"]
+
+        # 6 total PRs, but only 2 have cycle_time → below MIN_SAMPLE_SIZE=5
+        assert alpha_be["pr_count"] == 6
+        assert alpha_be["cycle_time_p50"] is None
+        assert alpha_be["cycle_time_p90"] is None
+
+
+class TestJsonNanSafety:
+    """Tests for JSON output safety (no NaN/Infinity values).
+
+    Validates that _write_json uses allow_nan=False and the NumpySafeEncoder
+    to produce valid JSON that conforms to the JSON specification.
+    """
+
+    def test_output_json_is_valid_json(
+        self, sample_db: tuple[DatabaseManager, Path], tmp_path: Path
+    ) -> None:
+        """All generated JSON files should be parseable as valid JSON."""
+        db, _ = sample_db
+        output_dir = tmp_path / "output"
+
+        generator = AggregateGenerator(db, output_dir)
+        generator.generate_all()
+
+        # Verify all JSON files in the output are valid
+        for json_file in output_dir.rglob("*.json"):
+            with json_file.open() as f:
+                content = f.read()
+            # json.loads with strict mode rejects NaN/Infinity
+            data = json.loads(content)
+            assert data is not None, f"Failed to parse {json_file}"
+
+    def test_output_json_contains_no_nan_strings(
+        self, sample_db: tuple[DatabaseManager, Path], tmp_path: Path
+    ) -> None:
+        """No JSON file should contain NaN or Infinity as literal values."""
+        db, _ = sample_db
+        output_dir = tmp_path / "output"
+
+        generator = AggregateGenerator(db, output_dir)
+        generator.generate_all()
+
+        for json_file in output_dir.rglob("*.json"):
+            content = json_file.read_text()
+            assert "NaN" not in content, f"NaN found in {json_file}"
+            assert "Infinity" not in content, f"Infinity found in {json_file}"


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where global rollup values (authors_count, reviewers_count, cycle_time) could leak through to filtered subsets when the filtered slice legitimately had zero or null values. It also improves JSON output safety and adds comprehensive test coverage.

## Key Changes

### Global Value Leakage Prevention
- **buildFilteredRollup**: Changed from conditional spreads (`...(condition ? {...} : {})`) to always explicitly setting `authors_count`, `reviewers_count`, `cycle_time_p50`, and `cycle_time_p90`. This ensures filtered slices with 0 authors but non-zero pr_count don't inherit the global author count.
- **Proportional path (applyFiltersToRollups)**: Applied the same fix for cross-dimensional filtering (repo + team). Now always overrides these fields instead of conditionally spreading them.
- **Share clamping**: Added `Math.max(0, ...)` to ensure repoShare and teamShare are clamped to [0, 1] range, preventing negative values.

### JSON Safety
- **_NumpySafeEncoder**: New JSON encoder that converts numpy types (numpy.float64, numpy.int64, numpy.ndarray) to native Python types before serialization.
- **_write_json**: Updated to use `allow_nan=False` and the new encoder, ensuring invalid JSON (containing NaN/Infinity) is rejected at write time rather than silently producing broken output.

### Cycle Time Minimum Sample Size Guard
- **_generate_team_repo_slice**: Fixed the MIN_SAMPLE_SIZE guard to count actual non-NaN cycle_time values (`notna().sum()`) rather than total rows. A cross-dim intersection with 6 PRs but only 2 non-NaN cycle times now correctly produces null percentiles.

### CSS Selector Safety
- **dashboard.ts**: Added `CSS.escape()` to all dynamic option value selectors in `removeFilter()` and `getFilterLabel()` to prevent selector injection when repo/team names contain special characters.

## Test Coverage
- Added 5 new test cases in `global value leakage prevention` suite validating that filtered slices don't inherit global values
- Added `TestMinSampleSizeNonNanGuard` to verify cycle time guards count non-NaN values correctly
- Added `TestJsonNanSafety` to validate JSON output contains no NaN/Infinity literals
- Updated existing test expectations to reflect the new null-based behavior instead of value preservation

## Implementation Details
- The fix maintains backward compatibility: valid filtered data still shows correct values; only illegitimate global leakage is prevented
- Null values are used consistently to indicate "no data" rather than relying on absence from the object
- All changes are defensive: even if upstream code produces unexpected zero/null values, they won't leak global state

https://claude.ai/code/session_013k982GMvL28o3NxrsSR1gB