### PR TITLE
fix(#273): verify subprocess allowlist entries against live violations

### DIFF
--- a/.subprocess-allowlist.json
+++ b/.subprocess-allowlist.json
@@ -32,30 +32,6 @@
       "reason": "Repo-owned parity command list"
     },
     {
-      "file": "scripts/run_pr_preflight.py",
-      "line": 590,
-      "code": "completed = subprocess.run(",
-      "reason": "CommandSpec-driven command list from build_commands()"
-    },
-    {
-      "file": "scripts/run_repo_hook.py",
-      "line": 96,
-      "code": "result = subprocess.run(",
-      "reason": "run_command() helper: command list from callers"
-    },
-    {
-      "file": "scripts/run_repo_hook.py",
-      "line": 192,
-      "code": "result = subprocess.run(",
-      "reason": "staged_file_content(): git show with repo-owned path"
-    },
-    {
-      "file": "tests/demo/test_regeneration.py",
-      "line": 91,
-      "code": "result = subprocess.run(",
-      "reason": "Test runner: trusted script invocation"
-    },
-    {
       "file": "tests/unit/test_coverage_delta.py",
       "line": 121,
       "code": "return subprocess.run(",

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "python": {
-    "min_collected": 1789,
+    "min_collected": 1791,
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "python": {
-    "min_collected": 1782,
+    "min_collected": 1789,
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "python": {
-    "min_collected": 1791,
+    "min_collected": 1804,
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "python": {
-    "min_collected": 1804,
+    "min_collected": 1814,
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {

--- a/scripts/check_rule_disable_invariants.py
+++ b/scripts/check_rule_disable_invariants.py
@@ -562,11 +562,11 @@ def verify_subprocess_allowlist_entries(
     if not allowlist_path.exists():
         return []
 
-    try:
-        with open(allowlist_path, encoding="utf-8") as f:
-            data = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        return []
+    # Let parse errors propagate — the caller in verify_artifacts() catches
+    # them and reports [FAIL].  Swallowing here would be fail-open: a corrupt
+    # allowlist silently passes verification.
+    with open(allowlist_path, encoding="utf-8") as f:
+        data = json.load(f)
 
     entries = data.get("entries", [])
     if not entries:
@@ -727,25 +727,36 @@ def verify_artifacts(repo_root: Path) -> int:
                 f"({len(fresh_raw)} entries, semantic match)"
             )
 
-    # Verify subprocess allowlist entries (issue #273)
-    orphans = verify_subprocess_allowlist_entries(repo_root)
-    if orphans:
-        print(f"[FAIL] {len(orphans)} orphan(s) in .subprocess-allowlist.json:")
-        for o in orphans:
-            print(f"  {o['file']}:{o['line']}: {o['category']}")
-            print(f"    code: {o['code']}")
-            print(f"    reason: {o['reason']}")
-        print(
-            "  Run: python scripts/check_rule_disable_invariants.py "
-            "--regenerate-allowlist"
-        )
-        exit_code = 1
-    else:
-        allowlist_path = repo_root / ".subprocess-allowlist.json"
-        if allowlist_path.exists():
-            with open(allowlist_path, encoding="utf-8") as f:
-                count = len(json.load(f).get("entries", []))
-            print(f"[PASS] Subprocess allowlist verified ({count} entries, all live)")
+    # Verify subprocess allowlist entries (issue #273).
+    # verify_subprocess_allowlist_entries() intentionally does NOT swallow parse
+    # errors — catch them here so a corrupt allowlist produces [FAIL], not a
+    # traceback.  The entry-access path (KeyError/ValueError) is also caught so
+    # malformed entries fail closed rather than crash.
+    allowlist_path = repo_root / ".subprocess-allowlist.json"
+    if allowlist_path.exists():
+        try:
+            orphans = verify_subprocess_allowlist_entries(repo_root)
+        except (OSError, json.JSONDecodeError, KeyError, ValueError) as exc:
+            print(f"[FAIL] .subprocess-allowlist.json is malformed: {exc}")
+            exit_code = 1
+        else:
+            if orphans:
+                print(f"[FAIL] {len(orphans)} orphan(s) in .subprocess-allowlist.json:")
+                for o in orphans:
+                    print(f"  {o['file']}:{o['line']}: {o['category']}")
+                    print(f"    code: {o['code']}")
+                    print(f"    reason: {o['reason']}")
+                print(
+                    "  Run: python scripts/check_rule_disable_invariants.py "
+                    "--regenerate-allowlist"
+                )
+                exit_code = 1
+            else:
+                with open(allowlist_path, encoding="utf-8") as f:
+                    count = len(json.load(f).get("entries", []))
+                print(
+                    f"[PASS] Subprocess allowlist verified ({count} entries, all live)"
+                )
 
     return exit_code
 

--- a/scripts/check_rule_disable_invariants.py
+++ b/scripts/check_rule_disable_invariants.py
@@ -568,6 +568,11 @@ def verify_subprocess_allowlist_entries(
     with open(allowlist_path, encoding="utf-8") as f:
         data = json.load(f)
 
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"top-level value must be an object, got {type(data).__name__}"
+        )
+
     entries = data.get("entries")
     if not isinstance(entries, list):
         raise ValueError(f"'entries' must be a list, got {type(entries).__name__}")

--- a/scripts/check_rule_disable_invariants.py
+++ b/scripts/check_rule_disable_invariants.py
@@ -568,7 +568,9 @@ def verify_subprocess_allowlist_entries(
     with open(allowlist_path, encoding="utf-8") as f:
         data = json.load(f)
 
-    entries = data.get("entries", [])
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError(f"'entries' must be a list, got {type(entries).__name__}")
     if not entries:
         return []
 
@@ -576,7 +578,11 @@ def verify_subprocess_allowlist_entries(
     file_cache: dict[str, tuple[list[str], list[dict[str, str | int]]]] = {}
     orphans: list[dict[str, str | int]] = []
 
-    for entry in entries:
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"entries[{i}] must be an object, got {type(entry).__name__}"
+            )
         file_key = str(entry["file"])
         line_num = int(entry["line"])
         code_key = _normalize_allowlist_code(entry["code"])
@@ -736,7 +742,7 @@ def verify_artifacts(repo_root: Path) -> int:
     if allowlist_path.exists():
         try:
             orphans = verify_subprocess_allowlist_entries(repo_root)
-        except (OSError, json.JSONDecodeError, KeyError, ValueError) as exc:
+        except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
             print(f"[FAIL] .subprocess-allowlist.json is malformed: {exc}")
             exit_code = 1
         else:

--- a/scripts/check_rule_disable_invariants.py
+++ b/scripts/check_rule_disable_invariants.py
@@ -10,7 +10,7 @@ Entry points:
   --check-subprocess  Detect unsafe subprocess patterns (compensates S603/S607)
   --check-random      Detect unsafe random patterns (compensates S311)
   --check-syspath     Detect sys.path.insert/append (enforces importlib-only)
-  --verify-artifacts  Verify committed proof artifacts match codebase
+  --verify-artifacts  Verify proof artifacts and subprocess allowlist match codebase
   --generate-artifacts Generate proof artifacts for rule-disable justification
 
 All checks use tokenize.generate_tokens for accuracy (no string-literal
@@ -899,7 +899,7 @@ def main() -> int:
     parser.add_argument(
         "--verify-artifacts",
         action="store_true",
-        help="Verify committed proof artifacts match codebase",
+        help="Verify proof artifacts and subprocess allowlist match codebase",
     )
     parser.add_argument(
         "--generate-artifacts",

--- a/scripts/check_rule_disable_invariants.py
+++ b/scripts/check_rule_disable_invariants.py
@@ -547,11 +547,121 @@ def _normalize_entries(
     )
 
 
+def verify_subprocess_allowlist_entries(
+    repo_root: Path,
+) -> list[dict[str, str | int]]:
+    """Verify each .subprocess-allowlist.json entry points at a live unsafe call.
+
+    Returns a list of orphan descriptors, one per stale entry.  Three categories:
+      file-removed        — target file no longer exists
+      line-shifted        — file exists but code snippet is not on the expected line
+      refactored-to-safe  — code is on the line but check_subprocess_safety() no
+                            longer classifies it as unsafe
+    """
+    allowlist_path = repo_root / ".subprocess-allowlist.json"
+    if not allowlist_path.exists():
+        return []
+
+    try:
+        with open(allowlist_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+
+    entries = data.get("entries", [])
+    if not entries:
+        return []
+
+    # Cache per-file content and violations to avoid redundant I/O + scanning
+    file_cache: dict[str, tuple[list[str], list[dict[str, str | int]]]] = {}
+    orphans: list[dict[str, str | int]] = []
+
+    for entry in entries:
+        file_key = str(entry["file"])
+        line_num = int(entry["line"])
+        code_key = _normalize_allowlist_code(entry["code"])
+        reason = str(entry.get("reason", ""))
+        full_path = repo_root / file_key
+
+        # Category 1: file removed
+        if not full_path.exists():
+            orphans.append(
+                {
+                    "file": file_key,
+                    "line": line_num,
+                    "code": code_key,
+                    "reason": reason,
+                    "category": "file-removed",
+                }
+            )
+            continue
+
+        # Load and cache file lines + violations
+        if file_key not in file_cache:
+            try:
+                content = full_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                orphans.append(
+                    {
+                        "file": file_key,
+                        "line": line_num,
+                        "code": code_key,
+                        "reason": reason,
+                        "category": "file-removed",
+                    }
+                )
+                continue
+            file_cache[file_key] = (
+                content.splitlines(),
+                check_subprocess_safety(file_key, content),
+            )
+
+        lines, violations = file_cache[file_key]
+
+        # Category 2: line shifted (code snippet not on expected line)
+        if (
+            line_num < 1
+            or line_num > len(lines)
+            or code_key not in lines[line_num - 1].strip()
+        ):
+            orphans.append(
+                {
+                    "file": file_key,
+                    "line": line_num,
+                    "code": code_key,
+                    "reason": reason,
+                    "category": "line-shifted",
+                }
+            )
+            continue
+
+        # Category 3: refactored to safe (code present but no matching violation)
+        has_matching_violation = any(
+            int(v["line"]) == line_num
+            and _normalize_allowlist_code(v["code"]) == code_key
+            for v in violations
+        )
+        if not has_matching_violation:
+            orphans.append(
+                {
+                    "file": file_key,
+                    "line": line_num,
+                    "code": code_key,
+                    "reason": reason,
+                    "category": "refactored-to-safe",
+                }
+            )
+
+    return orphans
+
+
 def verify_artifacts(repo_root: Path) -> int:
     """Verify committed proof artifacts match current codebase (FR-020).
 
     Verification is exact for artifact metadata and semantic entry content,
     while tolerating line-number-only churn from formatting or nearby edits.
+    Also verifies that every .subprocess-allowlist.json entry still corresponds
+    to a live unsafe call site (issue #273).
     """
     exit_code = 0
     artifact_configs: list[tuple[str, Callable[[Path], dict[str, object]], str]] = [
@@ -616,6 +726,26 @@ def verify_artifacts(repo_root: Path) -> int:
                 f"[PASS] {rule} artifact matches codebase "
                 f"({len(fresh_raw)} entries, semantic match)"
             )
+
+    # Verify subprocess allowlist entries (issue #273)
+    orphans = verify_subprocess_allowlist_entries(repo_root)
+    if orphans:
+        print(f"[FAIL] {len(orphans)} orphan(s) in .subprocess-allowlist.json:")
+        for o in orphans:
+            print(f"  {o['file']}:{o['line']}: {o['category']}")
+            print(f"    code: {o['code']}")
+            print(f"    reason: {o['reason']}")
+        print(
+            "  Run: python scripts/check_rule_disable_invariants.py "
+            "--regenerate-allowlist"
+        )
+        exit_code = 1
+    else:
+        allowlist_path = repo_root / ".subprocess-allowlist.json"
+        if allowlist_path.exists():
+            with open(allowlist_path, encoding="utf-8") as f:
+                count = len(json.load(f).get("entries", []))
+            print(f"[PASS] Subprocess allowlist verified ({count} entries, all live)")
 
     return exit_code
 

--- a/tests/unit/test_ci_parity_drift.py
+++ b/tests/unit/test_ci_parity_drift.py
@@ -762,7 +762,7 @@ class TestTestCountRatchetParity:
         assert "--suite extension" in ci_extension_run
 
         assert floor_contract["schema_version"] == 1
-        assert floor_contract["python"]["min_collected"] == 1782
+        assert floor_contract["python"]["min_collected"] > 0
         assert floor_contract["extension"]["min_collected"] > 0
 
     def test_preflight_and_ci_require_explicit_floor_contract_validation(self) -> None:

--- a/tests/unit/test_rule_disable_invariants.py
+++ b/tests/unit/test_rule_disable_invariants.py
@@ -855,6 +855,15 @@ class TestAllowlistOrphanDetection:
         orphans = _mod.verify_subprocess_allowlist_entries(case_dir)
         assert orphans == []
 
+    def test_malformed_json_raises(self) -> None:
+        """Malformed JSON propagates instead of silently returning []."""
+        case_dir = self._build_case("malformed-raises", [])
+        (case_dir / ".subprocess-allowlist.json").write_text(
+            "not valid json{{{", encoding="utf-8"
+        )
+        with pytest.raises(json.JSONDecodeError):
+            _mod.verify_subprocess_allowlist_entries(case_dir)
+
     def test_committed_allowlist_is_clean(self) -> None:
         """The repo's committed .subprocess-allowlist.json has zero orphans."""
         repo_root = Path(__file__).parent.parent.parent
@@ -900,3 +909,33 @@ class TestAllowlistOrphanDetection:
         out = capsys.readouterr().out
         assert "orphan" in out.lower()
         assert "--regenerate-allowlist" in out
+
+    def test_verify_artifacts_handles_malformed_allowlist(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Malformed allowlist JSON produces [FAIL], not a traceback."""
+        case_dir = self._build_case("malformed", [])
+        # Overwrite with invalid JSON
+        (case_dir / ".subprocess-allowlist.json").write_text(
+            "not valid json{{{", encoding="utf-8"
+        )
+        fresh_s603 = _mod.generate_subprocess_artifact(
+            Path(__file__).parent.parent.parent
+        )
+        fresh_s311 = _mod.generate_random_artifact(Path(__file__).parent.parent.parent)
+        (case_dir / ".rule-disable-audit-S603.json").write_text(
+            json.dumps(fresh_s603, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        (case_dir / ".rule-disable-audit-S311.json").write_text(
+            json.dumps(fresh_s311, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        with (
+            patch.object(_mod, "generate_subprocess_artifact", return_value=fresh_s603),
+            patch.object(_mod, "generate_random_artifact", return_value=fresh_s311),
+        ):
+            rc = _mod.verify_artifacts(case_dir)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "malformed" in out.lower()

--- a/tests/unit/test_rule_disable_invariants.py
+++ b/tests/unit/test_rule_disable_invariants.py
@@ -731,3 +731,172 @@ class TestCmdRegenerateAllowlistPrunesOrphans:
         )
         reasons = sorted(e["reason"] for e in written["entries"])
         assert reasons == ["dup-A", "dup-B"]
+
+
+class TestAllowlistOrphanDetection:
+    """Issue #273: verify_subprocess_allowlist_entries detects stale entries.
+
+    Three orphan categories:
+      file-removed        — target file deleted
+      line-shifted        — file exists but code not on expected line
+      refactored-to-safe  — code on line but call is now safe (literal list)
+    """
+
+    TMP_ROOT = (
+        Path(__file__).parent.parent.parent / "tmp_test_work" / "allowlist-orphan"
+    )
+
+    def _build_case(
+        self,
+        name: str,
+        entries: list[dict[str, str | int]],
+        files: dict[str, str] | None = None,
+    ) -> Path:
+        self.TMP_ROOT.mkdir(parents=True, exist_ok=True)
+        case_dir = self.TMP_ROOT / name
+        shutil.rmtree(case_dir, ignore_errors=True)
+        case_dir.mkdir(parents=True)
+        (case_dir / ".subprocess-allowlist.json").write_text(
+            json.dumps({"description": "test", "entries": entries}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        for rel_path, content in (files or {}).items():
+            full = case_dir / rel_path
+            full.parent.mkdir(parents=True, exist_ok=True)
+            full.write_text(content, encoding="utf-8")
+        return case_dir
+
+    def test_file_removed_detected(self) -> None:
+        """Entry pointing at a non-existent file is category file-removed."""
+        case_dir = self._build_case(
+            "file-removed",
+            [
+                {
+                    "file": "gone.py",
+                    "line": 1,
+                    "code": "subprocess.run(",
+                    "reason": "test",
+                }
+            ],
+        )
+        orphans = _mod.verify_subprocess_allowlist_entries(case_dir)
+        assert len(orphans) == 1
+        assert orphans[0]["category"] == "file-removed"
+        assert orphans[0]["file"] == "gone.py"
+
+    def test_line_shifted_detected(self) -> None:
+        """Entry with wrong line number is category line-shifted."""
+        case_dir = self._build_case(
+            "line-shifted",
+            [
+                {
+                    "file": "s.py",
+                    "line": 1,
+                    "code": "result = subprocess.run(cmd)",
+                    "reason": "test",
+                }
+            ],
+            files={
+                "s.py": "import subprocess\n# padding\nresult = subprocess.run(cmd)\n"
+            },
+        )
+        orphans = _mod.verify_subprocess_allowlist_entries(case_dir)
+        assert len(orphans) == 1
+        assert orphans[0]["category"] == "line-shifted"
+
+    def test_refactored_to_safe_detected(self) -> None:
+        """Entry where call was refactored to literal list is refactored-to-safe."""
+        case_dir = self._build_case(
+            "refactored-safe",
+            [
+                {
+                    "file": "s.py",
+                    "line": 2,
+                    "code": "result = subprocess.run(",
+                    "reason": "test",
+                }
+            ],
+            files={
+                "s.py": (
+                    "import subprocess\n"
+                    "result = subprocess.run(\n"
+                    '    ["git", "status"],\n'
+                    ")\n"
+                ),
+            },
+        )
+        orphans = _mod.verify_subprocess_allowlist_entries(case_dir)
+        assert len(orphans) == 1
+        assert orphans[0]["category"] == "refactored-to-safe"
+
+    def test_live_entry_not_flagged(self) -> None:
+        """Entry matching a real unsafe violation returns empty list."""
+        case_dir = self._build_case(
+            "live",
+            [
+                {
+                    "file": "s.py",
+                    "line": 2,
+                    "code": "result = subprocess.run(cmd)",
+                    "reason": "test",
+                }
+            ],
+            files={"s.py": "import subprocess\nresult = subprocess.run(cmd)\n"},
+        )
+        orphans = _mod.verify_subprocess_allowlist_entries(case_dir)
+        assert len(orphans) == 0
+
+    def test_missing_allowlist_returns_empty(self) -> None:
+        """No allowlist file returns empty list, not an error."""
+        self.TMP_ROOT.mkdir(parents=True, exist_ok=True)
+        case_dir = self.TMP_ROOT / "no-allowlist"
+        shutil.rmtree(case_dir, ignore_errors=True)
+        case_dir.mkdir(parents=True)
+        orphans = _mod.verify_subprocess_allowlist_entries(case_dir)
+        assert orphans == []
+
+    def test_committed_allowlist_is_clean(self) -> None:
+        """The repo's committed .subprocess-allowlist.json has zero orphans."""
+        repo_root = Path(__file__).parent.parent.parent
+        orphans = _mod.verify_subprocess_allowlist_entries(repo_root)
+        assert orphans == [], (
+            f"Committed allowlist has {len(orphans)} orphan(s): "
+            + ", ".join(f"{o['file']}:{o['line']} ({o['category']})" for o in orphans)
+        )
+
+    def test_verify_artifacts_fails_on_orphan(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--verify-artifacts returns non-zero when orphans exist."""
+        case_dir = self._build_case(
+            "verify-integration",
+            [
+                {
+                    "file": "gone.py",
+                    "line": 1,
+                    "code": "subprocess.run(",
+                    "reason": "test",
+                }
+            ],
+        )
+        fresh_s603 = _mod.generate_subprocess_artifact(
+            Path(__file__).parent.parent.parent
+        )
+        fresh_s311 = _mod.generate_random_artifact(Path(__file__).parent.parent.parent)
+        (case_dir / ".rule-disable-audit-S603.json").write_text(
+            json.dumps(fresh_s603, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        (case_dir / ".rule-disable-audit-S311.json").write_text(
+            json.dumps(fresh_s311, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        with (
+            patch.object(_mod, "generate_subprocess_artifact", return_value=fresh_s603),
+            patch.object(_mod, "generate_random_artifact", return_value=fresh_s311),
+        ):
+            rc = _mod.verify_artifacts(case_dir)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "orphan" in out.lower()
+        assert "--regenerate-allowlist" in out

--- a/tests/unit/test_rule_disable_invariants.py
+++ b/tests/unit/test_rule_disable_invariants.py
@@ -864,6 +864,38 @@ class TestAllowlistOrphanDetection:
         with pytest.raises(json.JSONDecodeError):
             _mod.verify_subprocess_allowlist_entries(case_dir)
 
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            '{"entries": {}}',
+            '{"entries": ""}',
+            '{"entries": null}',
+            '{"entries": 0}',
+            "{}",
+        ],
+        ids=["dict", "string", "null", "number", "missing-key"],
+    )
+    def test_non_list_entries_raises(self, payload: str) -> None:
+        """Entries that are not a list raise ValueError, not silent pass."""
+        case_dir = self._build_case("non-list-entries", [])
+        (case_dir / ".subprocess-allowlist.json").write_text(payload, encoding="utf-8")
+        with pytest.raises(ValueError, match="must be a list"):
+            _mod.verify_subprocess_allowlist_entries(case_dir)
+
+    @pytest.mark.parametrize(
+        "bad_entry",
+        [None, 1, "string", []],
+        ids=["null", "number", "string", "array"],
+    )
+    def test_non_dict_entry_raises(self, bad_entry: object) -> None:
+        """Non-object items in entries raise ValueError, not TypeError."""
+        case_dir = self._build_case("non-dict-entry", [])
+        (case_dir / ".subprocess-allowlist.json").write_text(
+            json.dumps({"entries": [bad_entry]}), encoding="utf-8"
+        )
+        with pytest.raises(ValueError, match="must be an object"):
+            _mod.verify_subprocess_allowlist_entries(case_dir)
+
     def test_committed_allowlist_is_clean(self) -> None:
         """The repo's committed .subprocess-allowlist.json has zero orphans."""
         repo_root = Path(__file__).parent.parent.parent
@@ -919,6 +951,45 @@ class TestAllowlistOrphanDetection:
         (case_dir / ".subprocess-allowlist.json").write_text(
             "not valid json{{{", encoding="utf-8"
         )
+        fresh_s603 = _mod.generate_subprocess_artifact(
+            Path(__file__).parent.parent.parent
+        )
+        fresh_s311 = _mod.generate_random_artifact(Path(__file__).parent.parent.parent)
+        (case_dir / ".rule-disable-audit-S603.json").write_text(
+            json.dumps(fresh_s603, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        (case_dir / ".rule-disable-audit-S311.json").write_text(
+            json.dumps(fresh_s311, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        with (
+            patch.object(_mod, "generate_subprocess_artifact", return_value=fresh_s603),
+            patch.object(_mod, "generate_random_artifact", return_value=fresh_s311),
+        ):
+            rc = _mod.verify_artifacts(case_dir)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "malformed" in out.lower()
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            '{"entries": {}}',
+            '{"entries": null}',
+            '{"entries": [null]}',
+            '{"entries": [1]}',
+        ],
+        ids=["entries-dict", "entries-null", "null-item", "int-item"],
+    )
+    def test_verify_artifacts_fails_on_structural_malformation(
+        self,
+        payload: str,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Structurally invalid allowlist shapes produce [FAIL], not traceback."""
+        case_dir = self._build_case("structural-malform", [])
+        (case_dir / ".subprocess-allowlist.json").write_text(payload, encoding="utf-8")
         fresh_s603 = _mod.generate_subprocess_artifact(
             Path(__file__).parent.parent.parent
         )

--- a/tests/unit/test_rule_disable_invariants.py
+++ b/tests/unit/test_rule_disable_invariants.py
@@ -896,6 +896,18 @@ class TestAllowlistOrphanDetection:
         with pytest.raises(ValueError, match="must be an object"):
             _mod.verify_subprocess_allowlist_entries(case_dir)
 
+    @pytest.mark.parametrize(
+        "payload",
+        ["[]", "null", '"x"', "42", "true"],
+        ids=["array", "null", "string", "number", "bool"],
+    )
+    def test_non_object_toplevel_raises(self, payload: str) -> None:
+        """Top-level JSON that is not an object raises ValueError."""
+        case_dir = self._build_case("non-object-toplevel", [])
+        (case_dir / ".subprocess-allowlist.json").write_text(payload, encoding="utf-8")
+        with pytest.raises(ValueError, match="must be an object"):
+            _mod.verify_subprocess_allowlist_entries(case_dir)
+
     def test_committed_allowlist_is_clean(self) -> None:
         """The repo's committed .subprocess-allowlist.json has zero orphans."""
         repo_root = Path(__file__).parent.parent.parent
@@ -968,9 +980,11 @@ class TestAllowlistOrphanDetection:
             patch.object(_mod, "generate_random_artifact", return_value=fresh_s311),
         ):
             rc = _mod.verify_artifacts(case_dir)
+        captured = capsys.readouterr()
         assert rc == 1
-        out = capsys.readouterr().out
-        assert "malformed" in out.lower()
+        assert "[FAIL] .subprocess-allowlist.json is malformed" in captured.out
+        assert "Traceback" not in captured.out
+        assert "Traceback" not in captured.err
 
     @pytest.mark.parametrize(
         "payload",
@@ -1007,6 +1021,46 @@ class TestAllowlistOrphanDetection:
             patch.object(_mod, "generate_random_artifact", return_value=fresh_s311),
         ):
             rc = _mod.verify_artifacts(case_dir)
+        captured = capsys.readouterr()
         assert rc == 1
-        out = capsys.readouterr().out
-        assert "malformed" in out.lower()
+        assert "[FAIL] .subprocess-allowlist.json is malformed" in captured.out
+        assert "Traceback" not in captured.out
+        assert "Traceback" not in captured.err
+
+    @pytest.mark.parametrize(
+        "payload",
+        ["[]", "null", '"x"', "42", "true"],
+        ids=["array", "null", "string", "number", "bool"],
+    )
+    def test_verify_artifacts_fails_on_non_object_toplevel(
+        self,
+        payload: str,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Non-object top-level JSON hits [FAIL] path, no traceback escapes."""
+        case_dir = self._build_case("toplevel-malform", [])
+        (case_dir / ".subprocess-allowlist.json").write_text(payload, encoding="utf-8")
+        fresh_s603 = _mod.generate_subprocess_artifact(
+            Path(__file__).parent.parent.parent
+        )
+        fresh_s311 = _mod.generate_random_artifact(Path(__file__).parent.parent.parent)
+        (case_dir / ".rule-disable-audit-S603.json").write_text(
+            json.dumps(fresh_s603, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        (case_dir / ".rule-disable-audit-S311.json").write_text(
+            json.dumps(fresh_s311, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        with (
+            patch.object(_mod, "generate_subprocess_artifact", return_value=fresh_s603),
+            patch.object(_mod, "generate_random_artifact", return_value=fresh_s311),
+        ):
+            rc = _mod.verify_artifacts(case_dir)
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "[FAIL] .subprocess-allowlist.json is malformed" in captured.out
+        assert "Traceback" not in captured.out
+        assert "Traceback" not in captured.err
+        assert "AttributeError" not in captured.out
+        assert "AttributeError" not in captured.err


### PR DESCRIPTION
## Summary

  - Prune 4 orphan entries from `.subprocess-allowlist.json` (stale since line-number shifts and refactors moved the original call sites)
  - Add `verify_subprocess_allowlist_entries()` to `check_rule_disable_invariants.py` — detects three orphan categories: file-removed, line-shifted, refactored-to-safe
  - Wire into existing `--verify-artifacts` gate (already in preflight/CI/pre-commit) — zero new CLI surface
  - Harden validation boundary: malformed JSON, non-object top-level, non-list entries, and non-dict items all fail closed with `[FAIL]` diagnostics
  - Remove hardcoded floor value from parity test (`== 1782` → `> 0`) to match extension assertion style and eliminate cross-branch coupling

  ## Fail-open audit

  Every error path (malformed JSON, structural shape violations, missing keys, unreadable files) was verified to produce `[FAIL]` + exit 1. No silent pass-through. See commit progression:
   `b09f0fd` closes the initial fail-open path, `9b7391d0` + `04e259f5` harden the shape validation boundary.

  ## Test plan

  - [x] 32 new tests in `TestAllowlistOrphanDetection` covering all three orphan categories, malformed-input rejection (parametrized across JSON shapes), `verify_artifacts` integration,
  and a regression lock on the committed allowlist
  - [x] `python scripts/check_rule_disable_invariants.py --verify-artifacts` prints `[PASS] Subprocess allowlist verified (8 entries, all live)`
  - [x] All 8 remaining allowlist entries verified to point at live unsafe call sites
  - [x] All 4 removed entries confirmed orphaned (code no longer present at recorded line numbers)
  - [x] Ratchet bump: 1782 → 1814 (+32)

  Closes #273