### PR TITLE
fix(#296): restore teams extraction in prod (migration + caller + shape)

### DIFF
--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "python": {
-    "min_collected": 2043,
+    "min_collected": 2044,
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "python": {
-    "min_collected": 2034,
+    "min_collected": 2042,
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "python": {
-    "min_collected": 2042,
+    "min_collected": 2043,
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "python": {
-    "min_collected": 2026,
+    "min_collected": 2034,
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {

--- a/docs/internal/teams-live-qa.md
+++ b/docs/internal/teams-live-qa.md
@@ -1,0 +1,252 @@
+# Teams Extraction — Live QA Runbook
+
+End-to-end manual validation for `_extract_teams()` in `cmd_extract`, the
+`AdoTeamMember` / `AdoTeam` TypedDicts, and the `teams` / `team_members`
+migration path. Run this before merging any branch that touches those
+surfaces.
+
+## What this QA catches that unit tests cannot
+
+- **Migration gaps** — A new `CREATE TABLE` in `models.py` `SCHEMA_SQL`
+  without a paired migration slips past every unit test that uses a
+  fresh DB (#295 pattern, caught by scenario 0).
+- **API shape drift** — Unit tests use mocks. If a mock mirrors a wrong
+  TypedDict, every unit test passes for the wrong reason. Live probes
+  against real ADO responses are the only surface that can falsify the
+  assumed shape (#296 pattern, caught by scenario 1 in a single run).
+- **Caller wiring gaps** — A data plane (`ADOClient.get_teams` etc.)
+  that no caller invokes produces no runtime errors; the dimension
+  stays silently empty for months (#296 symptom, caught by scenario 4).
+
+> **Invariant this QA protects:** end-to-end parity between ADO API
+> responses and the persisted DB shape. Unit tests may pass with
+> incorrect mocks. This runbook is the only layer that cannot.
+
+For the pre-write discipline that applies to every scenario below, see
+[Backfill Comments — Live QA Runbook §Discipline][backfill-discipline].
+
+---
+
+## Prerequisites
+
+- Python development environment per [Development Setup][setup]
+- `ado-insights` installed (`uv tool install -e .` or `pip install -e .`)
+- `sqlite3` CLI for DB inspection
+- `curl` for the API probe in scenario 1
+- Azure DevOps PAT with **Build (Read)** + **Code (Read)** +
+  **Project and Team (Read)** scopes
+- Node 22+ only if scenario 5 is being explicitly re-verified
+
+---
+
+## Target configuration
+
+Run against a multi-project organization. The `oddessentials` values
+below are maintainer examples. Project names are case-sensitive and
+exact; discover them before running:
+
+```bash
+AUTH=$(printf ":%s" "$ADO_PAT" | base64 -w 0)
+curl -s -H "Authorization: Basic $AUTH" \
+  "https://dev.azure.com/<org>/_apis/projects?api-version=7.1-preview.1" \
+  | python -c "import sys,json; print([p['name'] for p in json.load(sys.stdin).get('value',[])])"
+```
+
+Use a tight `--backfill-days 1` window: team extraction is project-scoped
+and does not depend on PR volume, so bundled PR extract stays fast.
+
+---
+
+## Setup (every run)
+
+- `$qaRoot` = working directory (staged DB + aggregates output)
+- `ADO_PAT` exported to environment; not written to disk
+- Scenario 0 runs against a **production-vintage** DB pulled from
+  pipeline 15. Scenarios 1–4 run against the same staged DB so the
+  migration gate from 0 is load-bearing
+
+---
+
+## STOP-AND-REPORT
+
+**If, at any point during scenario 1, the API team count for any
+project does not equal the DB team count for that project, halt
+immediately.** Do not proceed to scenarios 2 / 4 / 5. Capture the
+divergence (project, API count, DB count), attach the most recent
+`extract` log, and stop. Parity divergence is the exact signal the
+mocks-passed-for-the-wrong-reason bug class produces.
+
+---
+
+## Scenario 0 — Production-vintage migration gate
+
+Stage the real pipeline 15 artifact and run `extract` against it. On a
+pre-Phase-3.3 vintage DB this exercises the `migrate_v6_to_v7` path that
+creates `teams` / `team_members`. On a post-Phase-3.3 vintage DB (the
+current pipeline 15 shape) the migration is a no-op; either way the
+post-migration `_REQUIRED_TABLES` sweep and `_extract_teams()` wiring
+both run.
+
+```bash
+python -m ado_git_repo_insights.cli stage-artifacts \
+  --org <org> --project <project> \
+  --pipeline-id 15 --artifact ado-insights-db \
+  --pat "$ADO_PAT" --out "$qaRoot/staged"
+
+python -m ado_git_repo_insights.cli \
+  --artifacts-dir "$qaRoot/artifacts/s0" \
+  extract \
+  --organization <org> --projects <one project> \
+  --pat "$ADO_PAT" \
+  --database "$qaRoot/staged/ado-insights-db/ado-insights.sqlite" \
+  --backfill-days 1
+```
+
+**Assertions** (pre- vs post-):
+
+- `schema_version` = 7 after the run (migration chain terminates at latest)
+- `teams` and `team_members` tables present
+- No uncaught Python exception in the log (the `KeyError: 'identity'`
+  incident below is a regression indicator)
+- Log contains `teams: extracting teams across N PR-successful project(s)`
+  and `teams: extracted X teams / Y members across N PR-successful
+  projects (K skipped)`
+
+---
+
+## Scenario 1 — Fresh multi-project extract + API parity
+
+Run `extract` with all discovered projects, then probe each project's
+team count via the ADO API and compare to the DB. **This is the primary
+shape-drift detector.**
+
+```bash
+python -m ado_git_repo_insights.cli \
+  --artifacts-dir "$qaRoot/artifacts/s1" \
+  extract \
+  --organization <org> --projects <comma-separated project list> \
+  --pat "$ADO_PAT" \
+  --database "$qaRoot/staged/ado-insights-db/ado-insights.sqlite" \
+  --backfill-days 1
+
+# API ground truth per project
+for p in <project list>; do
+  curl -s -H "Authorization: Basic $AUTH" \
+    "https://dev.azure.com/<org>/_apis/projects/$p/teams?api-version=7.1-preview.1" \
+    | python -c "import sys,json; d=json.load(sys.stdin); print(f'API $p: {len(d.get(\"value\",[]))} teams')"
+done
+
+# DB count per project
+sqlite3 "$qaRoot/staged/ado-insights-db/ado-insights.sqlite" \
+  "SELECT project_name, COUNT(*) FROM teams GROUP BY project_name"
+```
+
+**Assertions**:
+
+- API count and DB count match for **every** project (see
+  STOP-AND-REPORT above)
+- `team_members` total > 0 and `user_id` values in `team_members` join
+  cleanly to `users`
+- No WARNING matching `skipping malformed member in` (indicates
+  `AdoTeamMember` shape drift — see real-incident log below)
+
+---
+
+## Scenario 2 — Idempotent re-run
+
+Re-run the exact command from scenario 1 without modifying the DB.
+
+**Assertions**:
+
+- `teams` and `team_members` row counts unchanged from scenario 1
+  (upsert + clear-then-refill semantics)
+- `SELECT COUNT(DISTINCT team_id) FROM teams` unchanged
+- No migration log entries (already at v7)
+
+---
+
+## Scenario 3 — Per-project 403 (permission skip)
+
+Unit-test covered by
+`tests/unit/test_team_extraction.py::TestExtractTeamsPipeline::test_project_team_fetch_403_logs_and_continues`
+via `get_teams` raising `ExtractionError`. Live-simulating a 403
+requires a scope-restricted PAT, which adds setup churn without adding
+confidence. Do not duplicate here unless investigating a specific
+permission-related regression.
+
+---
+
+## Scenario 4 — Aggregator features.teams flip
+
+```bash
+python -m ado_git_repo_insights.cli \
+  --artifacts-dir "$qaRoot/artifacts/s4" \
+  generate-aggregates \
+  --database "$qaRoot/staged/ado-insights-db/ado-insights.sqlite" \
+  --output "$qaRoot/aggregates-out"
+
+python -c "import json; m=json.load(open(r'$qaRoot/aggregates-out/dataset-manifest.json')); \
+  print('features.teams =', m['features']['teams']); \
+  print('coverage.teams_count =', m['coverage']['teams_count'])"
+```
+
+**Assertions**:
+
+- `features.teams == True`
+- `coverage.teams_count` equals `SELECT COUNT(*) FROM teams` from
+  scenario 1's DB
+
+---
+
+## Scenario 5 — Extension wrapper parity (structural)
+
+Option (a) in the #296 plan: team extraction is always-on via the
+existing `extract` code path. There is no new task input, no new env
+var, no task.json change. The extension wrapper at
+`extension/tasks/extract-prs/index.js` invokes the Python CLI unchanged.
+
+**Assertion** — a single grep, not a run:
+
+```bash
+grep -E 'team|includeTeam|extract_teams' extension/tasks/extract-prs/*.{js,json}
+```
+
+Must return no matches. Any hit means the wrapper has started making
+team-specific decisions and the shape-drift blast radius has widened
+past the CLI.
+
+---
+
+## Done criteria
+
+- [ ] Scenario 0: `schema_version` at latest, teams / team_members
+      tables present
+- [ ] Scenario 1: API / DB team count parity for every project
+- [ ] Scenario 2: row counts stable across re-run
+- [ ] Scenario 4: `features.teams=True`, `coverage.teams_count`
+      matches DB
+- [ ] Scenario 5: grep returns no team-specific decision in the
+      extension wrapper
+
+If any item fails, STOP-AND-REPORT above applies.
+
+---
+
+## Real incident log
+
+- **2026-04-19** — First live run of scenario 0 for PR #296 surfaced
+  `KeyError: 'identity'` in `_extract_teams` immediately after the
+  migration completed cleanly. Root cause: Phase 3.3 `AdoTeamMember`
+  TypedDict assumed a nested `{identity: {id, displayName}, isTeamAdmin}`
+  shape. Real ADO `GET _apis/projects/{p}/teams/{t}/members` returns a
+  flat IdentityRef (`id`, `displayName`, `uniqueName`, ...). Every unit
+  test in `test_team_extraction.py` passed because mocks mirrored the
+  wrong TypedDict. Fix: types.py + cli.py + all 5 affected mocks
+  updated in a single commit; a defensive per-field skip with specific
+  WARNING prose was added so any future shape drift logs instead of
+  crashing. Time-to-detection: ~3 seconds after the first
+  `get_team_members` call. **This is the canonical example of why this
+  QA exists.**
+
+[backfill-discipline]: backfill-live-qa.md#discipline-pre-write-expectations-before-every-scenario
+[setup]: ../development/setup.md

--- a/src/ado_git_repo_insights/cli.py
+++ b/src/ado_git_repo_insights/cli.py
@@ -876,6 +876,18 @@ def _extract_teams(
                 stats["projects_team_skipped"] += 1
                 continue
 
+            # #296 review P1: PRExtractor writes projects rows only as a
+            # side effect of ``upsert_pr_with_related`` inside its PR
+            # for-loop (pr_extractor.py:152-159).  A succeeded project
+            # with zero PRs in the extract window never hits that line,
+            # so (organization_name, project_name) stays absent on a
+            # fresh DB.  The teams FK to projects would then raise
+            # IntegrityError on the first ``upsert_team``.  Upsert the
+            # parent rows exactly once per project loop iteration
+            # (INSERT OR IGNORE is zero-cost when already present).
+            repo.upsert_organization(config.organization)
+            repo.upsert_project(config.organization, project)
+
             project_members = 0
             for team in teams:
                 team_id = team["id"]
@@ -886,8 +898,14 @@ def _extract_teams(
                     organization_name=config.organization,
                     description=team.get("description"),
                 )
-                repo.clear_team_members(team_id)
 
+                # #296 review P2: clear_team_members must NOT precede
+                # get_team_members.  Clearing first and then skipping on
+                # ExtractionError leaves the team with zero members —
+                # avoidable data loss on transient 403/network errors
+                # (exactly the class this branch is meant to tolerate).
+                # Clearing only after a successful fetch keeps the
+                # prior membership intact until fresh data is in hand.
                 try:
                     members = client.get_team_members(project, team_id)
                 except ExtractionError as e:
@@ -899,6 +917,7 @@ def _extract_teams(
                     )
                     continue
 
+                repo.clear_team_members(team_id)
                 for member in members:
                     user_id = member.get("id")
                     if not user_id:
@@ -921,11 +940,14 @@ def _extract_teams(
                         continue
                     # ``uniqueName`` is the AD account name from the ADO
                     # IdentityRef shape; commonly an email address.
+                    # Coalesce an empty string to None so the column
+                    # stores NULL rather than "" for users without a
+                    # resolvable account name.
                     repo.upsert_team_member(
                         team_id=team_id,
                         user_id=user_id,
                         display_name=display_name,
-                        email=member.get("uniqueName"),
+                        email=member.get("uniqueName") or None,
                     )
                     project_members += 1
 

--- a/src/ado_git_repo_insights/cli.py
+++ b/src/ado_git_repo_insights/cli.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
     from .config import Config
     from .extractor.ado_client import ADOClient
+    from .extractor.pr_extractor import ExtractionSummary
     from .persistence.database import DatabaseManager
     from .persistence.repository import PRRepository
     from .types import AdoThread
@@ -805,6 +806,130 @@ def _extract_comments(
     return stats
 
 
+def _extract_teams(
+    client: ADOClient,
+    db: DatabaseManager,
+    config: Config,
+    summary: ExtractionSummary,
+) -> dict[str, int]:
+    """Extract teams and team_members for each PR-successful project (#296).
+
+    Per option (b) in the #296 plan: teams are fetched for every project
+    whose PR extraction succeeded, regardless of other projects'
+    outcomes.  ``extract_all()``'s fail-fast semantics mean
+    ``summary.projects`` only contains projects up to the first PR
+    failure, so this helper simply operates on what is present — no
+    compensation or inference for projects never tried.
+
+    Per-project team-fetch failures (typically HTTP 403 for PATs
+    without team-read scope) and per-team member-fetch failures log a
+    WARNING and skip — never fatal to the run.  These caught
+    ``ExtractionError`` paths stay inside the wrapping transaction so
+    cross-project writes remain atomic.
+
+    All writes run inside a single ``db.transaction()`` (DEFERRED
+    ``BEGIN TRANSACTION``) so any unhandled exception in the helper
+    rolls back every persisted team / member row — no half-written
+    state survives helper failure.  ``clear_team_members`` issues
+    per-team DELETEs inside the same transaction; SQLite's connection-
+    scoped RESERVED lock is held across the full helper, which is
+    safe because the extract pipeline is the only writer on this
+    connection.
+
+    Args:
+        client: ADO API client (``get_teams`` / ``get_team_members``).
+        db: Database manager (provides the transaction context).
+        config: Application config (for ``organization`` in upserts).
+        summary: PR extraction summary (filtered to ``.success == True``).
+
+    Returns:
+        Stats dict with ``teams_extracted``, ``team_members_extracted``,
+        ``projects_team_skipped``.  Log-only — not fed to ``RunCounts``
+        per the #296 scope decision.
+    """
+    from .extractor.ado_client import ExtractionError
+    from .persistence.repository import PRRepository
+
+    repo = PRRepository(db)
+    stats: dict[str, int] = {
+        "teams_extracted": 0,
+        "team_members_extracted": 0,
+        "projects_team_skipped": 0,
+    }
+
+    succeeded_projects = [r.project for r in summary.projects if r.success]
+    if not succeeded_projects:
+        logger.info("teams: no PR-successful projects; skipping team extraction")
+        return stats
+
+    logger.info(
+        "teams: extracting teams across %d PR-successful project(s)",
+        len(succeeded_projects),
+    )
+
+    with db.transaction():
+        for project in succeeded_projects:
+            try:
+                teams = client.get_teams(project)
+            except ExtractionError as e:
+                logger.warning("teams: skipping %s: %s", project, e)
+                stats["projects_team_skipped"] += 1
+                continue
+
+            project_members = 0
+            for team in teams:
+                team_id = team["id"]
+                repo.upsert_team(
+                    team_id=team_id,
+                    team_name=team["name"],
+                    project_name=project,
+                    organization_name=config.organization,
+                    description=team.get("description"),
+                )
+                repo.clear_team_members(team_id)
+
+                try:
+                    members = client.get_team_members(project, team_id)
+                except ExtractionError as e:
+                    logger.warning(
+                        "teams: skipping members for %s/%s: %s",
+                        project,
+                        team_id,
+                        e,
+                    )
+                    continue
+
+                for member in members:
+                    identity = member["identity"]
+                    repo.upsert_team_member(
+                        team_id=team_id,
+                        user_id=identity["id"],
+                        display_name=identity["displayName"],
+                        email=None,
+                        is_team_admin=bool(member.get("isTeamAdmin", False)),
+                    )
+                    project_members += 1
+
+            stats["teams_extracted"] += len(teams)
+            stats["team_members_extracted"] += project_members
+            logger.info(
+                "teams: %s fetched %d teams, %d members",
+                project,
+                len(teams),
+                project_members,
+            )
+
+    logger.info(
+        "teams: extracted %d teams / %d members across "
+        "%d PR-successful projects (%d skipped)",
+        stats["teams_extracted"],
+        stats["team_members_extracted"],
+        len(succeeded_projects),
+        stats["projects_team_skipped"],
+    )
+    return stats
+
+
 @dataclass(frozen=True)
 class FetchedThreadsPayload:
     """Network-fetched thread payload for a single PR.
@@ -1260,6 +1385,11 @@ def cmd_extract(args: Namespace) -> int:
                         if project_result.error is not None
                         else f"Extraction failed for project: {project_result.project}"
                     )
+
+            # #296: team extraction for PR-successful projects — runs
+            # before fail-fast so chronically failing projects do not
+            # permanently block teams for succeeded projects (option b).
+            _extract_teams(client, db, config, summary)
 
             # Fail-fast: any project failure = exit 1
             if not summary.success:

--- a/src/ado_git_repo_insights/cli.py
+++ b/src/ado_git_repo_insights/cli.py
@@ -900,13 +900,32 @@ def _extract_teams(
                     continue
 
                 for member in members:
-                    identity = member["identity"]
+                    user_id = member.get("id")
+                    if not user_id:
+                        logger.warning(
+                            "teams: skipping malformed member in %s/%s: "
+                            "missing 'id' field",
+                            project,
+                            team_id,
+                        )
+                        continue
+                    display_name = member.get("displayName")
+                    if not display_name:
+                        logger.warning(
+                            "teams: skipping malformed member in %s/%s: "
+                            "missing 'displayName' field (id=%s)",
+                            project,
+                            team_id,
+                            user_id,
+                        )
+                        continue
+                    # ``uniqueName`` is the AD account name from the ADO
+                    # IdentityRef shape; commonly an email address.
                     repo.upsert_team_member(
                         team_id=team_id,
-                        user_id=identity["id"],
-                        display_name=identity["displayName"],
-                        email=None,
-                        is_team_admin=bool(member.get("isTeamAdmin", False)),
+                        user_id=user_id,
+                        display_name=display_name,
+                        email=member.get("uniqueName"),
                     )
                     project_members += 1
 

--- a/src/ado_git_repo_insights/persistence/database.py
+++ b/src/ado_git_repo_insights/persistence/database.py
@@ -58,6 +58,8 @@ _FUNDAMENTAL_TABLES: frozenset[str] = frozenset(
 _REQUIRED_TABLES: frozenset[str] = _FUNDAMENTAL_TABLES | frozenset(
     {
         "comments_extraction_metadata",  # introduced in v5→v6
+        "teams",  # introduced in v6→v7
+        "team_members",  # introduced in v6→v7
     }
 )
 

--- a/src/ado_git_repo_insights/persistence/migrations.py
+++ b/src/ado_git_repo_insights/persistence/migrations.py
@@ -605,6 +605,94 @@ def migrate_v5_to_v6(conn: Connection) -> None:
     logger.info("Applied migration v5 → v6 (comments_extraction_metadata)")
 
 
+# v7 teams / team_members DDL — byte-equivalent to the declarations in
+# ``src/ado_git_repo_insights/persistence/models.py`` SCHEMA_SQL.  The
+# duplication mirrors the v5→v6 precedent (``_V6_COMMENTS_EXTRACTION_
+# METADATA_DDL``); drift is locked by a PRAGMA parity test in
+# ``tests/unit/test_schema_migration.py::TestMigrationV6ToV7TeamsTables``.
+_V7_TEAMS_DDL = """
+    CREATE TABLE IF NOT EXISTS teams (
+        team_id TEXT PRIMARY KEY,
+        team_name TEXT NOT NULL,
+        project_name TEXT NOT NULL,
+        organization_name TEXT NOT NULL,
+        description TEXT,
+        last_updated TEXT NOT NULL,
+        FOREIGN KEY (organization_name, project_name)
+            REFERENCES projects(organization_name, project_name)
+    )
+"""
+
+_V7_TEAM_MEMBERS_DDL = """
+    CREATE TABLE IF NOT EXISTS team_members (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        team_id TEXT NOT NULL,
+        user_id TEXT NOT NULL,
+        is_team_admin INTEGER DEFAULT 0,
+        FOREIGN KEY (team_id) REFERENCES teams(team_id),
+        FOREIGN KEY (user_id) REFERENCES users(user_id),
+        UNIQUE(team_id, user_id)
+    )
+"""
+
+
+def migrate_v6_to_v7(conn: Connection) -> None:
+    """Create ``teams`` and ``team_members`` for legacy pre-existing DBs.
+
+    Schema v6 → v7:
+    Second instance of the SCHEMA_SQL-without-migration landmine (first
+    was ``migrate_v5_to_v6``).  The ``teams`` and ``team_members`` tables
+    were added to ``SCHEMA_SQL`` in Phase 3.3 (2026-01-14) but no earlier
+    migration ever created them.  DBs whose file predates that change
+    lack both tables entirely.  Once ``_extract_teams()`` in ``cli.py``
+    starts writing team rows, every such legacy DB would crash on the
+    first ``upsert_team`` with ``sqlite3.OperationalError: no such
+    table: teams`` — identical shape to the v5→v6 crash that motivated
+    that migration.
+
+    No row backfill — teams are refetched on every extract run
+    (current-state semantics per ``repository.py::clear_team_members``);
+    an empty post-migration state is correct.  The first successful
+    extract populates both tables for every project the PAT can read.
+
+    Runs inside ``BEGIN IMMEDIATE`` so a mid-migration failure rolls
+    back table creation along with the version bump — either all seven
+    statements commit or none do.  Idempotent via ``IF NOT EXISTS`` on
+    every CREATE plus ``INSERT OR IGNORE`` on ``schema_version``.
+    """
+    # ``txn_started`` guard mirrors ``migrate_v4_to_v5`` /
+    # ``migrate_v5_to_v6``: if BEGIN IMMEDIATE itself raises (writer
+    # lock contention), no transaction is open, so an unconditional
+    # ROLLBACK would raise ``OperationalError: cannot rollback - no
+    # transaction is active`` and mask the original lock error.
+    txn_started = False
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        txn_started = True
+        conn.execute(_V7_TEAMS_DDL)
+        conn.execute(_V7_TEAM_MEMBERS_DDL)
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_teams_project "
+            "ON teams(organization_name, project_name)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_team_members_team ON team_members(team_id)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_team_members_user ON team_members(user_id)"
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_version (version, applied_at) "
+            "VALUES (7, datetime('now'))"
+        )
+        conn.execute("COMMIT")
+    except Exception:
+        if txn_started:
+            conn.execute("ROLLBACK")
+        raise
+    logger.info("Applied migration v6 → v7 (teams, team_members)")
+
+
 # Version-keyed migration registry.  Keys are the *target* version;
 # the function upgrades from (key - 1) -> key.
 MIGRATIONS: dict[int, Callable[[Connection], None]] = {
@@ -613,4 +701,5 @@ MIGRATIONS: dict[int, Callable[[Connection], None]] = {
     4: migrate_v3_to_v4,
     5: migrate_v4_to_v5,
     6: migrate_v5_to_v6,
+    7: migrate_v6_to_v7,
 }

--- a/src/ado_git_repo_insights/persistence/models.py
+++ b/src/ado_git_repo_insights/persistence/models.py
@@ -181,11 +181,11 @@ CREATE TABLE IF NOT EXISTS schema_version (
     applied_at TEXT NOT NULL
 );
 
--- Insert initial schema version (v6: ensures comments_extraction_metadata is
--- present on every DB, including those whose creation predated the table's
--- addition to SCHEMA_SQL — see migrate_v5_to_v6).
+-- Insert initial schema version (v7: ensures teams and team_members are
+-- present on every DB, including those whose creation predated the
+-- tables' addition to SCHEMA_SQL in Phase 3.3 — see migrate_v6_to_v7).
 INSERT OR IGNORE INTO schema_version (version, applied_at)
-VALUES (6, datetime('now'));
+VALUES (7, datetime('now'));
 """
 
 # CSV column order contract (NON-NEGOTIABLE per Invariants 1-4)

--- a/src/ado_git_repo_insights/types.py
+++ b/src/ado_git_repo_insights/types.py
@@ -114,18 +114,22 @@ class AdoTeam(TypedDict):
     description: NotRequired[str | None]
 
 
-class AdoIdentity(TypedDict):
-    """Identity sub-object within team member responses."""
+class AdoTeamMember(TypedDict):
+    """Azure DevOps team-members API response item.
+
+    The endpoint ``GET _apis/projects/{project}/teams/{team}/members``
+    returns a flat IdentityRef shape — NOT a nested ``identity`` wrapper
+    as the Phase 3.3 draft incorrectly assumed.  Probed against
+    ``oddessentials/oddessentials`` 2026-04-19 (live QA for #296):
+    ``{id, displayName, uniqueName, url, descriptor, imageUrl, _links}``.
+    There is no ``isTeamAdmin`` field at this endpoint; admin status is
+    not returned by the base members API.
+    """
 
     id: str
     displayName: str
-
-
-class AdoTeamMember(TypedDict):
-    """Azure DevOps Team Member response object."""
-
-    identity: AdoIdentity
-    isTeamAdmin: bool
+    uniqueName: NotRequired[str]  # AD account name, often email-shaped
+    url: NotRequired[str]
 
 
 class AdoComment(TypedDict):

--- a/tests/unit/test_schema_migration.py
+++ b/tests/unit/test_schema_migration.py
@@ -179,8 +179,8 @@ class TestMigrationV1ToV2:
         db = DatabaseManager(db_path)
         db.connect()
         try:
-            # All pending migrations applied: v1→v2→v3→v4→v5→v6
-            assert db.get_schema_version() == 6
+            # All pending migrations applied: v1→v2→v3→v4→v5→v6→v7
+            assert db.get_schema_version() == 7
         finally:
             db.close()
 
@@ -217,18 +217,18 @@ class TestMigrationIdempotency:
         db_path = tmp_path / "test.db"
         _create_v1_database(db_path)
 
-        # First connect: migrates v1 → v6
+        # First connect: migrates v1 → v7
         db = DatabaseManager(db_path)
         db.connect()
         db.close()
 
-        assert _get_schema_version(db_path) == 6
+        assert _get_schema_version(db_path) == 7
 
         # Second connect: should be a no-op
         db2 = DatabaseManager(db_path)
         db2.connect()
         try:
-            assert db2.get_schema_version() == 6
+            assert db2.get_schema_version() == 7
             assert "reviewed_at" in _get_column_names(db_path, "reviewers")
         finally:
             db2.close()
@@ -271,7 +271,7 @@ class TestFreshInstall:
         db = DatabaseManager(db_path)
         db.connect()
         try:
-            assert db.get_schema_version() == 6
+            assert db.get_schema_version() == 7
         finally:
             db.close()
 
@@ -380,6 +380,24 @@ class TestMigrationV2ToV3CoverageBackfill:
             threads_fetched INTEGER NOT NULL DEFAULT 0,
             comments_fetched INTEGER NOT NULL DEFAULT 0,
             capped INTEGER NOT NULL DEFAULT 0
+        );
+        -- Pre-seeded to satisfy _REQUIRED_TABLES post-migration sweep under
+        -- the _freeze_migrations_at_v4 fixture above; mirrors the #295
+        -- precedent that pre-seeded comments_extraction_metadata here.
+        CREATE TABLE teams (
+            team_id TEXT PRIMARY KEY,
+            team_name TEXT NOT NULL,
+            project_name TEXT NOT NULL,
+            organization_name TEXT NOT NULL,
+            description TEXT,
+            last_updated TEXT NOT NULL
+        );
+        CREATE TABLE team_members (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            team_id TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            is_team_admin INTEGER DEFAULT 0,
+            UNIQUE(team_id, user_id)
         );
         CREATE TABLE schema_version (
             version INTEGER PRIMARY KEY,
@@ -881,6 +899,24 @@ class TestMigrationV3ToV4DedupAndRecovery:
             threads_fetched INTEGER NOT NULL DEFAULT 0,
             comments_fetched INTEGER NOT NULL DEFAULT 0,
             capped INTEGER NOT NULL DEFAULT 0
+        );
+        -- Pre-seeded to satisfy _REQUIRED_TABLES post-migration sweep under
+        -- the _freeze_migrations_at_v4 fixture above; mirrors the #295
+        -- precedent that pre-seeded comments_extraction_metadata here.
+        CREATE TABLE teams (
+            team_id TEXT PRIMARY KEY,
+            team_name TEXT NOT NULL,
+            project_name TEXT NOT NULL,
+            organization_name TEXT NOT NULL,
+            description TEXT,
+            last_updated TEXT NOT NULL
+        );
+        CREATE TABLE team_members (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            team_id TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            is_team_admin INTEGER DEFAULT 0,
+            UNIQUE(team_id, user_id)
         );
         CREATE TABLE schema_version (
             version INTEGER PRIMARY KEY,
@@ -1972,14 +2008,16 @@ class TestMigrationV5ToV6CommentsExtractionMetadata:
         )
 
     def test_connect_creates_table_and_advances_to_v6(self, tmp_path: Path) -> None:
-        """Legacy v5 DB gains the missing table and advances to schema v6."""
+        """Legacy v5 DB gains v6's comments_extraction_metadata via the
+        migration chain; schema_version lands at the current latest (v7)
+        because ``connect()`` applies every pending migration."""
         db_path = tmp_path / "v5_to_v6.db"
         self._create_v5_db_without_metadata(db_path)
 
         db = DatabaseManager(db_path)
         db.connect()
         try:
-            assert db.get_schema_version() == 6
+            assert db.get_schema_version() == 7
 
             cols = _get_column_names(db_path, "comments_extraction_metadata")
             assert cols == {
@@ -2052,7 +2090,7 @@ class TestMigrationV5ToV6CommentsExtractionMetadata:
         db2 = DatabaseManager(db_path)
         db2.connect()
         try:
-            assert db2.get_schema_version() == 6
+            assert db2.get_schema_version() == 7
             row = db2.execute(
                 "SELECT COUNT(*) AS cnt FROM comments_extraction_metadata"
             ).fetchone()
@@ -2230,6 +2268,487 @@ class TestMigrationV5ToV6CommentsExtractionMetadata:
             holder.close()
 
 
+class TestMigrationV6ToV7TeamsTables:
+    """v6 → v7: create ``teams`` and ``team_members`` for legacy pre-existing DBs.
+
+    Root cause:
+        Second instance of the SCHEMA_SQL-without-migration landmine
+        (first was ``migrate_v5_to_v6`` / comments_extraction_metadata).
+        Phase 3.3 (2026-01-14) added ``teams`` and ``team_members`` to
+        ``SCHEMA_SQL`` but no earlier migration ever created them.  Any
+        DB whose file predates that change lacks both tables entirely.
+        Once ``_extract_teams()`` in ``cli.py`` starts writing team
+        rows (the control-plane wiring landing in the same PR), every
+        such legacy DB would crash on the first ``upsert_team`` with
+        ``sqlite3.OperationalError: no such table: teams``.
+
+    Fix locked by tests in this module:
+        v6 → v7 migration creates both tables + their three indexes
+        (idempotent via ``IF NOT EXISTS``) and advances ``schema_version``
+        to 7.  No row backfill — teams are refetched every run.
+    """
+
+    # v6 schema WITHOUT teams/team_members — reproduces the affected
+    # vintage (DBs created before 2026-01-14 that nonetheless passed
+    # through v5→v6 to gain comments_extraction_metadata).  The
+    # ``projects`` table uses the composite PK matching current
+    # SCHEMA_SQL so the ``teams → projects`` FK check engaged by
+    # ``PRAGMA foreign_keys = ON`` in DatabaseManager.connect() can
+    # succeed when a fixture pre-seeds a project row.
+    _V6_SCHEMA_WITHOUT_TEAMS_SQL = """
+        CREATE TABLE extraction_metadata (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            organization_name TEXT NOT NULL,
+            project_name TEXT NOT NULL,
+            last_extraction_date TEXT NOT NULL,
+            last_extraction_timestamp TEXT NOT NULL
+        );
+        CREATE TABLE comments_extraction_metadata (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            last_run_timestamp TEXT NOT NULL,
+            prs_processed INTEGER NOT NULL DEFAULT 0,
+            threads_fetched INTEGER NOT NULL DEFAULT 0,
+            comments_fetched INTEGER NOT NULL DEFAULT 0,
+            capped INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE organizations (organization_name TEXT PRIMARY KEY);
+        CREATE TABLE projects (
+            organization_name TEXT NOT NULL,
+            project_name TEXT NOT NULL,
+            PRIMARY KEY (organization_name, project_name)
+        );
+        CREATE TABLE repositories (
+            repository_id TEXT PRIMARY KEY,
+            repository_name TEXT NOT NULL,
+            project_name TEXT NOT NULL,
+            organization_name TEXT NOT NULL
+        );
+        CREATE TABLE users (
+            user_id TEXT PRIMARY KEY,
+            display_name TEXT NOT NULL,
+            email TEXT
+        );
+        CREATE TABLE pull_requests (
+            pull_request_uid TEXT PRIMARY KEY,
+            pull_request_id INTEGER NOT NULL,
+            organization_name TEXT NOT NULL,
+            project_name TEXT NOT NULL,
+            repository_id TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            status TEXT NOT NULL,
+            description TEXT,
+            creation_date TEXT NOT NULL,
+            closed_date TEXT,
+            cycle_time_minutes REAL,
+            review_time_minutes REAL,
+            comments_extracted_at TEXT,
+            raw_json TEXT
+        );
+        CREATE TABLE reviewers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pull_request_uid TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            vote INTEGER NOT NULL,
+            repository_id TEXT NOT NULL,
+            reviewed_at TEXT,
+            UNIQUE(pull_request_uid, user_id)
+        );
+        CREATE TABLE pr_threads (
+            thread_id TEXT NOT NULL,
+            pull_request_uid TEXT NOT NULL,
+            status TEXT,
+            thread_context TEXT,
+            last_updated TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            is_deleted INTEGER DEFAULT 0,
+            PRIMARY KEY (pull_request_uid, thread_id)
+        );
+        CREATE TABLE pr_comments (
+            comment_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL,
+            pull_request_uid TEXT NOT NULL,
+            author_id TEXT NOT NULL,
+            content TEXT,
+            comment_type TEXT,
+            created_at TEXT NOT NULL,
+            last_updated TEXT,
+            is_deleted INTEGER DEFAULT 0,
+            PRIMARY KEY (pull_request_uid, thread_id, comment_id)
+        );
+        CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT NOT NULL
+        );
+        INSERT INTO schema_version (version, applied_at) VALUES (6, datetime('now'));
+    """
+
+    def _create_v6_db_without_teams(self, path: Path) -> None:
+        """Seed a v6-vintage DB with no teams / team_members tables."""
+        conn = sqlite3.connect(str(path))
+        conn.execute("PRAGMA foreign_keys = OFF")
+        conn.executescript(self._V6_SCHEMA_WITHOUT_TEAMS_SQL)
+        conn.commit()
+        conn.close()
+
+    @staticmethod
+    def _pragma_table_info(
+        path: Path, table: str
+    ) -> list[tuple[str, str, int, object, int]]:
+        """Return (name, type, notnull, dflt_value, pk) per column — cid dropped."""
+        conn = sqlite3.connect(str(path))
+        try:
+            rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+        finally:
+            conn.close()
+        return [(r[1], r[2], r[3], r[4], r[5]) for r in rows]
+
+    def test_pre_migration_state_reproduces_bug(self, tmp_path: Path) -> None:
+        """Sanity check: the v6 fixture lacks teams + team_members."""
+        db_path = tmp_path / "v6_precondition.db"
+        self._create_v6_db_without_teams(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            present = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND name IN ('teams', 'team_members')"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        assert present == set(), (
+            "Test fixture must start without teams/team_members — "
+            "otherwise the v6→v7 migration would be a no-op here"
+        )
+
+    def test_connect_creates_tables_and_advances_to_v7(self, tmp_path: Path) -> None:
+        """Legacy v6 DB gains teams + team_members + 3 indexes post-connect."""
+        db_path = tmp_path / "v6_to_v7.db"
+        self._create_v6_db_without_teams(db_path)
+
+        db = DatabaseManager(db_path)
+        db.connect()
+        try:
+            assert db.get_schema_version() == 7
+
+            tables = {
+                r[0]
+                for r in db.connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert "teams" in tables
+            assert "team_members" in tables
+
+            indexes = {
+                r[0]
+                for r in db.connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index' "
+                    "AND name NOT LIKE 'sqlite_autoindex_%'"
+                ).fetchall()
+            }
+            assert "idx_teams_project" in indexes
+            assert "idx_team_members_team" in indexes
+            assert "idx_team_members_user" in indexes
+        finally:
+            db.close()
+
+    def test_migration_is_idempotent(self, tmp_path: Path) -> None:
+        """Second connect after migration is a no-op; no duplicate v7 row."""
+        db_path = tmp_path / "v6_idempotent.db"
+        self._create_v6_db_without_teams(db_path)
+
+        db = DatabaseManager(db_path)
+        db.connect()
+        db.close()
+
+        db2 = DatabaseManager(db_path)
+        db2.connect()
+        try:
+            assert db2.get_schema_version() == 7
+            row = db2.execute(
+                "SELECT COUNT(*) AS cnt FROM schema_version WHERE version = 7"
+            ).fetchone()
+            assert int(row["cnt"]) == 1, "idempotent re-run must not duplicate rows"
+        finally:
+            db2.close()
+
+    def test_post_migration_upsert_team_persists_end_to_end(
+        self, tmp_path: Path
+    ) -> None:
+        """End-to-end lock on the production fix: first ``upsert_team`` call
+        ``_extract_teams()`` makes on a legacy DB now persists the row.
+
+        Mirrors the v5→v6 test_update_comments_extraction_metadata_no_longer_
+        crashes end-to-end shape.
+        """
+        from ado_git_repo_insights.persistence.repository import PRRepository
+
+        db_path = tmp_path / "v6_upsert_team.db"
+        self._create_v6_db_without_teams(db_path)
+
+        # Seed organization + project so the (org, project) FK on teams
+        # is satisfied once DatabaseManager.connect() re-engages
+        # ``PRAGMA foreign_keys = ON``.
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("INSERT INTO organizations (organization_name) VALUES ('org')")
+        conn.execute(
+            "INSERT INTO projects (organization_name, project_name) "
+            "VALUES ('org', 'proj')"
+        )
+        conn.commit()
+        conn.close()
+
+        db = DatabaseManager(db_path)
+        db.connect()
+        try:
+            repo = PRRepository(db)
+            repo.upsert_team(
+                team_id="t1",
+                team_name="Team One",
+                project_name="proj",
+                organization_name="org",
+                description="first team",
+            )
+            repo.upsert_team_member(
+                team_id="t1",
+                user_id="u1",
+                display_name="Alice",
+                email="alice@example.com",
+                is_team_admin=True,
+            )
+            db.connection.commit()
+
+            teams = repo.get_teams_for_project(
+                organization_name="org", project_name="proj"
+            )
+            assert len(teams) == 1
+            assert teams[0]["team_id"] == "t1"
+            assert teams[0]["team_name"] == "Team One"
+
+            members = repo.get_team_members("t1")
+            assert len(members) == 1
+            assert members[0]["user_id"] == "u1"
+            assert bool(members[0]["is_team_admin"]) is True
+        finally:
+            db.close()
+
+    def test_fresh_and_migrated_teams_tables_are_identical(
+        self, tmp_path: Path
+    ) -> None:
+        """Byte-level DDL parity between fresh SCHEMA_SQL and migrated v6.
+
+        Column shape (name / type / notnull / default / pk position) +
+        index list must match exactly.  Locks the duplicated
+        ``_V7_TEAMS_DDL`` / ``_V7_TEAM_MEMBERS_DDL`` constants in
+        migrations.py against drift from the declarations in
+        models.py SCHEMA_SQL.
+        """
+        fresh_path = tmp_path / "fresh.db"
+        fresh_db = DatabaseManager(fresh_path)
+        fresh_db.connect()
+        fresh_db.close()
+
+        migrated_path = tmp_path / "migrated.db"
+        self._create_v6_db_without_teams(migrated_path)
+        migrated_db = DatabaseManager(migrated_path)
+        migrated_db.connect()
+        migrated_db.close()
+
+        for table in ("teams", "team_members"):
+            fresh_cols = self._pragma_table_info(fresh_path, table)
+            migrated_cols = self._pragma_table_info(migrated_path, table)
+            assert fresh_cols == migrated_cols, (
+                f"Column parity mismatch on {table}:\n"
+                f"  fresh:    {fresh_cols}\n"
+                f"  migrated: {migrated_cols}"
+            )
+
+        teams_tables = {"teams", "team_members"}
+        fresh_indexes = {
+            (name, tbl, sql)
+            for name, tbl, sql in _get_user_indexes(fresh_path)
+            if tbl in teams_tables
+        }
+        migrated_indexes = {
+            (name, tbl, sql)
+            for name, tbl, sql in _get_user_indexes(migrated_path)
+            if tbl in teams_tables
+        }
+        assert fresh_indexes == migrated_indexes, (
+            f"Index parity mismatch on teams/team_members:\n"
+            f"  fresh only:    {fresh_indexes - migrated_indexes}\n"
+            f"  migrated only: {migrated_indexes - fresh_indexes}"
+        )
+
+    def test_rollback_leaves_schema_unchanged_on_mid_transaction_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """v6→v7 atomicity: a mid-txn failure rolls back every CREATE plus
+        the schema_version bump.
+
+        Forces the second DDL (team_members) to raise by patching its
+        module-level constant to syntactically invalid SQL.  After the
+        rollback:
+          - ``teams`` must NOT exist (first CREATE undone by SQLite's
+            transactional DDL)
+          - ``team_members`` must NOT exist
+          - ``schema_version`` must still be 6 (v7 insert undone)
+
+        Mirrors the v5→v6 rollback test at
+        ``test_rollback_leaves_schema_unchanged_on_mid_transaction_failure``.
+        """
+        import sqlite3
+
+        from ado_git_repo_insights.persistence import migrations
+
+        db_path = tmp_path / "v6_rollback.db"
+        self._create_v6_db_without_teams(db_path)
+
+        # Guardrail: prove pre-migration state so the rollback assertions
+        # below are load-bearing rather than trivially satisfied.
+        pre_conn = sqlite3.connect(str(db_path))
+        assert (
+            pre_conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+            == 6
+        ), "fixture must start at schema_version=6"
+        pre_tables = {
+            r[0]
+            for r in pre_conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "teams" not in pre_tables
+        assert "team_members" not in pre_tables
+        pre_conn.close()
+
+        # Patch the second DDL to invalid SQL so the inner execute raises
+        # *after* _V7_TEAMS_DDL has run inside the BEGIN IMMEDIATE txn.
+        monkeypatch.setattr(
+            migrations,
+            "_V7_TEAM_MEMBERS_DDL",
+            "CREATE TABLE team_members (INVALID_SYNTAX",
+        )
+
+        # Run the migration directly against a raw connection so the
+        # exception surfaces to the test, bypassing the catch-and-log
+        # in DatabaseManager.connect().
+        conn = sqlite3.connect(str(db_path))
+        conn.isolation_level = None  # match DatabaseManager's autocommit mode
+        try:
+            with pytest.raises(sqlite3.OperationalError):
+                migrations.migrate_v6_to_v7(conn)
+        finally:
+            conn.close()
+
+        post_conn = sqlite3.connect(str(db_path))
+        try:
+            post_tables = {
+                r[0]
+                for r in post_conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert "teams" not in post_tables, (
+                "v6→v7 must NOT leave teams half-created after rollback"
+            )
+            assert "team_members" not in post_tables, (
+                "v6→v7 must NOT leave team_members half-created after rollback"
+            )
+            assert (
+                post_conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[
+                    0
+                ]
+                == 6
+            ), "schema_version must stay at 6 after rollback (v7 insert undone)"
+        finally:
+            post_conn.close()
+
+    def test_begin_immediate_failure_does_not_rollback_or_mask_error(
+        self, tmp_path: Path
+    ) -> None:
+        """``migrate_v6_to_v7`` MUST NOT issue ROLLBACK after a failed
+        BEGIN IMMEDIATE.
+
+        If BEGIN IMMEDIATE raises (writer lock held elsewhere), no txn is
+        open, so an unconditional ROLLBACK would itself raise ``cannot
+        rollback - no transaction is active`` and mask the original
+        lock error.  The ``txn_started`` guard mirrors ``migrate_v4_to_
+        v5`` / ``migrate_v5_to_v6``; this test locks that branch against
+        regression.
+
+        Real-shape reproduction: hold the writer lock on one connection
+        and invoke the migration on a second connection with
+        ``busy_timeout=0`` so BEGIN IMMEDIATE raises immediately.
+        """
+        import sqlite3
+
+        from ado_git_repo_insights.persistence.migrations import migrate_v6_to_v7
+
+        db_path = tmp_path / "v6_begin_fails.db"
+        self._create_v6_db_without_teams(db_path)
+
+        holder = sqlite3.connect(str(db_path), isolation_level=None)
+        holder.execute("BEGIN IMMEDIATE")
+        try:
+            migrator = sqlite3.connect(str(db_path), isolation_level=None)
+            migrator.execute("PRAGMA busy_timeout = 0")
+            try:
+                with pytest.raises(sqlite3.OperationalError) as excinfo:
+                    migrate_v6_to_v7(migrator)
+                message = str(excinfo.value).lower()
+                assert "database is locked" in message, message
+                # The masking "cannot rollback - no transaction is
+                # active" text from an unguarded implementation must
+                # NOT appear.
+                assert "cannot rollback" not in message, message
+                assert not migrator.in_transaction
+            finally:
+                migrator.close()
+        finally:
+            holder.execute("ROLLBACK")
+            holder.close()
+
+    def test_required_tables_check_catches_silent_migration_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Post-migration ``_REQUIRED_TABLES`` sweep rejects DBs where the
+        migration silently failed to create teams / team_members.
+
+        If a future refactor ever removes a CREATE TABLE from
+        migrate_v6_to_v7 (or a later migration silently skips a
+        required table), the post-migration validation must catch it at
+        ``connect()`` time — NOT at first ``upsert_team`` crash.  This
+        is the exact defense #295 added (the two-phase fundamental /
+        required check) for this class of bug: the SCHEMA_SQL-without-
+        migration landmine that bit both ``comments_extraction_metadata``
+        (#295) and ``teams`` / ``team_members`` (#296).
+        """
+        from sqlite3 import Connection as _Conn
+
+        from ado_git_repo_insights.persistence import migrations
+        from ado_git_repo_insights.persistence.database import DatabaseError
+
+        db_path = tmp_path / "v6_silent_skip.db"
+        self._create_v6_db_without_teams(db_path)
+
+        def no_op_migration(conn: _Conn) -> None:
+            """Simulated regression: bumps schema_version but skips DDL."""
+            conn.execute(
+                "INSERT OR IGNORE INTO schema_version (version, applied_at) "
+                "VALUES (7, datetime('now'))"
+            )
+
+        monkeypatch.setitem(migrations.MIGRATIONS, 7, no_op_migration)
+
+        db = DatabaseManager(db_path)
+        with pytest.raises(DatabaseError, match="Missing tables"):
+            db.connect()
+
+
 class TestConnectFailFastOnPartialDatabases:
     """Fail-fast preservation when opening a partial / foreign DB.
 
@@ -2320,8 +2839,11 @@ class TestConnectFailFastOnPartialDatabases:
         manager = DatabaseManager(db_path)
         manager.connect()
         try:
-            assert manager.get_schema_version() == 6
-            # Post-migration validation sees the migration-added table.
+            assert manager.get_schema_version() == 7
+            # Post-migration validation sees the migration-added tables
+            # from every migration in the chain (v5→v6 added
+            # comments_extraction_metadata; v6→v7 added teams +
+            # team_members).
             cursor = manager.connection.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' "
                 "AND name='comments_extraction_metadata'"

--- a/tests/unit/test_schema_migration_v4_to_v5.py
+++ b/tests/unit/test_schema_migration_v4_to_v5.py
@@ -174,7 +174,12 @@ class TestMigrationV4ToV5PrCommentsCompositePK:
         return conn
 
     def test_old_schema_upgrades_to_composite_pk(self, tmp_path: Path) -> None:
-        """After v4→v5, pr_comments PRIMARY KEY covers (pull_request_uid, thread_id, comment_id)."""
+        """After v4→v5, pr_comments PRIMARY KEY covers (pull_request_uid, thread_id, comment_id).
+
+        ``db.connect()`` runs the full pending migration chain, so
+        schema_version lands at the current latest (v7) even though the
+        behavior under test is v4→v5.
+        """
         db_path = tmp_path / "v4_to_v5.db"
         conn = self._create_v4_db(db_path)
         conn.commit()
@@ -183,7 +188,7 @@ class TestMigrationV4ToV5PrCommentsCompositePK:
         db = DatabaseManager(db_path)
         db.connect()
         try:
-            assert db.get_schema_version() == 6
+            assert db.get_schema_version() == 7
             pk_cols = [
                 row["name"]
                 for row in sorted(
@@ -352,13 +357,13 @@ class TestMigrationV4ToV5PrCommentsCompositePK:
 
         db = DatabaseManager(db_path)
         db.connect()
-        assert db.get_schema_version() == 6
+        assert db.get_schema_version() == 7
         db.close()
 
         db2 = DatabaseManager(db_path)
         db2.connect()
         try:
-            assert db2.get_schema_version() == 6
+            assert db2.get_schema_version() == 7
             pk_cols = [
                 row["name"]
                 for row in sorted(

--- a/tests/unit/test_team_extraction.py
+++ b/tests/unit/test_team_extraction.py
@@ -593,16 +593,46 @@ class TestExtractTeamsPipeline:
         warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
         assert any("projA" in m and "skipping" in m for m in warnings)
 
-    def test_member_fetch_failure_team_persisted_members_skipped(
+    def test_member_fetch_failure_preserves_existing_members(
         self,
         ctx: tuple[MagicMock, DatabaseManager, Config],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """``get_team_members`` failing for one team: team row still
-        persisted, its members skipped with WARN, sibling teams unaffected."""
+        """P2 review-fix (#296): ``get_team_members`` failing for one team
+        must leave that team's pre-existing members *unchanged* — clearing
+        only runs after a successful fetch, so transient 403 / network
+        errors never cause data loss.  Sibling teams still refresh
+        normally.
+
+        Locks the no-data-loss invariant explicitly by pre-seeding a
+        member row and asserting it survives the failed fetch.  The
+        earlier version of this test only asserted "team persisted",
+        which would have passed the broken ``clear-before-fetch`` code
+        path for the wrong reason.
+        """
         from ado_git_repo_insights.cli import _extract_teams
 
         client, db, config = ctx
+
+        # Pre-seed t1 with a prior member so the preservation assertion
+        # below is load-bearing (not trivially satisfied by an already-
+        # empty team).  The parent team row is also pre-seeded because
+        # FK from team_members → teams requires it.
+        db.execute(
+            "INSERT INTO users (user_id, display_name) VALUES "
+            "('u_existing', 'Existing User')"
+        )
+        now = datetime.now(UTC).isoformat()
+        db.execute(
+            "INSERT INTO teams (team_id, team_name, project_name, "
+            "organization_name, last_updated) VALUES (?, ?, ?, ?, ?)",
+            ("t1", "Team 1 (prior)", "projA", "org1", now),
+        )
+        db.execute(
+            "INSERT INTO team_members (team_id, user_id, is_team_admin) "
+            "VALUES ('t1', 'u_existing', 0)"
+        )
+        db.connection.commit()
 
         client.get_teams.return_value = [
             {"id": "t1", "name": "Team 1", "description": None},
@@ -614,9 +644,9 @@ class TestExtractTeamsPipeline:
                 raise ExtractionError("member fetch failed for t1")
             return [
                 {
-                    "id": "u1",
-                    "displayName": "Alice",
-                    "uniqueName": "alice@example.com",
+                    "id": "u_new",
+                    "displayName": "New",
+                    "uniqueName": "new@example.com",
                 }
             ]
 
@@ -627,14 +657,33 @@ class TestExtractTeamsPipeline:
         with caplog.at_level(logging.WARNING, logger="ado_git_repo_insights.cli"):
             _extract_teams(client, db, config, summary)
 
-        assert db.execute("SELECT COUNT(*) FROM teams").fetchone()[0] == 2
-        member_team_ids = [
-            row[0] for row in db.execute("SELECT team_id FROM team_members").fetchall()
+        # P2 INVARIANT: t1's pre-existing member row is unchanged.
+        t1_members = [
+            row[0]
+            for row in db.execute(
+                "SELECT user_id FROM team_members WHERE team_id = 't1' ORDER BY user_id"
+            ).fetchall()
         ]
-        assert member_team_ids == ["t2"]
+        assert t1_members == ["u_existing"], (
+            "P2 no-data-loss invariant: t1's pre-existing member must "
+            "survive a failed get_team_members call"
+        )
+
+        # Sibling t2 populates normally (fetch succeeded there).
+        t2_members = [
+            row[0]
+            for row in db.execute(
+                "SELECT user_id FROM team_members WHERE team_id = 't2'"
+            ).fetchall()
+        ]
+        assert t2_members == ["u_new"]
+
+        # Both team rows present (t1 refreshed with new name/last_updated,
+        # t2 freshly inserted).
+        assert db.execute("SELECT COUNT(*) FROM teams").fetchone()[0] == 2
 
         warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
-        assert any("t1" in m for m in warnings)
+        assert any("t1" in m and "skipping members" in m for m in warnings)
 
     def test_clear_team_members_called_before_refresh(
         self,
@@ -848,3 +897,90 @@ class TestExtractTeamsPipeline:
             "projA" in m and "t1" in m and "'displayName'" in m and "u_no_name" in m
             for m in warnings
         ), warnings
+
+    def test_zero_pr_project_still_extracts_teams_on_fresh_db(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """P1 review-fix (#296): a succeeded project with zero PRs in the
+        extract window has NO projects-table row on a fresh DB, because
+        ``PRExtractor._extract_project`` only writes the projects row
+        through ``upsert_pr_with_related`` inside its per-PR loop — a
+        loop that never executes when the window yields zero PRs.
+
+        Without the defensive ``upsert_organization`` /
+        ``upsert_project`` inside ``_extract_teams`` (added in this
+        fix), the first ``upsert_team`` would crash with
+        ``sqlite3.IntegrityError`` on the teams → projects FK.
+
+        Uses a fresh DB directly (not the ``ctx`` fixture) because
+        ``ctx`` pre-seeds org + both projects, which would hide the
+        bug this test exists to lock.
+        """
+        from ado_git_repo_insights.cli import _extract_teams
+
+        db_path = tmp_path / "fresh.sqlite"
+        db = DatabaseManager(db_path)
+        db.connect()
+        try:
+            # Pre-condition: empty DB, no (org, project) rows so the
+            # FK target is genuinely absent.  Without this guard, a
+            # silent schema seed could trivially satisfy the post-
+            # assertion for the wrong reason.
+            assert db.execute("SELECT COUNT(*) FROM organizations").fetchone()[0] == 0
+            assert db.execute("SELECT COUNT(*) FROM projects").fetchone()[0] == 0
+
+            client = MagicMock(spec=ADOClient)
+            client.get_teams.return_value = [
+                {"id": "t1", "name": "Zero-PR Team", "description": None}
+            ]
+            client.get_team_members.return_value = [
+                {
+                    "id": "u1",
+                    "displayName": "Alice",
+                    "uniqueName": "alice@example.com",
+                }
+            ]
+            config = cast(Config, SimpleNamespace(organization="org1"))
+
+            # Succeeded project + zero PRs extracted is the failure
+            # shape this test locks.
+            summary = ExtractionSummary()
+            summary.add_result(
+                ProjectExtractionResult(
+                    project="projA",
+                    start_date=date(2026, 4, 1),
+                    end_date=date(2026, 4, 19),
+                    prs_extracted=0,
+                    success=True,
+                )
+            )
+
+            # Must complete without IntegrityError.
+            _extract_teams(client, db, config, summary)
+
+            # Defensive upserts created the parent rows exactly once.
+            assert (
+                db.execute(
+                    "SELECT COUNT(*) FROM organizations "
+                    "WHERE organization_name = 'org1'"
+                ).fetchone()[0]
+                == 1
+            )
+            assert (
+                db.execute(
+                    "SELECT COUNT(*) FROM projects "
+                    "WHERE organization_name = 'org1' AND project_name = 'projA'"
+                ).fetchone()[0]
+                == 1
+            )
+            # Team + member landed normally.
+            assert (
+                db.execute(
+                    "SELECT COUNT(*) FROM teams WHERE project_name = 'projA'"
+                ).fetchone()[0]
+                == 1
+            )
+            assert db.execute("SELECT COUNT(*) FROM team_members").fetchone()[0] == 1
+        finally:
+            db.close()

--- a/tests/unit/test_team_extraction.py
+++ b/tests/unit/test_team_extraction.py
@@ -1,23 +1,30 @@
-"""Unit tests for team extraction (Phase 3.3).
+"""Unit tests for team extraction (Phase 3.3 data plane + #296 control plane).
 
-Covers §5 from IMPLEMENTATION_DETAILS.md:
-- Team extraction with pagination
+- Team extraction with pagination (ADOClient.get_teams / get_team_members)
 - Graceful degradation when team APIs unavailable
-- Team persistence and membership
+- Team persistence (PRRepository upsert/get helpers)
+- Control-plane pipeline wiring: ``_extract_teams`` helper (#296)
 """
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterator
-from datetime import UTC
+from datetime import UTC, date, datetime
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 
-from ado_git_repo_insights.config import APIConfig
+from ado_git_repo_insights.config import APIConfig, Config
 from ado_git_repo_insights.extractor.ado_client import ADOClient, ExtractionError
+from ado_git_repo_insights.extractor.pr_extractor import (
+    ExtractionSummary,
+    ProjectExtractionResult,
+)
 from ado_git_repo_insights.persistence.database import DatabaseManager
 from ado_git_repo_insights.persistence.repository import PRRepository
 
@@ -390,3 +397,373 @@ class TestTeamGracefulDegradation:
         assert manifest.coverage["teams_count"] == 1
 
         db.close()
+
+
+class TestExtractTeamsPipeline:
+    """End-to-end pipeline tests for ``_extract_teams`` (#296 control plane).
+
+    Exercises the helper against a real ``DatabaseManager`` (so upserts
+    actually persist and the ``db.transaction()`` wrapper behaves as in
+    production) with a mocked ``ADOClient`` and a ``SimpleNamespace``
+    config stub.  Each test covers one invariant from the #296 review:
+
+    - Per-project fan-out filtered to ``success == True`` (option b)
+    - Per-project team-fetch failures skip-not-fail
+    - Per-team member-fetch failures skip-not-fail, team still persists
+    - Current-state membership via ``clear_team_members`` + refresh
+    - Transaction wrapper rolls back both ``teams`` and ``team_members``
+      on unhandled mid-loop exception (directive #3, tightened)
+    - Terminal log uses ``PR-successful projects`` wording (directive #3,
+      invariant portion only)
+    - Empty projects list is a clean no-op
+    """
+
+    @pytest.fixture
+    def ctx(
+        self, tmp_path: Path
+    ) -> Iterator[tuple[MagicMock, DatabaseManager, Config]]:
+        """Mocked ADOClient + real DatabaseManager (with FK seed) + config stub."""
+        db_path = tmp_path / "test.sqlite"
+        db = DatabaseManager(db_path)
+        db.connect()
+
+        db.execute("INSERT INTO organizations (organization_name) VALUES ('org1')")
+        db.execute(
+            "INSERT INTO projects (organization_name, project_name) VALUES (?, ?)",
+            ("org1", "projA"),
+        )
+        db.execute(
+            "INSERT INTO projects (organization_name, project_name) VALUES (?, ?)",
+            ("org1", "projB"),
+        )
+        db.connection.commit()
+
+        mock_client = MagicMock(spec=ADOClient)
+        # _extract_teams only reads ``config.organization``; a duck-typed
+        # namespace covers the real contract without constructing a full
+        # Config (which requires every production field).  The cast keeps
+        # mypy strict against the helper's annotated shape.
+        config = cast(Config, SimpleNamespace(organization="org1"))
+
+        try:
+            yield mock_client, db, config
+        finally:
+            db.close()
+
+    @staticmethod
+    def _mk_result(project: str, *, success: bool = True) -> ProjectExtractionResult:
+        return ProjectExtractionResult(
+            project=project,
+            start_date=date(2026, 4, 1),
+            end_date=date(2026, 4, 19),
+            prs_extracted=5 if success else 0,
+            success=success,
+            error=None if success else "simulated PR fetch failure",
+        )
+
+    @staticmethod
+    def _mk_summary(*results: ProjectExtractionResult) -> ExtractionSummary:
+        summary = ExtractionSummary()
+        for r in results:
+            summary.add_result(r)
+        return summary
+
+    def test_happy_path_all_projects_succeed_extracts_teams(
+        self,
+        ctx: tuple[MagicMock, DatabaseManager, Config],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """All PR-successful projects: every team + member persists; terminal
+        log locks the ``PR-successful projects`` invariant wording."""
+        from ado_git_repo_insights.cli import _extract_teams
+
+        client, db, config = ctx
+
+        def teams_for(proj: str) -> list[dict[str, object]]:
+            if proj == "projA":
+                return [
+                    {"id": "t1", "name": "Team One", "description": "first"},
+                    {"id": "t2", "name": "Team Two", "description": None},
+                ]
+            return [{"id": "t3", "name": "Team Three", "description": "b-team"}]
+
+        def members_for(proj: str, tid: str) -> list[dict[str, object]]:
+            return [
+                {
+                    "identity": {"id": f"u-{tid}-1", "displayName": "Alice"},
+                    "isTeamAdmin": True,
+                },
+                {
+                    "identity": {"id": f"u-{tid}-2", "displayName": "Bob"},
+                    "isTeamAdmin": False,
+                },
+            ]
+
+        client.get_teams.side_effect = teams_for
+        client.get_team_members.side_effect = members_for
+
+        summary = self._mk_summary(
+            self._mk_result("projA"),
+            self._mk_result("projB"),
+        )
+
+        with caplog.at_level(logging.INFO, logger="ado_git_repo_insights.cli"):
+            stats = _extract_teams(client, db, config, summary)
+
+        assert stats["teams_extracted"] == 3
+        assert stats["team_members_extracted"] == 6
+        assert stats["projects_team_skipped"] == 0
+
+        assert db.execute("SELECT COUNT(*) FROM teams").fetchone()[0] == 3
+        assert db.execute("SELECT COUNT(*) FROM team_members").fetchone()[0] == 6
+
+        # Lock only the invariant portion of the terminal log (directive #3).
+        combined = " ".join(r.getMessage() for r in caplog.records)
+        assert "PR-successful projects" in combined
+        assert "3 teams" in combined
+        assert "6 members" in combined
+
+    def test_skips_project_with_failed_pr_extraction(
+        self,
+        ctx: tuple[MagicMock, DatabaseManager, Config],
+    ) -> None:
+        """Option (b): project with ``success=False`` is NEVER passed to
+        ``get_teams``; succeeded projects are still processed."""
+        from ado_git_repo_insights.cli import _extract_teams
+
+        client, db, config = ctx
+        client.get_teams.return_value = [
+            {"id": "t1", "name": "Team", "description": None}
+        ]
+        client.get_team_members.return_value = []
+
+        summary = self._mk_summary(
+            self._mk_result("projA", success=True),
+            self._mk_result("projB", success=False),
+        )
+
+        _extract_teams(client, db, config, summary)
+
+        called_projects = [call.args[0] for call in client.get_teams.call_args_list]
+        assert called_projects == ["projA"]
+
+    def test_project_team_fetch_403_logs_and_continues(
+        self,
+        ctx: tuple[MagicMock, DatabaseManager, Config],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """``get_teams`` raising ``ExtractionError`` on one project logs a
+        WARNING, increments ``projects_team_skipped``, and continues."""
+        from ado_git_repo_insights.cli import _extract_teams
+
+        client, db, config = ctx
+
+        def team_fetch(proj: str) -> list[dict[str, object]]:
+            if proj == "projA":
+                raise ExtractionError("403 Forbidden on projA teams")
+            return [{"id": "t3", "name": "Team B", "description": None}]
+
+        client.get_teams.side_effect = team_fetch
+        client.get_team_members.return_value = []
+
+        summary = self._mk_summary(
+            self._mk_result("projA"),
+            self._mk_result("projB"),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ado_git_repo_insights.cli"):
+            stats = _extract_teams(client, db, config, summary)
+
+        assert stats["teams_extracted"] == 1
+        assert stats["projects_team_skipped"] == 1
+
+        team_names = [
+            row[0] for row in db.execute("SELECT team_name FROM teams").fetchall()
+        ]
+        assert team_names == ["Team B"]
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any("projA" in m and "skipping" in m for m in warnings)
+
+    def test_member_fetch_failure_team_persisted_members_skipped(
+        self,
+        ctx: tuple[MagicMock, DatabaseManager, Config],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """``get_team_members`` failing for one team: team row still
+        persisted, its members skipped with WARN, sibling teams unaffected."""
+        from ado_git_repo_insights.cli import _extract_teams
+
+        client, db, config = ctx
+
+        client.get_teams.return_value = [
+            {"id": "t1", "name": "Team 1", "description": None},
+            {"id": "t2", "name": "Team 2", "description": None},
+        ]
+
+        def members(proj: str, tid: str) -> list[dict[str, object]]:
+            if tid == "t1":
+                raise ExtractionError("member fetch failed for t1")
+            return [
+                {
+                    "identity": {"id": "u1", "displayName": "Alice"},
+                    "isTeamAdmin": False,
+                }
+            ]
+
+        client.get_team_members.side_effect = members
+
+        summary = self._mk_summary(self._mk_result("projA"))
+
+        with caplog.at_level(logging.WARNING, logger="ado_git_repo_insights.cli"):
+            _extract_teams(client, db, config, summary)
+
+        assert db.execute("SELECT COUNT(*) FROM teams").fetchone()[0] == 2
+        member_team_ids = [
+            row[0] for row in db.execute("SELECT team_id FROM team_members").fetchall()
+        ]
+        assert member_team_ids == ["t2"]
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any("t1" in m for m in warnings)
+
+    def test_clear_team_members_called_before_refresh(
+        self,
+        ctx: tuple[MagicMock, DatabaseManager, Config],
+    ) -> None:
+        """Pre-seeded stale member must be removed before new members are
+        written — locks current-state membership semantics."""
+        from ado_git_repo_insights.cli import _extract_teams
+
+        client, db, config = ctx
+
+        db.execute(
+            "INSERT INTO users (user_id, display_name) VALUES ('stale_user', 'Stale')"
+        )
+        now = datetime.now(UTC).isoformat()
+        db.execute(
+            "INSERT INTO teams (team_id, team_name, project_name, "
+            "organization_name, last_updated) VALUES (?, ?, ?, ?, ?)",
+            ("t1", "Team 1", "projA", "org1", now),
+        )
+        db.execute(
+            "INSERT INTO team_members (team_id, user_id, is_team_admin) "
+            "VALUES ('t1', 'stale_user', 0)"
+        )
+        db.connection.commit()
+
+        client.get_teams.return_value = [
+            {"id": "t1", "name": "Team 1", "description": None}
+        ]
+        client.get_team_members.return_value = [
+            {
+                "identity": {"id": "fresh_user", "displayName": "Fresh"},
+                "isTeamAdmin": True,
+            }
+        ]
+
+        summary = self._mk_summary(self._mk_result("projA"))
+        _extract_teams(client, db, config, summary)
+
+        users_for_t1 = [
+            row[0]
+            for row in db.execute(
+                "SELECT user_id FROM team_members WHERE team_id = 't1'"
+            ).fetchall()
+        ]
+        assert users_for_t1 == ["fresh_user"]
+
+    def test_empty_teams_list_no_upserts_no_warning(
+        self,
+        ctx: tuple[MagicMock, DatabaseManager, Config],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A project with zero teams: no upserts, no WARNING, no crash."""
+        from ado_git_repo_insights.cli import _extract_teams
+
+        client, db, config = ctx
+        client.get_teams.return_value = []
+
+        summary = self._mk_summary(self._mk_result("projA"))
+
+        with caplog.at_level(logging.WARNING, logger="ado_git_repo_insights.cli"):
+            stats = _extract_teams(client, db, config, summary)
+
+        assert stats["teams_extracted"] == 0
+        assert stats["projects_team_skipped"] == 0
+        assert db.execute("SELECT COUNT(*) FROM teams").fetchone()[0] == 0
+        assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+        assert client.get_team_members.call_count == 0
+
+    def test_unhandled_exception_mid_loop_rolls_back_all_writes(
+        self,
+        ctx: tuple[MagicMock, DatabaseManager, Config],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Directive #3 tightened: BOTH ``teams`` AND ``team_members`` must
+        remain empty after a mid-loop unhandled exception — proves the
+        single-transaction wrapper rolls back cross-table writes, not
+        just one table."""
+        from ado_git_repo_insights.cli import _extract_teams
+
+        client, db, config = ctx
+
+        client.get_teams.return_value = [
+            {"id": "t1", "name": "Team 1", "description": None},
+            {"id": "t2", "name": "Team 2", "description": None},
+            {"id": "t3", "name": "Team 3", "description": None},
+        ]
+        client.get_team_members.return_value = [
+            {
+                "identity": {"id": "u1", "displayName": "Alice"},
+                "isTeamAdmin": False,
+            }
+        ]
+
+        # Force an unhandled exception on upsert_team_member.  By the
+        # time this fires, the outer transaction has already persisted
+        # at least one ``teams`` row (upsert_team runs first in the
+        # inner loop); the rollback must undo that too — not just the
+        # pending team_members write that never completed.
+        def always_fail(self: PRRepository, **kwargs: object) -> None:
+            raise RuntimeError("simulated mid-loop failure")
+
+        monkeypatch.setattr(PRRepository, "upsert_team_member", always_fail)
+
+        summary = self._mk_summary(self._mk_result("projA"))
+
+        with pytest.raises(RuntimeError, match="simulated mid-loop failure"):
+            _extract_teams(client, db, config, summary)
+
+        assert db.execute("SELECT COUNT(*) FROM teams").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM team_members").fetchone()[0] == 0
+
+    def test_no_succeeded_projects_is_clean_noop(
+        self,
+        ctx: tuple[MagicMock, DatabaseManager, Config],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """All projects failed PR extract: zero API calls, clean INFO log,
+        no exception."""
+        from ado_git_repo_insights.cli import _extract_teams
+
+        client, db, config = ctx
+
+        summary = self._mk_summary(
+            self._mk_result("projA", success=False),
+            self._mk_result("projB", success=False),
+        )
+
+        with caplog.at_level(logging.INFO, logger="ado_git_repo_insights.cli"):
+            stats = _extract_teams(client, db, config, summary)
+
+        assert stats == {
+            "teams_extracted": 0,
+            "team_members_extracted": 0,
+            "projects_team_skipped": 0,
+        }
+        assert client.get_teams.call_count == 0
+        assert client.get_team_members.call_count == 0
+
+        info_msgs = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
+        assert any("no PR-successful projects" in m for m in info_msgs)

--- a/tests/unit/test_team_extraction.py
+++ b/tests/unit/test_team_extraction.py
@@ -113,7 +113,11 @@ class TestTeamExtraction:
                 client.get_teams("TestProject")
 
     def test_get_team_members_returns_list(self, client: ADOClient) -> None:
-        """Test that get_team_members returns member list."""
+        """Test that get_team_members returns member list.
+
+        Real ADO shape is a flat IdentityRef — no ``identity`` wrapper, no
+        ``isTeamAdmin`` field — confirmed by live probe during #296 QA.
+        """
         mock_response = MagicMock()
         mock_response.ok = True
         mock_response.status_code = 200
@@ -121,12 +125,14 @@ class TestTeamExtraction:
         mock_response.json.return_value = {
             "value": [
                 {
-                    "identity": {"id": "user1", "displayName": "User One"},
-                    "isTeamAdmin": True,
+                    "id": "user1",
+                    "displayName": "User One",
+                    "uniqueName": "user1@example.com",
                 },
                 {
-                    "identity": {"id": "user2", "displayName": "User Two"},
-                    "isTeamAdmin": False,
+                    "id": "user2",
+                    "displayName": "User Two",
+                    "uniqueName": "user2@example.com",
                 },
             ],
         }
@@ -490,12 +496,14 @@ class TestExtractTeamsPipeline:
         def members_for(proj: str, tid: str) -> list[dict[str, object]]:
             return [
                 {
-                    "identity": {"id": f"u-{tid}-1", "displayName": "Alice"},
-                    "isTeamAdmin": True,
+                    "id": f"u-{tid}-1",
+                    "displayName": "Alice",
+                    "uniqueName": "alice@example.com",
                 },
                 {
-                    "identity": {"id": f"u-{tid}-2", "displayName": "Bob"},
-                    "isTeamAdmin": False,
+                    "id": f"u-{tid}-2",
+                    "displayName": "Bob",
+                    "uniqueName": "bob@example.com",
                 },
             ]
 
@@ -606,8 +614,9 @@ class TestExtractTeamsPipeline:
                 raise ExtractionError("member fetch failed for t1")
             return [
                 {
-                    "identity": {"id": "u1", "displayName": "Alice"},
-                    "isTeamAdmin": False,
+                    "id": "u1",
+                    "displayName": "Alice",
+                    "uniqueName": "alice@example.com",
                 }
             ]
 
@@ -657,8 +666,9 @@ class TestExtractTeamsPipeline:
         ]
         client.get_team_members.return_value = [
             {
-                "identity": {"id": "fresh_user", "displayName": "Fresh"},
-                "isTeamAdmin": True,
+                "id": "fresh_user",
+                "displayName": "Fresh",
+                "uniqueName": "fresh@example.com",
             }
         ]
 
@@ -715,8 +725,9 @@ class TestExtractTeamsPipeline:
         ]
         client.get_team_members.return_value = [
             {
-                "identity": {"id": "u1", "displayName": "Alice"},
-                "isTeamAdmin": False,
+                "id": "u1",
+                "displayName": "Alice",
+                "uniqueName": "alice@example.com",
             }
         ]
 
@@ -767,3 +778,73 @@ class TestExtractTeamsPipeline:
 
         info_msgs = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
         assert any("no PR-successful projects" in m for m in info_msgs)
+
+    def test_malformed_member_missing_id_or_displayname_logged_and_skipped(
+        self,
+        ctx: tuple[MagicMock, DatabaseManager, Config],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Defensive skip: member rows missing ``id`` or ``displayName``
+        log a specific WARNING (naming project, team, and the missing
+        field) and skip that row — never fatal to the run.
+
+        Guards against future ADO shape drift (e.g., if a new identity
+        variant omits fields) and locks the operator-facing signal that
+        distinguishes malformed upstream data from ordinary permission
+        skips.  Added 2026-04-19 after the live QA probe on
+        ``oddessentials/oddessentials`` revealed the real member shape
+        is a flat IdentityRef, not the nested ``{identity: {...}}``
+        the Phase 3.3 TypedDict incorrectly assumed.
+        """
+        from ado_git_repo_insights.cli import _extract_teams
+
+        client, db, config = ctx
+
+        client.get_teams.return_value = [
+            {"id": "t1", "name": "Team 1", "description": None}
+        ]
+        client.get_team_members.return_value = [
+            # Valid member — persists.
+            {
+                "id": "u_ok",
+                "displayName": "Alice",
+                "uniqueName": "alice@example.com",
+            },
+            # Missing ``id`` — skip with WARNING.
+            {
+                "displayName": "Bob Broken",
+                "uniqueName": "bob@example.com",
+            },
+            # Missing ``displayName`` — skip with WARNING.
+            {
+                "id": "u_no_name",
+                "uniqueName": "charlie@example.com",
+            },
+        ]
+
+        summary = self._mk_summary(self._mk_result("projA"))
+
+        with caplog.at_level(logging.WARNING, logger="ado_git_repo_insights.cli"):
+            _extract_teams(client, db, config, summary)
+
+        # Only the valid member persisted.
+        users = [
+            row[0]
+            for row in db.execute(
+                "SELECT user_id FROM team_members WHERE team_id = 't1'"
+            ).fetchall()
+        ]
+        assert users == ["u_ok"]
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 2, warnings
+        # Each warning names the project + team context and identifies
+        # the specific missing field so operators can distinguish
+        # malformed rows from permission skips.
+        assert any("projA" in m and "t1" in m and "'id'" in m for m in warnings), (
+            warnings
+        )
+        assert any(
+            "projA" in m and "t1" in m and "'displayName'" in m and "u_no_name" in m
+            for m in warnings
+        ), warnings


### PR DESCRIPTION
## Summary

- Restores the teams dimension that has been empty in prod since Phase 3.3 (2026-01-14). Two defects, one PR:
  1. **Missing migration** — `teams` / `team_members` declared in `SCHEMA_SQL` but no `migrate_v6_to_v7` ever created them on legacy DBs (second instance of the `#295` landmine class).
  2. **Missing caller** — `ADOClient.get_teams` / `get_team_members` shipped in 2026-01-14 but no caller ever invoked them. `_extract_teams()` is now wired into `cmd_extract` between the per-project-status loop and the fail-fast gate, so teams fetch for every PR-successful project (option b), inside a single `db.transaction()` for cross-table atomicity.
- **Live vintage QA surfaced a third defect** that every unit test had passed for the wrong reason: `AdoTeamMember` TypedDict assumed a nested `{identity: {...}, isTeamAdmin}` shape; real ADO returns a flat `IdentityRef` (`id`, `displayName`, `uniqueName`, …). Fixed types.py, cli.py, and every affected mock in one commit (`7557521e`), plus a defensive per-field skip with specific WARNING prose so any future shape drift logs instead of crashes.
- New internal runbook `docs/internal/teams-live-qa.md` records the proven QA procedure and the canonical #296 incident so future operators see why live vintage QA is load-bearing for this bug class.
- Follow-up structural guard (parity test that every `SCHEMA_SQL` table is either fundamental or covered by a migration) filed as #304, explicitly out of scope here.

## Commits

| SHA | Scope |
|---|---|
| `6ad58879` | `migrate_v6_to_v7` + 8 tests + fixture updates (ratchet 2026→2034) |
| `cdc7942d` | `_extract_teams` wiring + 8 tests + orphan docstring cleanup (ratchet 2034→2042) |
| `f765a227` | Complete `== 6` → `== 7` sweep in `test_schema_migration_v4_to_v5.py` (missed in commit 1's sweep) |
| `7557521e` | `AdoTeamMember` shape fix caught by vintage QA; 5 mocks updated (ratchet 2042→2043) |
| `9b8bc50a` | `docs/internal/teams-live-qa.md` internal runbook |

## Test plan

- [x] Local full chain (`python scripts/run_repo_hook.py pre-push`) — green 3×:
  - After Commit 1+2+3 chain
  - After Commit 4 (shape fix)
  - After Commit 5 (docs) — on push
- [x] Live vintage QA on oddessentials + pipeline-15 staged DB:
  - [x] Scenario 0 — production-vintage migration advances `schema_version 6 → 7`, tables present
  - [x] Scenario 1 — 4-project extract produced `teams: extracted 5 teams / 5 members across 4 PR-successful projects (0 skipped)`; **API / DB count parity on every project** (oddessentials 1/1, engineering 1/1, marketing 2/2, hospitality 1/1)
  - [x] Scenario 2 — idempotent re-run, row counts stable
  - [x] Scenario 3 — permission skip locked by unit test `test_project_team_fetch_403_logs_and_continues`
  - [x] Scenario 4 — `generate-aggregates` produced `features.teams=True`, `coverage.teams_count=1`
  - [x] Scenario 5 — extension wrapper grep confirms zero team-specific decisions (structural parity)
- [x] 16 new tests across `test_schema_migration.py` + `test_team_extraction.py` (migration + pipeline + shape-drift defense); `.test-floor-contract.json` bumped 2026 → 2043
- [x] Mypy clean, ruff (check + format) clean
- [x] Zero new suppressions

## Changes at a glance

- `src/ado_git_repo_insights/persistence/migrations.py` — `migrate_v6_to_v7` + v7 DDL constants + `MIGRATIONS[7]`
- `src/ado_git_repo_insights/persistence/models.py` — `SCHEMA_SQL` initial schema_version seed 6 → 7
- `src/ado_git_repo_insights/persistence/database.py` — `teams`, `team_members` added to `_REQUIRED_TABLES` (not `_FUNDAMENTAL_TABLES`)
- `src/ado_git_repo_insights/cli.py` — `_extract_teams` helper + one call-site; `ExtractionSummary` added to TYPE_CHECKING
- `src/ado_git_repo_insights/types.py` — `AdoTeamMember` rewritten to flat IdentityRef shape; dead `AdoIdentity` removed
- `tests/unit/test_schema_migration.py` — new `TestMigrationV6ToV7TeamsTables` class (8 tests including strict DDL parity, rollback atomicity, silent-skip `_REQUIRED_TABLES` defense); 7 post-connect `== 6` → `== 7` assertion sweep
- `tests/unit/test_schema_migration_v4_to_v5.py` — 3 post-connect assertions swept to v7
- `tests/unit/test_team_extraction.py` — new `TestExtractTeamsPipeline` class (9 tests); existing 5 mocks updated to real flat shape; orphan `IMPLEMENTATION_DETAILS.md` reference dropped
- `docs/internal/teams-live-qa.md` — incident-driven runbook
- `.test-floor-contract.json` — ratchet 2026 → 2043 (+17 cumulative)

## Risks accepted

- **Pipeline 15 vintage**: current artifact is post-Phase-3.3, so the v6→v7 migration is a no-op on it (teams tables already in `SCHEMA_SQL` on fresh DB). Unit tests cover the true legacy path; live QA covers the idempotent path. Structural guard against any future instance filed as #304.
- **Admin status**: not tracked. The `GET /_apis/projects/{p}/teams/{t}/members` endpoint does not return `isTeamAdmin`; `upsert_team_member` defaults `is_team_admin=False`. Adding admin tracking would require a separate endpoint call per team.

Closes #296

Refs: #252, #295, #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)
