### PR TITLE
test(synthetic): use sys.executable for generator subprocess

### DIFF
--- a/tests/unit/test_synthetic_dataset.py
+++ b/tests/unit/test_synthetic_dataset.py
@@ -51,7 +51,7 @@ def _build_generator_args(
         / "generate-synthetic-dataset.py"
     )
     args = [
-        "python",
+        sys.executable,
         str(script),
         "--pr-count",
         str(pr_count),


### PR DESCRIPTION
## Summary

`tests/unit/test_synthetic_dataset.py:54` hardcoded bare `"python"` as the subprocess command, forcing PATH resolution to an arbitrary interpreter rather than the one running pytest. When bare `python` is absent (common on Windows CI agents, where `py.exe` / `python3` are canonical) or points to a system interpreter without `numpy`, all 32 generator-backed tests fail.

Switched to `sys.executable`, which always points to the currently-running interpreter. The same file already uses this pattern at lines 887-888 and 900-901 — this aligns the third subprocess site with the existing convention.

Strictly more cross-OS-robust; not a behaviour change on CI where `python` on PATH already is the test interpreter.

## Test plan

- [x] `python -m pytest tests/unit/test_synthetic_dataset.py --no-cov` — 40/40 pass locally under venv Python 3.12
- [x] CI green on `ubuntu-latest`, `windows-latest`, `macos-latest` lanes
- [x] Ratchet gate unaffected (test collection count unchanged — test-body change only)

## Context

Not tied to a specific issue. Discovered while running the local preflight during #294 work; two other pre-existing failures surfaced at the same time and are tracked independently in #309 and #310.

https://claude.ai/code/session_01MV3mGzxLvrDTePYn1FFJwT