### PR TITLE
fix: raise NOISE_FLOOR_MS to 5 ms to eliminate CI flakiness

### DIFF
--- a/extension/tests/modules/metrics.edge-cases.test.ts
+++ b/extension/tests/modules/metrics.edge-cases.test.ts
@@ -486,7 +486,7 @@ describe("T025: SC-002 dashboard load time overhead", () => {
   const MEASURE_RUNS = 50;
   const MAX_OVERHEAD_PERCENT = 10;
   /** Below this threshold (ms), percentage comparisons are noise-dominated. */
-  const NOISE_FLOOR_MS = 2;
+  const NOISE_FLOOR_MS = 5;
 
   /**
    * Build an array of rollups for timing measurement.


### PR DESCRIPTION
## Summary
- Raises `NOISE_FLOOR_MS` from `2` to `5` in `metrics.edge-cases.test.ts` (line 489) to prevent false failures on GitHub Actions shared runners where sub-3ms timings make percentage comparisons noise-dominated.

Closes #202

## Test plan
- [ ] CI passes with no flaky SC-002 failures
- [ ] Verify the test still catches real regressions (overhead > 10% on operations taking > 5ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)