### PR TITLE
fix(#294): correct ML setup guides to real ADO task YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,10 @@ Enable ML-powered forecasting for PR throughput and cycle times. **Zero-config**
 Add to your pipeline YAML:
 
 ```yaml
-build-aggregates:
-    run-predictions: true
+- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enablePredictions: true
 ```
 
 Features:
@@ -257,9 +259,11 @@ Enable AI-powered analysis of your PR patterns. Requires an OpenAI API key.
 3. Add to your pipeline YAML:
 
 ```yaml
-build-aggregates:
-    run-insights: true
-    openai-api-key: $(OPENAI_API_KEY)
+- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enableInsights: true
+    openaiApiKey: $(OPENAI_API_KEY)
 ```
 
 Features:

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -5541,11 +5541,15 @@ var PRInsightsDashboard = (() => {
   // ../ui/modules/ml/setup-guides.ts
   var yamlStore = /* @__PURE__ */ new Map();
   var delegatedContainers = /* @__PURE__ */ new WeakSet();
-  var PREDICTIONS_YAML = `build-aggregates:
-  run-predictions: true`;
-  var INSIGHTS_YAML = `build-aggregates:
-  run-insights: true
-  openai-api-key: $(OPENAI_API_KEY)`;
+  var PREDICTIONS_YAML = `- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enablePredictions: true`;
+  var INSIGHTS_YAML = `- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enableInsights: true
+    openaiApiKey: $(OPENAI_API_KEY)`;
   async function copyToClipboard(text) {
     if (navigator.clipboard && navigator.clipboard.writeText) {
       await navigator.clipboard.writeText(text);
@@ -5644,7 +5648,7 @@ var PRInsightsDashboard = (() => {
       </div>
       <div class="setup-note">
         <span class="note-icon">\u{1F4A1}</span>
-        <span>Uses NumPy-based linear regression. For Prophet support, install the optional dependency.</span>
+        <span>Uses NumPy-based linear regression. For Prophet (seasonality detection), install <code>pip install "ado-git-repo-insights[ml]"</code>. See <a href="https://github.com/oddessentials/ado-git-repo-insights/blob/main/docs/user-guide/enable-ml-features.md#for-predictions" target="_blank" rel="noopener">platform prerequisites</a>.</span>
       </div>
     </div>
   `;

--- a/docs/internal/manual-walkthrough.md
+++ b/docs/internal/manual-walkthrough.md
@@ -211,6 +211,6 @@ Commit the updated file.
 ## See Also
 
 - [Testing Guide](../development/testing.md) -- Automated test organization and patterns
-- [Enable ML Features](enable-ml-features.md) -- Detailed ML pipeline setup
+- [Enable ML Features](../user-guide/enable-ml-features.md) -- Detailed ML pipeline setup
 - [CLI Command Reference](../reference/cli-reference.md) -- All commands and options
 - [Backfill Comments Live QA](backfill-live-qa.md) -- Scenario-level manual QA for the `backfill-comments` subcommand and its extension task wrapper

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -752,5 +752,5 @@ ado-insights build-aggregates --db data.db --out ./dataset --enable-insights
 - [CLI User Guide](../user-guide/local-cli.md) — Getting started with the CLI
 - [CSV Schema](csv-schema.md) — Output file format details
 - [Troubleshooting](../user-guide/troubleshooting.md) — Common issues
-- [Enable ML Features](../internal/enable-ml-features.md) — Detailed ML setup guide
+- [Enable ML Features](../user-guide/enable-ml-features.md) — Detailed ML setup guide
 - [Manual Testing Walkthrough](../internal/manual-walkthrough.md) — End-to-end CLI scenarios

--- a/docs/user-guide/enable-ml-features.md
+++ b/docs/user-guide/enable-ml-features.md
@@ -27,8 +27,10 @@ Predictions work out-of-the-box with **no additional dependencies**. The built-i
 Simply enable predictions - no Prophet installation needed:
 
 ```yaml
-build-aggregates:
-  run-predictions: true
+- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enablePredictions: true
 ```
 
 **Enhanced Option (Prophet)**

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -5541,11 +5541,15 @@ var PRInsightsDashboard = (() => {
   // ../ui/modules/ml/setup-guides.ts
   var yamlStore = /* @__PURE__ */ new Map();
   var delegatedContainers = /* @__PURE__ */ new WeakSet();
-  var PREDICTIONS_YAML = `build-aggregates:
-  run-predictions: true`;
-  var INSIGHTS_YAML = `build-aggregates:
-  run-insights: true
-  openai-api-key: $(OPENAI_API_KEY)`;
+  var PREDICTIONS_YAML = `- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enablePredictions: true`;
+  var INSIGHTS_YAML = `- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enableInsights: true
+    openaiApiKey: $(OPENAI_API_KEY)`;
   async function copyToClipboard(text) {
     if (navigator.clipboard && navigator.clipboard.writeText) {
       await navigator.clipboard.writeText(text);
@@ -5644,7 +5648,7 @@ var PRInsightsDashboard = (() => {
       </div>
       <div class="setup-note">
         <span class="note-icon">\u{1F4A1}</span>
-        <span>Uses NumPy-based linear regression. For Prophet support, install the optional dependency.</span>
+        <span>Uses NumPy-based linear regression. For Prophet (seasonality detection), install <code>pip install "ado-git-repo-insights[ml]"</code>. See <a href="https://github.com/oddessentials/ado-git-repo-insights/blob/main/docs/user-guide/enable-ml-features.md#for-predictions" target="_blank" rel="noopener">platform prerequisites</a>.</span>
       </div>
     </div>
   `;

--- a/extension/tests/modules/ml/setup-guides.test.ts
+++ b/extension/tests/modules/ml/setup-guides.test.ts
@@ -27,7 +27,9 @@ describe("setup-guides", () => {
 
     it("includes predictions YAML snippet", () => {
       const html = renderPredictionsSetupGuide();
-      expect(html).toContain("run-predictions: true");
+      expect(html).toContain("- task: ExtractPullRequests@2");
+      expect(html).toContain("enablePredictions: true");
+      expect(html).toContain("generateAggregates: true");
     });
 
     it("includes copy button with aria-label", () => {
@@ -57,8 +59,9 @@ describe("setup-guides", () => {
 
     it("includes insights YAML snippet", () => {
       const html = renderInsightsSetupGuide();
-      expect(html).toContain("run-insights: true");
-      expect(html).toContain("openai-api-key: $(OPENAI_API_KEY)");
+      expect(html).toContain("- task: ExtractPullRequests@2");
+      expect(html).toContain("enableInsights: true");
+      expect(html).toContain("openaiApiKey: $(OPENAI_API_KEY)");
     });
 
     it("includes copy button with unique ID", () => {
@@ -449,15 +452,17 @@ describe("setup-guides", () => {
   describe("getters", () => {
     it("getPredictionsYaml returns correct YAML", () => {
       const yaml = getPredictionsYaml();
-      expect(yaml).toContain("build-aggregates:");
-      expect(yaml).toContain("run-predictions: true");
+      expect(yaml).toContain("- task: ExtractPullRequests@2");
+      expect(yaml).toContain("generateAggregates: true");
+      expect(yaml).toContain("enablePredictions: true");
     });
 
     it("getInsightsYaml returns correct YAML", () => {
       const yaml = getInsightsYaml();
-      expect(yaml).toContain("build-aggregates:");
-      expect(yaml).toContain("run-insights: true");
-      expect(yaml).toContain("openai-api-key: $(OPENAI_API_KEY)");
+      expect(yaml).toContain("- task: ExtractPullRequests@2");
+      expect(yaml).toContain("generateAggregates: true");
+      expect(yaml).toContain("enableInsights: true");
+      expect(yaml).toContain("openaiApiKey: $(OPENAI_API_KEY)");
     });
   });
 

--- a/extension/ui/modules/ml/setup-guides.ts
+++ b/extension/ui/modules/ml/setup-guides.ts
@@ -16,15 +16,19 @@ const delegatedContainers = new WeakSet<HTMLElement>();
 /**
  * YAML snippet for enabling predictions in ADO pipeline.
  */
-const PREDICTIONS_YAML = `build-aggregates:
-  run-predictions: true`;
+const PREDICTIONS_YAML = `- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enablePredictions: true`;
 
 /**
  * YAML snippet for enabling AI insights in ADO pipeline.
  */
-const INSIGHTS_YAML = `build-aggregates:
-  run-insights: true
-  openai-api-key: $(OPENAI_API_KEY)`;
+const INSIGHTS_YAML = `- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enableInsights: true
+    openaiApiKey: $(OPENAI_API_KEY)`;
 
 /**
  * Copy text to clipboard with fallback for older browsers.
@@ -169,7 +173,7 @@ export function renderPredictionsSetupGuide(): string {
       </div>
       <div class="setup-note">
         <span class="note-icon">💡</span>
-        <span>Uses NumPy-based linear regression. For Prophet support, install the optional dependency.</span>
+        <span>Uses NumPy-based linear regression. For Prophet (seasonality detection), install <code>pip install "ado-git-repo-insights[ml]"</code>. See <a href="https://github.com/oddessentials/ado-git-repo-insights/blob/main/docs/user-guide/enable-ml-features.md#for-predictions" target="_blank" rel="noopener">platform prerequisites</a>.</span>
       </div>
     </div>
   `;

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -5541,11 +5541,15 @@ var PRInsightsDashboard = (() => {
   // ../ui/modules/ml/setup-guides.ts
   var yamlStore = /* @__PURE__ */ new Map();
   var delegatedContainers = /* @__PURE__ */ new WeakSet();
-  var PREDICTIONS_YAML = `build-aggregates:
-  run-predictions: true`;
-  var INSIGHTS_YAML = `build-aggregates:
-  run-insights: true
-  openai-api-key: $(OPENAI_API_KEY)`;
+  var PREDICTIONS_YAML = `- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enablePredictions: true`;
+  var INSIGHTS_YAML = `- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enableInsights: true
+    openaiApiKey: $(OPENAI_API_KEY)`;
   async function copyToClipboard(text) {
     if (navigator.clipboard && navigator.clipboard.writeText) {
       await navigator.clipboard.writeText(text);
@@ -5644,7 +5648,7 @@ var PRInsightsDashboard = (() => {
       </div>
       <div class="setup-note">
         <span class="note-icon">\u{1F4A1}</span>
-        <span>Uses NumPy-based linear regression. For Prophet support, install the optional dependency.</span>
+        <span>Uses NumPy-based linear regression. For Prophet (seasonality detection), install <code>pip install "ado-git-repo-insights[ml]"</code>. See <a href="https://github.com/oddessentials/ado-git-repo-insights/blob/main/docs/user-guide/enable-ml-features.md#for-predictions" target="_blank" rel="noopener">platform prerequisites</a>.</span>
       </div>
     </div>
   `;

--- a/tests/unit/test_setup_guides.py
+++ b/tests/unit/test_setup_guides.py
@@ -14,38 +14,47 @@ class TestYamlSnippetGeneration:
     def test_predictions_yaml_snippet_structure(self) -> None:
         """Predictions YAML snippet should have correct structure."""
         yaml_snippet = """
-build-aggregates:
-  run-predictions: true
+- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enablePredictions: true
 """.strip()
 
-        assert "build-aggregates" in yaml_snippet
-        assert "run-predictions: true" in yaml_snippet
+        assert "- task: ExtractPullRequests@2" in yaml_snippet
+        assert "enablePredictions: true" in yaml_snippet
+        assert "generateAggregates: true" in yaml_snippet
 
     def test_predictions_yaml_indentation(self) -> None:
-        """Predictions YAML should use 2-space indentation."""
-        yaml_snippet = """build-aggregates:
-  run-predictions: true"""
+        """Predictions YAML should use 2-space indentation under inputs."""
+        yaml_snippet = """- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enablePredictions: true"""
 
         lines = yaml_snippet.split("\n")
-        # Second line should start with 2 spaces
-        assert lines[1].startswith("  ")
-        assert not lines[1].startswith("    ")  # Not 4 spaces
+        # inputs: is 2 spaces under the task
+        assert lines[1].startswith("  inputs:")
+        # input keys are 4 spaces (2-space indent under inputs:)
+        assert lines[2].startswith("    ")
+        assert not lines[2].startswith("      ")  # Not 6 spaces
 
     def test_insights_yaml_snippet_structure(self) -> None:
         """Insights YAML snippet should have correct structure."""
         yaml_snippet = """
-build-aggregates:
-  run-insights: true
-  openai-api-key: $(OPENAI_API_KEY)
+- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enableInsights: true
+    openaiApiKey: $(OPENAI_API_KEY)
 """.strip()
 
-        assert "build-aggregates" in yaml_snippet
-        assert "run-insights: true" in yaml_snippet
-        assert "openai-api-key" in yaml_snippet
+        assert "- task: ExtractPullRequests@2" in yaml_snippet
+        assert "enableInsights: true" in yaml_snippet
+        assert "openaiApiKey" in yaml_snippet
 
     def test_insights_yaml_uses_variable_syntax(self) -> None:
         """Insights YAML should use ADO variable syntax for API key."""
-        yaml_snippet = "openai-api-key: $(OPENAI_API_KEY)"
+        yaml_snippet = "openaiApiKey: $(OPENAI_API_KEY)"
 
         # Should use $() syntax for ADO variables
         assert "$(" in yaml_snippet
@@ -56,14 +65,16 @@ build-aggregates:
     def test_combined_yaml_snippet(self) -> None:
         """Combined YAML should enable both features."""
         yaml_snippet = """
-build-aggregates:
-  run-predictions: true
-  run-insights: true
-  openai-api-key: $(OPENAI_API_KEY)
+- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enablePredictions: true
+    enableInsights: true
+    openaiApiKey: $(OPENAI_API_KEY)
 """.strip()
 
-        assert "run-predictions: true" in yaml_snippet
-        assert "run-insights: true" in yaml_snippet
+        assert "enablePredictions: true" in yaml_snippet
+        assert "enableInsights: true" in yaml_snippet
 
 
 class TestClipboardCopy:
@@ -75,8 +86,10 @@ class TestClipboardCopy:
 
     def test_copy_content_is_string(self) -> None:
         """Content to copy should be a string."""
-        content = """build-aggregates:
-  run-predictions: true"""
+        content = """- task: ExtractPullRequests@2
+  inputs:
+    generateAggregates: true
+    enablePredictions: true"""
 
         assert isinstance(content, str)
         assert len(content) > 0
@@ -120,7 +133,7 @@ class TestSetupGuideContent:
         guide = {
             "title": "Enable Predictions",
             "description": "Add time-series forecasting to your pipeline.",
-            "yaml": "run-predictions: true",
+            "yaml": "enablePredictions: true",
         }
 
         assert len(guide["description"]) > 10
@@ -154,7 +167,7 @@ class TestSetupGuideContent:
         guide = {
             "title": "Enable Predictions",
             "description": "Zero-config forecasting. No API key required.",
-            "yaml": "run-predictions: true",
+            "yaml": "enablePredictions: true",
         }
 
         # Should not require API key


### PR DESCRIPTION
## Summary

Closes #294.

- Replace the fictional `build-aggregates:` / `run-predictions:` / `run-insights:` / `openai-api-key:` YAML in the Predictions and Insights setup guides with the real `- task: ExtractPullRequests@2` / `inputs: { generateAggregates, enablePredictions, enableInsights, openaiApiKey }` shape that `extension/tasks/extract-prs/task.json` actually parses.
- Name the optional extra in the Prophet tip (`pip install "ado-git-repo-insights[ml]"`) and link to the platform-prerequisites doc, per the "tell the user what to install" requirement in #294.
- Move `docs/internal/enable-ml-features.md` → `docs/user-guide/enable-ml-features.md` so the dashboard can link to it publicly; fix the self-contradicting YAML snippet inside that file (lines 30-32 contradicted lines 73-85). Updated two cross-links (`docs/internal/manual-walkthrough.md`, `docs/reference/cli-reference.md`).
- Apply the same YAML corrections to `README.md` (predictions + insights snippets were both broken).
- Rewrite `tests/unit/test_setup_guides.py` and `extension/tests/modules/ml/setup-guides.test.ts` so assertions verify the real YAML shape, not the fictional one. Test counts preserved per INVARIANTS #26.
- Regenerate `docs/dashboard.js`, `src/ado_git_repo_insights/ui_bundle/dashboard.js`, and `extension/tests/fixtures/broken-docs/dashboard.js` via `python scripts/manage_generated_artifacts.py sync --scope all`.

## Test plan

- [x] Python setup-guides tests pass (13/13) — `python scripts/run_pytest.py tests/unit/test_setup_guides.py`
- [x] TypeScript setup-guides tests pass (36/36) — `pnpm exec jest tests/modules/ml/setup-guides.test.ts`
- [x] UI bundle regeneration produces no fictional keys — `grep -E "run-predictions|run-insights|build-aggregates:" docs/dashboard.js` returns nothing
- [x] Local preflight gate exits 0 — `python scripts/run_pr_preflight.py --allow-local-degraded`
- [x] Generated-artifact parity gate passes (`manage_generated_artifacts.py verify --scope all` clean after staging)
- [x] CI green on all lanes

## Out of scope / follow-ups

During preflight, 34 unrelated test failures surfaced; all pre-existing and orthogonal to this change. Captured as #309 (`test_doctor` exit-code contract mismatch) and #310 (`test_setup_path` chmod-ignored-by-root). A separate one-line fix for the synthetic-dataset suite is filed in its own PR.

https://claude.ai/code/session_01MV3mGzxLvrDTePYn1FFJwT