### PR TITLE
refactor(types): QG-40 complete — zero typing.Any in src/

### DIFF
--- a/.any-type-baseline.json
+++ b/.any-type-baseline.json
@@ -1,7 +1,5 @@
 {
   "_comment": "QG-40 Any-type ratchet baseline. This ceiling can only decrease. Run: python scripts/check_no_any_types.py --update-baseline",
-  "files": {
-    "src/ado_git_repo_insights/transform/aggregators.py": 20
-  },
-  "total": 20
+  "files": {},
+  "total": 0
 }

--- a/scripts/check_no_any_types.py
+++ b/scripts/check_no_any_types.py
@@ -182,7 +182,7 @@ def main() -> int:
     baseline = load_baseline()
     baseline_total = sum(baseline.values())
 
-    if not baseline:
+    if not BASELINE_PATH.exists():
         print(
             "[FAIL] QG-40: No baseline found. "
             "Run: python scripts/check_no_any_types.py --update-baseline"

--- a/scripts/generate-synthetic-dataset.py
+++ b/scripts/generate-synthetic-dataset.py
@@ -15,7 +15,7 @@ from dataclasses import asdict
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 # Load aggregators via importlib with package stubs so relative imports resolve.
 # This allows direct script execution from a plain checkout without editable install.
@@ -50,10 +50,13 @@ if TYPE_CHECKING:
         YearlyDistribution,
     )
     from ado_git_repo_insights.types import (
+        DistributionIndexEntry,
+        JSONValue,
         ProjectRecord,
         RepositoryRecord,
         TeamRecord,
         UserRecord,
+        WeeklyRollupIndexEntry,
     )
 else:
     _agg_spec = importlib.util.spec_from_file_location(
@@ -71,6 +74,16 @@ else:
     Dimensions = _agg_mod.Dimensions
     WeeklyRollup = _agg_mod.WeeklyRollup
     YearlyDistribution = _agg_mod.YearlyDistribution
+
+    # Types module is loaded as a side-effect of aggregators importing from ..types
+    _types_mod = sys.modules["ado_git_repo_insights.types"]
+    DistributionIndexEntry = _types_mod.DistributionIndexEntry
+    JSONValue = _types_mod.JSONValue
+    ProjectRecord = _types_mod.ProjectRecord
+    RepositoryRecord = _types_mod.RepositoryRecord
+    TeamRecord = _types_mod.TeamRecord
+    UserRecord = _types_mod.UserRecord
+    WeeklyRollupIndexEntry = _types_mod.WeeklyRollupIndexEntry
 
 # Load demo_generation_common from scripts/ via importlib (avoids sys.path manipulation)
 _common_spec = importlib.util.spec_from_file_location(
@@ -614,7 +627,8 @@ def generate_dataset(
         run_id=f"synthetic-{seed}",
         warnings=["SYNTHETIC TEST DATA"],
         aggregate_index=AggregateIndex(
-            weekly_rollups=weekly_index, distributions=dist_index
+            weekly_rollups=cast(list[WeeklyRollupIndexEntry], weekly_index),
+            distributions=cast(list[DistributionIndexEntry], dist_index),
         ),
         defaults={"default_date_range_days": 90},
         limits={"max_date_range_days_soft": 730},
@@ -633,18 +647,21 @@ def generate_dataset(
             "reviewer_team_mode": "disallowed",
             "cross_dimensional_available": True,
         },
-        coverage={
-            "total_prs": pr_count,
-            "date_range": dimensions.date_range,
-            "teams_count": len(dimensions.teams),
-            "comments": comment_stats,
-            "row_counts": {
-                "pull_requests": pr_count,
-                "reviewers": 0,
-                "users": len(dimensions.users),
-                "repositories": len(dimensions.repositories),
+        coverage=cast(
+            dict[str, JSONValue],
+            {
+                "total_prs": pr_count,
+                "date_range": dimensions.date_range,
+                "teams_count": len(dimensions.teams),
+                "comments": comment_stats,
+                "row_counts": {
+                    "pull_requests": pr_count,
+                    "reviewers": 0,
+                    "users": len(dimensions.users),
+                    "repositories": len(dimensions.repositories),
+                },
             },
-        },
+        ),
     )
 
     # Add operational summary

--- a/src/ado_git_repo_insights/transform/aggregators.py
+++ b/src/ado_git_repo_insights/transform/aggregators.py
@@ -19,13 +19,17 @@ import random
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pandas as pd
 
 from ..types import (
     AuthorRecord,
+    CommentsCoverage,
+    DistributionIndexEntry,
+    JSONValue,
+    OperationalSummary,
     ProjectRecord,
     RepositoryRecord,
     ReviewerRecord,
@@ -33,6 +37,7 @@ from ..types import (
     SliceMetrics,
     TeamRecord,
     UserRecord,
+    WeeklyRollupIndexEntry,
 )
 from .schema_versions import (
     AGGREGATES_SCHEMA_VERSION,
@@ -185,8 +190,8 @@ def _df_to_team_records(df: pd.DataFrame) -> list[TeamRecord]:
 class AggregateIndex:
     """Index of available aggregate files."""
 
-    weekly_rollups: list[dict[str, Any]] = field(default_factory=list)
-    distributions: list[dict[str, Any]] = field(default_factory=list)
+    weekly_rollups: list[WeeklyRollupIndexEntry] = field(default_factory=list)
+    distributions: list[DistributionIndexEntry] = field(default_factory=list)
 
 
 @dataclass
@@ -202,11 +207,11 @@ class DatasetManifest:
     run_id: str = ""
     warnings: list[str] = field(default_factory=list)  # Phase 3.5: stub warnings
     aggregate_index: AggregateIndex = field(default_factory=AggregateIndex)
-    defaults: dict[str, Any] = field(default_factory=dict)
-    limits: dict[str, Any] = field(default_factory=dict)
+    defaults: dict[str, int] = field(default_factory=dict)
+    limits: dict[str, int] = field(default_factory=dict)
     features: dict[str, bool] = field(default_factory=dict)
-    capabilities: dict[str, Any] = field(default_factory=dict)
-    coverage: dict[str, Any] = field(default_factory=dict)
+    capabilities: dict[str, str | bool] = field(default_factory=dict)
+    coverage: dict[str, JSONValue] = field(default_factory=dict)
 
 
 class AggregateGenerator:
@@ -392,14 +397,17 @@ class AggregateGenerator:
                     "ai_insights": insights_generated,  # Phase 3.5/5: file-gated
                 },
                 capabilities=self._get_capabilities(),
-                coverage={
-                    "total_prs": self._get_pr_count(),
-                    "date_range": dimensions.date_range,
-                    "teams_count": len(dimensions.teams),  # Phase 3.3
-                    "comments": self._get_comments_coverage(),  # Phase 3.4
-                    # Phase 4 §5: Operational visibility
-                    "row_counts": self._get_row_counts(),
-                },
+                coverage=cast(
+                    dict[str, JSONValue],
+                    {
+                        "total_prs": self._get_pr_count(),
+                        "date_range": dimensions.date_range,
+                        "teams_count": len(dimensions.teams),  # Phase 3.3
+                        "comments": self._get_comments_coverage(),  # Phase 3.4
+                        # Phase 4 §5: Operational visibility
+                        "row_counts": self._get_row_counts(),
+                    },
+                ),
             )
 
             # Phase 4 §5: Calculate total artifact size after manifest written
@@ -572,7 +580,7 @@ class AggregateGenerator:
             date_range=date_range,
         )
 
-    def _generate_weekly_rollups(self) -> list[dict[str, Any]]:
+    def _generate_weekly_rollups(self) -> list[WeeklyRollupIndexEntry]:
         """Generate weekly rollup files, one per ISO week."""
         # Query PRs with closed dates and repository info for dimension slicing
         df = pd.read_sql_query(
@@ -627,7 +635,7 @@ class AggregateGenerator:
         df["iso_year"] = df["closed_dt"].dt.isocalendar().year
         df["iso_week"] = df["closed_dt"].dt.isocalendar().week
 
-        index: list[dict[str, Any]] = []
+        index: list[WeeklyRollupIndexEntry] = []
         any_rollup_has_cross_dim = False
         # Track cross-dim availability for features flag (set on self after loop)
 
@@ -1249,7 +1257,7 @@ class AggregateGenerator:
 
         return by_team_and_repo
 
-    def _generate_distributions(self) -> list[dict[str, Any]]:
+    def _generate_distributions(self) -> list[DistributionIndexEntry]:
         """Generate yearly distribution files."""
         df = pd.read_sql_query(
             """
@@ -1270,7 +1278,7 @@ class AggregateGenerator:
         df["year"] = df["closed_dt"].dt.year
         df["month"] = df["closed_dt"].dt.strftime("%Y-%m")
 
-        index: list[dict[str, Any]] = []
+        index: list[DistributionIndexEntry] = []
 
         for year, group in df.groupby("year"):
             year_str = str(year)
@@ -1334,9 +1342,9 @@ class AggregateGenerator:
             # Legacy DB may not have pr_threads table
             return False
 
-    def _get_capabilities(self) -> dict[str, Any]:
+    def _get_capabilities(self) -> dict[str, str | bool]:
         """Get additive capability metadata for loader normalization."""
-        capabilities: dict[str, Any] = {
+        capabilities: dict[str, str | bool] = {
             "author_filters": True,
             "author_repo_exact": True,
             "comments_metrics": self._has_comments(),
@@ -1352,7 +1360,7 @@ class AggregateGenerator:
             if key in capabilities
         }
 
-    def _get_comments_coverage(self) -> dict[str, Any]:
+    def _get_comments_coverage(self) -> CommentsCoverage:
         """Get comments coverage statistics.
 
         §6: coverage.comments: "full" | "partial" | "disabled"
@@ -1449,9 +1457,9 @@ class AggregateGenerator:
 
     def _get_operational_summary(
         self,
-        weekly_index: list[dict[str, Any]],
-        dist_index: list[dict[str, Any]],
-    ) -> dict[str, Any]:
+        weekly_index: list[WeeklyRollupIndexEntry],
+        dist_index: list[DistributionIndexEntry],
+    ) -> OperationalSummary:
         """Generate operational summary for operators (Phase 4 §5).
 
         Provides immediate insight into dataset health and scale.
@@ -1485,7 +1493,7 @@ class AggregateGenerator:
             ),
         }
 
-    def _write_json(self, path: Path, data: dict[str, Any]) -> None:
+    def _write_json(self, path: Path, data: dict[str, JSONValue]) -> None:
         """Write JSON file with deterministic formatting.
 
         Uses allow_nan=False to reject NaN/Infinity values that would
@@ -1542,7 +1550,7 @@ class PredictionGenerator:
         self.output_dir = output_dir
         self.seed_base = seed_base
 
-    def generate(self) -> dict[str, Any] | None:
+    def generate(self) -> dict[str, JSONValue] | None:
         """Generate predictions stub file.
 
         Returns:
@@ -1615,7 +1623,7 @@ class PredictionGenerator:
             json.dump(predictions, f, indent=2, sort_keys=True)
 
         logger.info("Generated predictions/trends.json (stub data)")
-        return predictions
+        return cast(dict[str, JSONValue], predictions)
 
 
 class InsightsGenerator:
@@ -1664,7 +1672,7 @@ class InsightsGenerator:
         self.output_dir = output_dir
         self.seed_base = seed_base
 
-    def generate(self) -> dict[str, Any] | None:
+    def generate(self) -> dict[str, JSONValue] | None:
         """Generate insights stub file.
 
         Returns:
@@ -1726,4 +1734,4 @@ class InsightsGenerator:
             json.dump(insights, f, indent=2, sort_keys=True)
 
         logger.info("Generated insights/summary.json (stub data)")
-        return insights
+        return cast(dict[str, JSONValue], insights)

--- a/src/ado_git_repo_insights/types.py
+++ b/src/ado_git_repo_insights/types.py
@@ -288,3 +288,47 @@ class WeeklyRollupIndexEntry(TypedDict):
     start_date: str
     end_date: str
     size_bytes: int
+
+
+class DistributionIndexEntry(TypedDict):
+    """Index entry for a yearly distribution file in aggregate_index."""
+
+    year: str
+    path: str
+    start_date: str
+    end_date: str
+    size_bytes: int
+
+
+# ---------------------------------------------------------------------------
+# Manifest sub-structure types (P5c — aggregators.py DatasetManifest)
+# ---------------------------------------------------------------------------
+
+
+class CommentsCoverage(TypedDict):
+    """Comments extraction coverage statistics for dataset manifest."""
+
+    status: str
+    threads_fetched: int
+    comments_fetched: int
+    prs_with_threads: int
+    capped: bool
+
+
+class ManifestCoverage(TypedDict):
+    """Dataset manifest coverage section."""
+
+    total_prs: int
+    date_range: dict[str, str]
+    teams_count: int
+    comments: CommentsCoverage
+    row_counts: dict[str, int]
+
+
+class OperationalSummary(TypedDict):
+    """Operational summary for dataset manifest (Phase 4 §5)."""
+
+    artifact_size_bytes: int
+    weekly_rollup_count: int
+    distribution_count: int
+    retention_notice: str | None

--- a/tests/unit/test_aggregators.py
+++ b/tests/unit/test_aggregators.py
@@ -448,8 +448,10 @@ class TestAggregateGenerator:
         manifest = generator.generate_all()
 
         assert manifest.capabilities["comments_metrics"] is True
-        assert manifest.coverage["comments"]["status"] == "full"
-        assert manifest.coverage["comments"]["capped"] is False
+        comments = manifest.coverage["comments"]
+        assert isinstance(comments, dict)
+        assert comments["status"] == "full"
+        assert comments["capped"] is False
 
     def test_manifest_sets_partial_comments_coverage_when_capped(
         self, sample_db: tuple[DatabaseManager, Path], tmp_path: Path
@@ -480,8 +482,10 @@ class TestAggregateGenerator:
         manifest = generator.generate_all()
 
         assert manifest.capabilities["comments_metrics"] is True
-        assert manifest.coverage["comments"]["status"] == "partial"
-        assert manifest.coverage["comments"]["capped"] is True
+        comments = manifest.coverage["comments"]
+        assert isinstance(comments, dict)
+        assert comments["status"] == "partial"
+        assert comments["capped"] is True
 
     def test_manifest_capabilities_are_emitted_from_guarded_keyset(
         self, sample_db: tuple[DatabaseManager, Path], tmp_path: Path

--- a/tests/unit/test_comments_extraction.py
+++ b/tests/unit/test_comments_extraction.py
@@ -290,8 +290,10 @@ class TestCommentsCoverage:
         manifest = generator.generate_all()
 
         assert manifest.features["comments"] is False
-        assert manifest.coverage["comments"]["status"] == "disabled"
-        assert manifest.coverage["comments"]["threads_fetched"] == 0
+        comments = manifest.coverage["comments"]
+        assert isinstance(comments, dict)
+        assert comments["status"] == "disabled"
+        assert comments["threads_fetched"] == 0
 
         db.close()
 
@@ -355,8 +357,10 @@ class TestCommentsCoverage:
         manifest = generator.generate_all()
 
         assert manifest.features["comments"] is True
-        assert manifest.coverage["comments"]["status"] == "full"
-        assert manifest.coverage["comments"]["threads_fetched"] == 1
-        assert manifest.coverage["comments"]["prs_with_threads"] == 1
+        comments = manifest.coverage["comments"]
+        assert isinstance(comments, dict)
+        assert comments["status"] == "full"
+        assert comments["threads_fetched"] == 1
+        assert comments["prs_with_threads"] == 1
 
         db.close()


### PR DESCRIPTION
## Summary

Closes #237. Eliminates all 46 `typing.Any` tokens from `aggregators.py` — the last file blocking QG-40 completion for `src/`. The ratchet baseline is now **0 total across 0 files**, enforced via pre-commit on every commit.

- **P5a** (12 tokens): Define 6 entity record TypedDicts (`RepositoryRecord`, `UserRecord`, `AuthorRecord`, `ReviewerRecord`, `ProjectRecord`, `TeamRecord`) + per-entity DataFrame conversion functions (FR-014). Replace all `dict[str, Any]` in `Dimensions` dataclass and `_generate_dimensions`.
- **P5b** (14 tokens): Define `SliceMetrics`, `ReviewerSliceMetrics`, `WeeklyRollupIndexEntry`. Replace annotations across all 6 slice methods. Cross-dim dicts use `cast()` for the heterogeneous `_truncated` flag + `isinstance` narrowing in consumers.
- **P5c** (20 tokens): Define `DistributionIndexEntry`, `CommentsCoverage`, `ManifestCoverage`, `OperationalSummary`. Replace annotations across `AggregateIndex`, `DatasetManifest`, `_generate_distributions`, `_get_capabilities`, `_get_comments_coverage`, `_get_operational_summary`, `_write_json` (→ `JSONValue`), and both stub generators. Remove `Any` from the `typing` import entirely. Fix ratchet script edge case where an empty baseline (0 files) was incorrectly treated as a missing baseline.

All 15 new TypedDicts live in the shared `types.py` module per FR-013 (no local redefinitions).

## Verification

- `python scripts/check_no_any_types.py` → **0 total for src/**
- `mypy src/ tests/ scripts/` → **Success: no issues found in 161 source files**
- `pytest` → **all tests pass**, 83.68% coverage
- `ruff check` → **all checks passed**
- `.any-type-baseline.json` → `{"files": {}, "total": 0}`
- Zero new `# type: ignore` or `# noqa` suppressions (FR-009)

## Test plan

- [x] mypy --strict passes across src/, tests/, scripts/ (161 files)
- [x] Full test suite green (all tests pass, coverage ≥ 75%)
- [x] QG-40 ratchet reports 0 Any usages
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass on all 3 commits
- [x] Ratchet script correctly handles the zero-Any terminal state (empty baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)