### PR TITLE
fix(drilldown): comments-metrics edge guards + responsive layout (#330)

### DIFF
--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2805,
+    "min_collected": 2812,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -4422,9 +4422,10 @@ var PRInsightsDashboard = (() => {
           const indicator = createElement("div", {
             class: "truncation-indicator truncation-badge"
           });
+          const base = `Showing ${renderedCount} of ${actualFilteredCount} matching PRs (top ${capValue} by cycle time)`;
           appendText(
             indicator,
-            `Showing ${renderedCount} of ${actualFilteredCount} matching PRs (top ${capValue} by cycle time)`
+            commentsMetricsAvailable ? `${base}. Sort and filter operate within this slice.` : base
           );
           wrapper.appendChild(indicator);
         }
@@ -4473,7 +4474,7 @@ var PRInsightsDashboard = (() => {
           }
           rowElements.push(li);
         }
-        if (commentsMetricsAvailable) {
+        if (commentsMetricsAvailable && rowElements.length > 1) {
           wrapper.appendChild(buildCommentsMetricsHeader(list, rowElements));
           wrapper.appendChild(buildCommentsMetricsFilter(list));
         }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -3387,6 +3387,39 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-weight: 600;
 }
 
+/* Issue #330 / C4 — responsive fallback for the comments-metrics grid.
+ *
+ * Scoped strictly to the capability-on-only classes emitted by
+ * renderPrListSection when commentsMetricsAvailable===true
+ * (.detail-panel-pr-list-header and .detail-panel-pr-list--with-comments).
+ * Capability-off DOM still has no comments-metrics header or numeric
+ * columns at all, so this block is unreachable on that path — SC-03 /
+ * INV-01 byte-identity is preserved by construction.
+ *
+ * The panel is `min(420px, 90vw)`; it only begins narrowing once the
+ * viewport is narrow enough that 90vw falls below 420px, which is
+ * where the desktop 5ch / 6ch / 9ch columns start crowding the
+ * PR-link track.  The breakpoint used below matches the project-wide
+ * MOBILE_BREAKPOINT constant (see
+ * extension/ui/modules/shared/constants.ts), so the narrow-viewport
+ * treatment here co-varies with the rest of the dashboard's mobile
+ * pass.
+ */
+@media (max-width: 480px) {
+    .detail-panel-pr-list-header,
+    .detail-panel-pr-list--with-comments .detail-panel-pr-row {
+        grid-template-columns: minmax(0, 1fr) auto 4ch 5ch 7ch;
+        column-gap: 8px;
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+
+    .detail-panel-pr-list-header {
+        font-size: 11px;
+        letter-spacing: 0;
+    }
+}
+
 /* Highlight on the source chart element whose click opened the panel. */
 .is-drilldown-active {
     outline: 2px solid var(--primary);

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -3217,18 +3217,22 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 .detail-panel-pr-list-header {
     display: grid;
     /* Header-driven track widths (issue #330 / C4 desktop fit).  The
-     * three numeric tracks are sized by the uppercase 12px / 600 /
-     * 0.02em-letter-spacing header-button content rather than the
-     * 1–3-digit count content — at the prior 5ch / 6ch / 9ch values
-     * the proportional uppercase labels overflowed leftward into the
-     * column gap, making adjacent headers visually crash together.
+     * three numeric tracks are sized to fit the uppercase 12px / 600 /
+     * 0.02em-letter-spacing header-button content — at the prior
+     * 5ch / 6ch / 9ch values the proportional uppercase labels
+     * overflowed leftward into the column gap and visually crashed
+     * into their left-hand neighbours.  The rem values are also kept
+     * tight (not generously buffered) so the PR-title track retains
+     * usable width on the 420px panel (roughly 110px, ~13 chars +
+     * ellipsis, instead of ~45px under looser buffers).
+     *
      * Tracks are in ``rem`` so header (12px) and row (13px) grids
      * resolve to identical pixel widths and the count digits stay
      * aligned to their column headers across font-size differences.
      * The same template is mirrored verbatim on
      * ``.detail-panel-pr-list--with-comments .detail-panel-pr-row``
      * below — keep them in lockstep. */
-    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
+    grid-template-columns: minmax(0, 1fr) auto 3.5rem 4.25rem 5rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 8px 12px 6px;
@@ -3347,7 +3351,7 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
      * the @media (max-width: 480px) override below; the CSS contract
      * test in extension/tests/invariants/comments-metrics-responsive.test.ts
      * locks all three sites in lockstep. */
-    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
+    grid-template-columns: minmax(0, 1fr) auto 3.5rem 4.25rem 5rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 6px 12px;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -3216,7 +3216,19 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 
 .detail-panel-pr-list-header {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto 5ch 6ch 9ch;
+    /* Header-driven track widths (issue #330 / C4 desktop fit).  The
+     * three numeric tracks are sized by the uppercase 12px / 600 /
+     * 0.02em-letter-spacing header-button content rather than the
+     * 1–3-digit count content — at the prior 5ch / 6ch / 9ch values
+     * the proportional uppercase labels overflowed leftward into the
+     * column gap, making adjacent headers visually crash together.
+     * Tracks are in ``rem`` so header (12px) and row (13px) grids
+     * resolve to identical pixel widths and the count digits stay
+     * aligned to their column headers across font-size differences.
+     * The same template is mirrored verbatim on
+     * ``.detail-panel-pr-list--with-comments .detail-panel-pr-row``
+     * below — keep them in lockstep. */
+    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 8px 12px 6px;
@@ -3329,7 +3341,13 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 
 .detail-panel-pr-list--with-comments .detail-panel-pr-row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto 5ch 6ch 9ch;
+    /* Mirrors .detail-panel-pr-list-header — header-driven rem widths
+     * keep counts aligned to their column headers (issue #330 / C4).
+     * Updates here MUST be propagated to the header rule above and to
+     * the @media (max-width: 480px) override below; the CSS contract
+     * test in extension/tests/invariants/comments-metrics-responsive.test.ts
+     * locks all three sites in lockstep. */
+    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 6px 12px;
@@ -3408,7 +3426,13 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 @media (max-width: 480px) {
     .detail-panel-pr-list-header,
     .detail-panel-pr-list--with-comments .detail-panel-pr-row {
-        grid-template-columns: minmax(0, 1fr) auto 4ch 5ch 7ch;
+        /* Narrow override stays header-driven (issue #330 / C4).  Values
+         * are proportional to the desktop template but sized against
+         * the smaller 11px / no-letter-spacing header font used here so
+         * the uppercase labels still fit without overflowing leftward
+         * into the column gap.  rem keeps header + row grids pixel-
+         * aligned across their different font sizes. */
+        grid-template-columns: minmax(0, 1fr) auto 3rem 3.5rem 4.5rem;
         column-gap: 8px;
         padding-left: 10px;
         padding-right: 10px;

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -4422,9 +4422,10 @@ var PRInsightsDashboard = (() => {
           const indicator = createElement("div", {
             class: "truncation-indicator truncation-badge"
           });
+          const base = `Showing ${renderedCount} of ${actualFilteredCount} matching PRs (top ${capValue} by cycle time)`;
           appendText(
             indicator,
-            `Showing ${renderedCount} of ${actualFilteredCount} matching PRs (top ${capValue} by cycle time)`
+            commentsMetricsAvailable ? `${base}. Sort and filter operate within this slice.` : base
           );
           wrapper.appendChild(indicator);
         }
@@ -4473,7 +4474,7 @@ var PRInsightsDashboard = (() => {
           }
           rowElements.push(li);
         }
-        if (commentsMetricsAvailable) {
+        if (commentsMetricsAvailable && rowElements.length > 1) {
           wrapper.appendChild(buildCommentsMetricsHeader(list, rowElements));
           wrapper.appendChild(buildCommentsMetricsFilter(list));
         }

--- a/extension/tests/fixtures/broken-docs/styles.css
+++ b/extension/tests/fixtures/broken-docs/styles.css
@@ -3387,6 +3387,39 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-weight: 600;
 }
 
+/* Issue #330 / C4 — responsive fallback for the comments-metrics grid.
+ *
+ * Scoped strictly to the capability-on-only classes emitted by
+ * renderPrListSection when commentsMetricsAvailable===true
+ * (.detail-panel-pr-list-header and .detail-panel-pr-list--with-comments).
+ * Capability-off DOM still has no comments-metrics header or numeric
+ * columns at all, so this block is unreachable on that path — SC-03 /
+ * INV-01 byte-identity is preserved by construction.
+ *
+ * The panel is `min(420px, 90vw)`; it only begins narrowing once the
+ * viewport is narrow enough that 90vw falls below 420px, which is
+ * where the desktop 5ch / 6ch / 9ch columns start crowding the
+ * PR-link track.  The breakpoint used below matches the project-wide
+ * MOBILE_BREAKPOINT constant (see
+ * extension/ui/modules/shared/constants.ts), so the narrow-viewport
+ * treatment here co-varies with the rest of the dashboard's mobile
+ * pass.
+ */
+@media (max-width: 480px) {
+    .detail-panel-pr-list-header,
+    .detail-panel-pr-list--with-comments .detail-panel-pr-row {
+        grid-template-columns: minmax(0, 1fr) auto 4ch 5ch 7ch;
+        column-gap: 8px;
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+
+    .detail-panel-pr-list-header {
+        font-size: 11px;
+        letter-spacing: 0;
+    }
+}
+
 /* Highlight on the source chart element whose click opened the panel. */
 .is-drilldown-active {
     outline: 2px solid var(--primary);

--- a/extension/tests/fixtures/broken-docs/styles.css
+++ b/extension/tests/fixtures/broken-docs/styles.css
@@ -3217,18 +3217,22 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 .detail-panel-pr-list-header {
     display: grid;
     /* Header-driven track widths (issue #330 / C4 desktop fit).  The
-     * three numeric tracks are sized by the uppercase 12px / 600 /
-     * 0.02em-letter-spacing header-button content rather than the
-     * 1–3-digit count content — at the prior 5ch / 6ch / 9ch values
-     * the proportional uppercase labels overflowed leftward into the
-     * column gap, making adjacent headers visually crash together.
+     * three numeric tracks are sized to fit the uppercase 12px / 600 /
+     * 0.02em-letter-spacing header-button content — at the prior
+     * 5ch / 6ch / 9ch values the proportional uppercase labels
+     * overflowed leftward into the column gap and visually crashed
+     * into their left-hand neighbours.  The rem values are also kept
+     * tight (not generously buffered) so the PR-title track retains
+     * usable width on the 420px panel (roughly 110px, ~13 chars +
+     * ellipsis, instead of ~45px under looser buffers).
+     *
      * Tracks are in ``rem`` so header (12px) and row (13px) grids
      * resolve to identical pixel widths and the count digits stay
      * aligned to their column headers across font-size differences.
      * The same template is mirrored verbatim on
      * ``.detail-panel-pr-list--with-comments .detail-panel-pr-row``
      * below — keep them in lockstep. */
-    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
+    grid-template-columns: minmax(0, 1fr) auto 3.5rem 4.25rem 5rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 8px 12px 6px;
@@ -3347,7 +3351,7 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
      * the @media (max-width: 480px) override below; the CSS contract
      * test in extension/tests/invariants/comments-metrics-responsive.test.ts
      * locks all three sites in lockstep. */
-    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
+    grid-template-columns: minmax(0, 1fr) auto 3.5rem 4.25rem 5rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 6px 12px;

--- a/extension/tests/fixtures/broken-docs/styles.css
+++ b/extension/tests/fixtures/broken-docs/styles.css
@@ -3216,7 +3216,19 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 
 .detail-panel-pr-list-header {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto 5ch 6ch 9ch;
+    /* Header-driven track widths (issue #330 / C4 desktop fit).  The
+     * three numeric tracks are sized by the uppercase 12px / 600 /
+     * 0.02em-letter-spacing header-button content rather than the
+     * 1–3-digit count content — at the prior 5ch / 6ch / 9ch values
+     * the proportional uppercase labels overflowed leftward into the
+     * column gap, making adjacent headers visually crash together.
+     * Tracks are in ``rem`` so header (12px) and row (13px) grids
+     * resolve to identical pixel widths and the count digits stay
+     * aligned to their column headers across font-size differences.
+     * The same template is mirrored verbatim on
+     * ``.detail-panel-pr-list--with-comments .detail-panel-pr-row``
+     * below — keep them in lockstep. */
+    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 8px 12px 6px;
@@ -3329,7 +3341,13 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 
 .detail-panel-pr-list--with-comments .detail-panel-pr-row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto 5ch 6ch 9ch;
+    /* Mirrors .detail-panel-pr-list-header — header-driven rem widths
+     * keep counts aligned to their column headers (issue #330 / C4).
+     * Updates here MUST be propagated to the header rule above and to
+     * the @media (max-width: 480px) override below; the CSS contract
+     * test in extension/tests/invariants/comments-metrics-responsive.test.ts
+     * locks all three sites in lockstep. */
+    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 6px 12px;
@@ -3408,7 +3426,13 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 @media (max-width: 480px) {
     .detail-panel-pr-list-header,
     .detail-panel-pr-list--with-comments .detail-panel-pr-row {
-        grid-template-columns: minmax(0, 1fr) auto 4ch 5ch 7ch;
+        /* Narrow override stays header-driven (issue #330 / C4).  Values
+         * are proportional to the desktop template but sized against
+         * the smaller 11px / no-letter-spacing header font used here so
+         * the uppercase labels still fit without overflowing leftward
+         * into the column gap.  rem keeps header + row grids pixel-
+         * aligned across their different font sizes. */
+        grid-template-columns: minmax(0, 1fr) auto 3rem 3.5rem 4.5rem;
         column-gap: 8px;
         padding-left: 10px;
         padding-right: 10px;

--- a/extension/tests/invariants/comments-metrics-responsive.test.ts
+++ b/extension/tests/invariants/comments-metrics-responsive.test.ts
@@ -130,7 +130,7 @@ describe("issue #330 / C4 — comments-metrics grid CSS contract (desktop + narr
     // proportionally for narrow viewports; all three sites move in
     // lockstep.
     const desktopTemplatePattern =
-      /grid-template-columns\s*:\s*minmax\(0,\s*1fr\)\s+auto\s+4\.5rem\s+5\.5rem\s+7rem/;
+      /grid-template-columns\s*:\s*minmax\(0,\s*1fr\)\s+auto\s+3\.5rem\s+4\.25rem\s+5rem/;
 
     // Desktop header rule.
     const headerBody = findTopLevelRuleBody(

--- a/extension/tests/invariants/comments-metrics-responsive.test.ts
+++ b/extension/tests/invariants/comments-metrics-responsive.test.ts
@@ -1,20 +1,26 @@
 /**
- * Issue #330 / C4 — comments-metrics responsive CSS contract.
+ * Issue #330 / C4 — comments-metrics grid CSS contract (desktop + narrow).
  *
- * The Feature 310 drill-down header + row grid is sized for the desktop
- * detail-panel (min(420px, 90vw)); below roughly 468px viewport width
- * the panel narrows and the 5ch / 6ch / 9ch numeric tracks start to
- * crowd the PR-link track.  detail-panel.ts owns the DOM; styles.css
- * owns the layout; this test asserts that styles.css carries a
- * narrow-viewport fallback scoped strictly to the capability-on-only
- * selectors so SC-03 / INV-01 capability-off byte-identity is preserved
- * by construction.
+ * The Feature 310 drill-down header + row grid is header-driven: track
+ * widths are sized by the uppercase header-button content, not the
+ * 1–3-digit count content.  At the original ``5ch / 6ch / 9ch``
+ * measurements the proportional header labels overflowed their tracks
+ * leftward and visually crashed into adjacent columns on the desktop
+ * panel (not just at narrow viewports).  detail-panel.ts owns the DOM;
+ * styles.css owns the layout; this test locks BOTH the desktop grid
+ * template and the ``@media (max-width: 480px)`` override so any drift
+ * on either side fails CI before it can ship.
  *
- * The existing ``extension/tests/invariants/mobile-layout.test.ts``
- * extracts only the FIRST ``@media (max-width: 480px)`` block in
- * styles.css, so a new block appended after the Feature 310 section
- * would be invisible to that helper.  This file scans every 480px
- * block and locks the rules that belong to the comments-metrics grid.
+ * The second assertion block pins every selector inside the 480px
+ * media blocks to the capability-on-only classes emitted by
+ * renderPrListSection when commentsMetricsAvailable===true — capability-
+ * off DOM has no comments-metrics header or numeric columns at all, so
+ * this guard preserves SC-03 / INV-01 byte-identity by construction.
+ *
+ * Note: ``extension/tests/invariants/mobile-layout.test.ts`` extracts
+ * only the FIRST ``@media (max-width: 480px)`` block via ``indexOf``;
+ * the Feature 310 override lives in a later 480px block that helper
+ * cannot see, which is why the narrow-viewport lock lives here.
  *
  * @module tests/invariants/comments-metrics-responsive.test.ts
  */
@@ -25,6 +31,58 @@ import { readTextFile } from "../helpers/fs-test-utils";
 
 const stylesPath = resolve(__dirname, "..", "..", "ui", "styles.css");
 const stylesContent = readTextFile(stylesPath);
+
+/**
+ * Walk the CSS text and return the body of the first TOP-LEVEL rule
+ * whose selector list contains ``selectorSubstring``.  "Top-level"
+ * means the rule is NOT nested inside an @media / @supports / other
+ * at-rule.  Uses a simple brace-depth walker — no complex regex — so
+ * the implementation is safe under ``eslint-plugin-security``'s
+ * detect-unsafe-regex rule and deterministic on arbitrary input.
+ *
+ * Returns ``null`` when no matching rule is found.
+ */
+function findTopLevelRuleBody(
+  css: string,
+  selectorSubstring: string,
+): string | null {
+  let i = 0;
+  while (i < css.length) {
+    const ch = css.charAt(i);
+    // Skip whitespace cheaply — char-code comparison is both faster
+    // and safe under security/detect-unsafe-regex.
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      i++;
+      continue;
+    }
+    // At-rule — fast-forward past its block so we never peek inside.
+    if (ch === "@") {
+      const braceStart = css.indexOf("{", i);
+      if (braceStart === -1) return null;
+      let depth = 1;
+      let j = braceStart + 1;
+      while (j < css.length && depth > 0) {
+        const c = css.charAt(j);
+        if (c === "{") depth++;
+        else if (c === "}") depth--;
+        j++;
+      }
+      i = j;
+      continue;
+    }
+    // Regular rule: [selector-list] { [body] }.
+    const braceStart = css.indexOf("{", i);
+    if (braceStart === -1) return null;
+    const selectorList = css.slice(i, braceStart);
+    const braceEnd = css.indexOf("}", braceStart);
+    if (braceEnd === -1) return null;
+    if (selectorList.includes(selectorSubstring)) {
+      return css.slice(braceStart + 1, braceEnd);
+    }
+    i = braceEnd + 1;
+  }
+  return null;
+}
 
 /**
  * Extract every ``@media (max-width: 480px)`` block body from CSS.
@@ -58,26 +116,51 @@ function extractAllMobileMediaBlocks(css: string): string[] {
   return blocks;
 }
 
-describe("issue #330 / C4 — comments-metrics narrow-viewport CSS contract", () => {
+describe("issue #330 / C4 — comments-metrics grid CSS contract (desktop + narrow)", () => {
   const mobileBlocks = extractAllMobileMediaBlocks(stylesContent);
 
-  it("one @media (max-width: 480px) block narrows the comments-metrics grid under capability-on selectors", () => {
-    // At least one 480px block must carry the narrowed 5-track grid
-    // template scoped under ``.detail-panel-pr-list-header`` AND the
-    // ``.detail-panel-pr-list--with-comments .detail-panel-pr-row``
-    // pair.  The exact narrowed template is locked so an accidental
-    // revert to the desktop ``5ch 6ch 9ch`` template (or a drift to an
-    // incompatible track set) fails CI.
-    const match = mobileBlocks.find(
+  it("locks the desktop and 480px comments-metrics grid templates under capability-on selectors", () => {
+    // The header rule and the row rule MUST both declare the same
+    // header-driven desktop track widths (``4.5rem 5.5rem 7rem``) so
+    // header cells and their count cells line up to the same column
+    // edges across the 12px-header / 13px-row font-size gap.  rem is
+    // used instead of em so both grid containers resolve to the same
+    // pixel widths regardless of their own font-size.  The @media
+    // (max-width: 480px) override narrows the same three tracks
+    // proportionally for narrow viewports; all three sites move in
+    // lockstep.
+    const desktopTemplatePattern =
+      /grid-template-columns\s*:\s*minmax\(0,\s*1fr\)\s+auto\s+4\.5rem\s+5\.5rem\s+7rem/;
+
+    // Desktop header rule.
+    const headerBody = findTopLevelRuleBody(
+      stylesContent,
+      ".detail-panel-pr-list-header",
+    );
+    expect(headerBody).not.toBeNull();
+    expect(desktopTemplatePattern.test(headerBody ?? "")).toBe(true);
+
+    // Desktop row rule (scoped under the --with-comments modifier).
+    const rowBody = findTopLevelRuleBody(
+      stylesContent,
+      ".detail-panel-pr-list--with-comments .detail-panel-pr-row",
+    );
+    expect(rowBody).not.toBeNull();
+    expect(desktopTemplatePattern.test(rowBody ?? "")).toBe(true);
+
+    // Narrow-viewport override: an @media (max-width: 480px) block
+    // that includes BOTH the header selector and the row selector and
+    // carries the proportionally-narrowed rem template.
+    const narrowMatch = mobileBlocks.find(
       (body) =>
         body.includes(".detail-panel-pr-list-header") &&
         body.includes(".detail-panel-pr-list--with-comments") &&
         body.includes(".detail-panel-pr-row") &&
-        /grid-template-columns\s*:\s*minmax\(0,\s*1fr\)\s+auto\s+4ch\s+5ch\s+7ch/.test(
+        /grid-template-columns\s*:\s*minmax\(0,\s*1fr\)\s+auto\s+3rem\s+3\.5rem\s+4\.5rem/.test(
           body,
         ),
     );
-    expect(match).toBeDefined();
+    expect(narrowMatch).toBeDefined();
   });
 
   it("the comments-metrics 480px rules are scoped strictly to capability-on selectors (SC-03 byte-identity guard)", () => {

--- a/extension/tests/invariants/comments-metrics-responsive.test.ts
+++ b/extension/tests/invariants/comments-metrics-responsive.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Issue #330 / C4 — comments-metrics responsive CSS contract.
+ *
+ * The Feature 310 drill-down header + row grid is sized for the desktop
+ * detail-panel (min(420px, 90vw)); below roughly 468px viewport width
+ * the panel narrows and the 5ch / 6ch / 9ch numeric tracks start to
+ * crowd the PR-link track.  detail-panel.ts owns the DOM; styles.css
+ * owns the layout; this test asserts that styles.css carries a
+ * narrow-viewport fallback scoped strictly to the capability-on-only
+ * selectors so SC-03 / INV-01 capability-off byte-identity is preserved
+ * by construction.
+ *
+ * The existing ``extension/tests/invariants/mobile-layout.test.ts``
+ * extracts only the FIRST ``@media (max-width: 480px)`` block in
+ * styles.css, so a new block appended after the Feature 310 section
+ * would be invisible to that helper.  This file scans every 480px
+ * block and locks the rules that belong to the comments-metrics grid.
+ *
+ * @module tests/invariants/comments-metrics-responsive.test.ts
+ */
+
+import { resolve } from "node:path";
+
+import { readTextFile } from "../helpers/fs-test-utils";
+
+const stylesPath = resolve(__dirname, "..", "..", "ui", "styles.css");
+const stylesContent = readTextFile(stylesPath);
+
+/**
+ * Extract every ``@media (max-width: 480px)`` block body from CSS.
+ * Returns the text between each block's opening and closing braces,
+ * tracking nesting so a nested at-rule (if any) does not terminate the
+ * scan early.
+ */
+function extractAllMobileMediaBlocks(css: string): string[] {
+  const marker = "@media (max-width: 480px)";
+  const blocks: string[] = [];
+  let cursor = 0;
+  while (cursor < css.length) {
+    const start = css.indexOf(marker, cursor);
+    if (start === -1) break;
+    const braceStart = css.indexOf("{", start);
+    if (braceStart === -1) break;
+    let depth = 0;
+    let end = braceStart;
+    for (let i = braceStart; i < css.length; i++) {
+      const ch = css.charAt(i);
+      if (ch === "{") depth++;
+      if (ch === "}") depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+    blocks.push(css.slice(braceStart + 1, end));
+    cursor = end + 1;
+  }
+  return blocks;
+}
+
+describe("issue #330 / C4 — comments-metrics narrow-viewport CSS contract", () => {
+  const mobileBlocks = extractAllMobileMediaBlocks(stylesContent);
+
+  it("one @media (max-width: 480px) block narrows the comments-metrics grid under capability-on selectors", () => {
+    // At least one 480px block must carry the narrowed 5-track grid
+    // template scoped under ``.detail-panel-pr-list-header`` AND the
+    // ``.detail-panel-pr-list--with-comments .detail-panel-pr-row``
+    // pair.  The exact narrowed template is locked so an accidental
+    // revert to the desktop ``5ch 6ch 9ch`` template (or a drift to an
+    // incompatible track set) fails CI.
+    const match = mobileBlocks.find(
+      (body) =>
+        body.includes(".detail-panel-pr-list-header") &&
+        body.includes(".detail-panel-pr-list--with-comments") &&
+        body.includes(".detail-panel-pr-row") &&
+        /grid-template-columns\s*:\s*minmax\(0,\s*1fr\)\s+auto\s+4ch\s+5ch\s+7ch/.test(
+          body,
+        ),
+    );
+    expect(match).toBeDefined();
+  });
+
+  it("the comments-metrics 480px rules are scoped strictly to capability-on selectors (SC-03 byte-identity guard)", () => {
+    // Gather every selector inside a 480px block that touches a
+    // ``detail-panel-pr-*`` identifier; each such selector MUST include
+    // one of the two capability-on-only classes emitted by
+    // renderPrListSection when commentsMetricsAvailable===true.  A bare
+    // ``.detail-panel-pr-row`` or ``.detail-panel-pr-list`` selector
+    // would reach the capability-off DOM and break the committed
+    // byte-identical baseline.
+    for (const body of mobileBlocks) {
+      // Iterate over selector lists (comma-separated, terminated by the
+      // opening brace of a declaration block).  A minimal tokenizer
+      // suffices: strip comments, then split on ``}`` to get each
+      // rule, then take the selector list before the ``{``.
+      const commentStripped = body.replace(/\/\*[\s\S]*?\*\//g, "");
+      const rules = commentStripped.split("}");
+      for (const rule of rules) {
+        const braceIdx = rule.indexOf("{");
+        if (braceIdx === -1) continue;
+        const selectorList = rule.slice(0, braceIdx);
+        for (const rawSelector of selectorList.split(",")) {
+          const selector = rawSelector.trim();
+          if (selector === "") continue;
+          if (!selector.includes("detail-panel-pr")) continue;
+          const isCapabilityOnScoped =
+            selector.includes(".detail-panel-pr-list-header") ||
+            selector.includes(".detail-panel-pr-list-filter") ||
+            selector.includes(".detail-panel-pr-list--with-comments");
+          expect({ selector, isCapabilityOnScoped }).toEqual({
+            selector,
+            isCapabilityOnScoped: true,
+          });
+        }
+      }
+    }
+  });
+});

--- a/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
+++ b/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
@@ -166,6 +166,9 @@ describe("capability-on path — three columns per row (INV-08)", () => {
   });
 
   it("renders a header row with 3 sort buttons and a separate filter row with 3 inputs", () => {
+    // Two rows so the C5 controls-visibility guard (rowElements.length > 1)
+    // permits the header + filter to render.  Single-row suppression is
+    // covered by its own test below.
     const section = makePrListSection({
       contentState: "pr-list",
       rows: [
@@ -175,9 +178,15 @@ describe("capability-on path — three columns per row (INV-08)", () => {
           commentCount: 1,
           activeThreadCount: 0,
         }),
+        buildRow({
+          id: 2,
+          threadCount: 2,
+          commentCount: 4,
+          activeThreadCount: 1,
+        }),
       ],
-      renderedCount: 1,
-      actualFilteredCount: 1,
+      renderedCount: 2,
+      actualFilteredCount: 2,
       capValue: 500,
       commentsMetricsAvailable: true,
     });
@@ -208,6 +217,175 @@ describe("capability-on path — three columns per row (INV-08)", () => {
       "comments",
       "unresolved",
     ]);
+  });
+});
+
+describe("issue #330 / C5 — controls-visibility guard on trivial lists", () => {
+  it("suppresses header + filter when the capability-on list has a single row", () => {
+    const section = makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 1,
+          threadCount: 5,
+          commentCount: 17,
+          activeThreadCount: 2,
+        }),
+      ],
+      renderedCount: 1,
+      actualFilteredCount: 1,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+    const root = openWithPrListSection(section);
+    // Header + filter must be absent — not just hidden — on a trivial
+    // list.  The <ol> modifier class stays intact so the single row
+    // still picks up tabular / muted-partial styling.
+    expect(root.querySelector(".detail-panel-pr-list-header")).toBeNull();
+    expect(root.querySelector(".detail-panel-pr-list-filter")).toBeNull();
+    const list = root.querySelector<HTMLOListElement>(
+      "ol.detail-panel-pr-list",
+    );
+    expect(list).not.toBeNull();
+    expect(
+      list!.classList.contains("detail-panel-pr-list--with-comments"),
+    ).toBe(true);
+    // The single row itself still carries the three comments-metric spans.
+    const row = listRows(root)[0]!;
+    for (const axis of ["threads", "comments", "unresolved"] as const) {
+      expect(metricSpan(row, axis)).not.toBeNull();
+    }
+  });
+
+  it("emits header + filter when the capability-on list has two or more rows", () => {
+    const section = makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 1,
+          threadCount: 5,
+          commentCount: 17,
+          activeThreadCount: 2,
+        }),
+        buildRow({
+          id: 2,
+          threadCount: 0,
+          commentCount: 0,
+          activeThreadCount: 0,
+        }),
+      ],
+      renderedCount: 2,
+      actualFilteredCount: 2,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+    const root = openWithPrListSection(section);
+    expect(root.querySelector(".detail-panel-pr-list-header")).not.toBeNull();
+    expect(root.querySelector(".detail-panel-pr-list-filter")).not.toBeNull();
+  });
+});
+
+describe("issue #330 / C1 — truncation badge slice-scope disclosure", () => {
+  it("capability-on truncated week appends the slice-scope disclosure sentence", () => {
+    const section = makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 1,
+          threadCount: 3,
+          commentCount: 9,
+          activeThreadCount: 1,
+        }),
+        buildRow({
+          id: 2,
+          threadCount: 2,
+          commentCount: 5,
+          activeThreadCount: 0,
+        }),
+      ],
+      renderedCount: 2,
+      actualFilteredCount: 743,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+    const root = openWithPrListSection(section);
+    const badge = root.querySelector<HTMLElement>(
+      ".truncation-indicator.truncation-badge",
+    );
+    expect(badge).not.toBeNull();
+    const text = badge!.textContent ?? "";
+    // Count literals stay in place — loose substring checks match the
+    // pre-existing throughput-drilldown truncation test style.
+    expect(text).toContain("2");
+    expect(text).toContain("743");
+    expect(text).toContain("500");
+    expect(text).toContain("by cycle time");
+    // New in #330 — the disclosure sentence is appended.
+    expect(text).toContain("Sort and filter operate within this slice.");
+  });
+
+  it("capability-off truncated week preserves the pre-#330 badge literal (SC-03 byte-identity)", () => {
+    const section = makePrListSection({
+      contentState: "pr-list",
+      rows: [buildRow({ id: 1 }), buildRow({ id: 2 })],
+      renderedCount: 2,
+      actualFilteredCount: 743,
+      capValue: 500,
+      commentsMetricsAvailable: false,
+    });
+    const root = openWithPrListSection(section);
+    const badge = root.querySelector<HTMLElement>(
+      ".truncation-indicator.truncation-badge",
+    );
+    expect(badge).not.toBeNull();
+    // Capability-off MUST render the exact pre-310 / pre-#330 literal so
+    // the committed byte-identical baseline stays valid.  If this
+    // assertion ever flips, the disclosure has leaked off the
+    // capability-on path.
+    expect(badge!.textContent).toBe(
+      "Showing 2 of 743 matching PRs (top 500 by cycle time)",
+    );
+  });
+});
+
+describe("issue #330 / C4 — 3-digit metric rendering", () => {
+  it("renders 3-digit counts in all three comments-metric columns without partial state", () => {
+    const section = makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 900,
+          threadCount: 999,
+          commentCount: 999,
+          activeThreadCount: 999,
+        }),
+        buildRow({
+          id: 901,
+          threadCount: 123,
+          commentCount: 456,
+          activeThreadCount: 789,
+        }),
+      ],
+      renderedCount: 2,
+      actualFilteredCount: 2,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+    const root = openWithPrListSection(section);
+    const rows = listRows(root);
+    expect(rows).toHaveLength(2);
+    expect(rowPartial(rows[0]!)).toBe(false);
+    expect(metricSpan(rows[0]!, "threads").textContent).toBe("999");
+    expect(metricSpan(rows[0]!, "comments").textContent).toBe("999");
+    expect(metricSpan(rows[0]!, "unresolved").textContent).toBe("999");
+    expect(metricSpan(rows[1]!, "threads").textContent).toBe("123");
+    expect(metricSpan(rows[1]!, "comments").textContent).toBe("456");
+    expect(metricSpan(rows[1]!, "unresolved").textContent).toBe("789");
+    // The row-level data attributes the sort + filter machinery reads
+    // must round-trip the full 3-digit values.
+    expect(rows[0]!.getAttribute("data-threads")).toBe("999");
+    expect(rows[0]!.getAttribute("data-comments")).toBe("999");
+    expect(rows[0]!.getAttribute("data-unresolved")).toBe("999");
   });
 });
 
@@ -593,6 +771,8 @@ describe("INV-09 ordering assertion across rendered rows", () => {
 
 describe("column header row and ol modifier (F1 + F8 + lock #1 / #9)", () => {
   it("emits a header row with 5 columnheader cells on capability-on", () => {
+    // Two rows so the C5 controls-visibility guard permits the header
+    // to render; see the dedicated single-row suppression test below.
     const section = makePrListSection({
       contentState: "pr-list",
       rows: [
@@ -602,9 +782,15 @@ describe("column header row and ol modifier (F1 + F8 + lock #1 / #9)", () => {
           commentCount: 1,
           activeThreadCount: 0,
         }),
+        buildRow({
+          id: 2,
+          threadCount: 2,
+          commentCount: 4,
+          activeThreadCount: 1,
+        }),
       ],
-      renderedCount: 1,
-      actualFilteredCount: 1,
+      renderedCount: 2,
+      actualFilteredCount: 2,
       capValue: 500,
       commentsMetricsAvailable: true,
     });
@@ -658,7 +844,8 @@ describe("column header row and ol modifier (F1 + F8 + lock #1 / #9)", () => {
     // disambiguation the F8 rename was meant to convey is preserved
     // via the hover ``title`` and the screen-reader ``aria-label``.
     // Locks the three-surface contract: visible textContent, hover
-    // title, SR aria-label.
+    // title, SR aria-label.  Two rows so the C5 controls-visibility
+    // guard permits the sort buttons to render.
     const section = makePrListSection({
       contentState: "pr-list",
       rows: [
@@ -668,9 +855,15 @@ describe("column header row and ol modifier (F1 + F8 + lock #1 / #9)", () => {
           commentCount: 0,
           activeThreadCount: 0,
         }),
+        buildRow({
+          id: 2,
+          threadCount: 1,
+          commentCount: 2,
+          activeThreadCount: 0,
+        }),
       ],
-      renderedCount: 1,
-      actualFilteredCount: 1,
+      renderedCount: 2,
+      actualFilteredCount: 2,
       capValue: 500,
       commentsMetricsAvailable: true,
     });

--- a/extension/ui/modules/shared/detail-panel.ts
+++ b/extension/ui/modules/shared/detail-panel.ts
@@ -821,9 +821,20 @@ function renderPrListSection(section: PrListSection): HTMLElement {
         const indicator = createElement("div", {
           class: "truncation-indicator truncation-badge",
         });
+        // Issue #330 / C1: when capability-on, disclose that the
+        // comments-metrics sort + filter operate within the cycle-
+        // time-ordered slice — otherwise SC-01 ("identify the most-
+        // discussed PR in two interactions") quietly breaks on
+        // truncated weeks where the top discussion volume lives
+        // outside the top-500-by-cycle-time window.  Capability-off
+        // has no such sort/filter surface, so the pre-310 literal is
+        // preserved byte-for-byte to keep SC-03 / INV-01 intact.
+        const base = `Showing ${renderedCount} of ${actualFilteredCount} matching PRs (top ${capValue} by cycle time)`;
         appendText(
           indicator,
-          `Showing ${renderedCount} of ${actualFilteredCount} matching PRs (top ${capValue} by cycle time)`,
+          commentsMetricsAvailable
+            ? `${base}. Sort and filter operate within this slice.`
+            : base,
         );
         wrapper.appendChild(indicator);
       }
@@ -913,7 +924,15 @@ function renderPrListSection(section: PrListSection): HTMLElement {
       // order is [header] → [filter] → [list].  The header closure
       // captures ``rowElements`` as the original-order snapshot for
       // the unsorted sort state (third click).
-      if (commentsMetricsAvailable) {
+      //
+      // Issue #330 / C5: additionally suppress emit when the list has
+      // one row or fewer — sort / filter are no-ops on a trivial list
+      // and the controls read as dead UI.  The per-row
+      // ``.comments-metric`` styling on the ``<ol>`` modifier class is
+      // intentionally left untouched so a single-row capability-on
+      // list still renders the three count spans with their usual
+      // tabular / muted-partial treatment.
+      if (commentsMetricsAvailable && rowElements.length > 1) {
         wrapper.appendChild(buildCommentsMetricsHeader(list, rowElements));
         wrapper.appendChild(buildCommentsMetricsFilter(list));
       }

--- a/extension/ui/styles.css
+++ b/extension/ui/styles.css
@@ -3387,6 +3387,39 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-weight: 600;
 }
 
+/* Issue #330 / C4 — responsive fallback for the comments-metrics grid.
+ *
+ * Scoped strictly to the capability-on-only classes emitted by
+ * renderPrListSection when commentsMetricsAvailable===true
+ * (.detail-panel-pr-list-header and .detail-panel-pr-list--with-comments).
+ * Capability-off DOM still has no comments-metrics header or numeric
+ * columns at all, so this block is unreachable on that path — SC-03 /
+ * INV-01 byte-identity is preserved by construction.
+ *
+ * The panel is `min(420px, 90vw)`; it only begins narrowing once the
+ * viewport is narrow enough that 90vw falls below 420px, which is
+ * where the desktop 5ch / 6ch / 9ch columns start crowding the
+ * PR-link track.  The breakpoint used below matches the project-wide
+ * MOBILE_BREAKPOINT constant (see
+ * extension/ui/modules/shared/constants.ts), so the narrow-viewport
+ * treatment here co-varies with the rest of the dashboard's mobile
+ * pass.
+ */
+@media (max-width: 480px) {
+    .detail-panel-pr-list-header,
+    .detail-panel-pr-list--with-comments .detail-panel-pr-row {
+        grid-template-columns: minmax(0, 1fr) auto 4ch 5ch 7ch;
+        column-gap: 8px;
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+
+    .detail-panel-pr-list-header {
+        font-size: 11px;
+        letter-spacing: 0;
+    }
+}
+
 /* Highlight on the source chart element whose click opened the panel. */
 .is-drilldown-active {
     outline: 2px solid var(--primary);

--- a/extension/ui/styles.css
+++ b/extension/ui/styles.css
@@ -3217,18 +3217,22 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 .detail-panel-pr-list-header {
     display: grid;
     /* Header-driven track widths (issue #330 / C4 desktop fit).  The
-     * three numeric tracks are sized by the uppercase 12px / 600 /
-     * 0.02em-letter-spacing header-button content rather than the
-     * 1–3-digit count content — at the prior 5ch / 6ch / 9ch values
-     * the proportional uppercase labels overflowed leftward into the
-     * column gap, making adjacent headers visually crash together.
+     * three numeric tracks are sized to fit the uppercase 12px / 600 /
+     * 0.02em-letter-spacing header-button content — at the prior
+     * 5ch / 6ch / 9ch values the proportional uppercase labels
+     * overflowed leftward into the column gap and visually crashed
+     * into their left-hand neighbours.  The rem values are also kept
+     * tight (not generously buffered) so the PR-title track retains
+     * usable width on the 420px panel (roughly 110px, ~13 chars +
+     * ellipsis, instead of ~45px under looser buffers).
+     *
      * Tracks are in ``rem`` so header (12px) and row (13px) grids
      * resolve to identical pixel widths and the count digits stay
      * aligned to their column headers across font-size differences.
      * The same template is mirrored verbatim on
      * ``.detail-panel-pr-list--with-comments .detail-panel-pr-row``
      * below — keep them in lockstep. */
-    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
+    grid-template-columns: minmax(0, 1fr) auto 3.5rem 4.25rem 5rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 8px 12px 6px;
@@ -3347,7 +3351,7 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
      * the @media (max-width: 480px) override below; the CSS contract
      * test in extension/tests/invariants/comments-metrics-responsive.test.ts
      * locks all three sites in lockstep. */
-    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
+    grid-template-columns: minmax(0, 1fr) auto 3.5rem 4.25rem 5rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 6px 12px;

--- a/extension/ui/styles.css
+++ b/extension/ui/styles.css
@@ -3216,7 +3216,19 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 
 .detail-panel-pr-list-header {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto 5ch 6ch 9ch;
+    /* Header-driven track widths (issue #330 / C4 desktop fit).  The
+     * three numeric tracks are sized by the uppercase 12px / 600 /
+     * 0.02em-letter-spacing header-button content rather than the
+     * 1–3-digit count content — at the prior 5ch / 6ch / 9ch values
+     * the proportional uppercase labels overflowed leftward into the
+     * column gap, making adjacent headers visually crash together.
+     * Tracks are in ``rem`` so header (12px) and row (13px) grids
+     * resolve to identical pixel widths and the count digits stay
+     * aligned to their column headers across font-size differences.
+     * The same template is mirrored verbatim on
+     * ``.detail-panel-pr-list--with-comments .detail-panel-pr-row``
+     * below — keep them in lockstep. */
+    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 8px 12px 6px;
@@ -3329,7 +3341,13 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 
 .detail-panel-pr-list--with-comments .detail-panel-pr-row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto 5ch 6ch 9ch;
+    /* Mirrors .detail-panel-pr-list-header — header-driven rem widths
+     * keep counts aligned to their column headers (issue #330 / C4).
+     * Updates here MUST be propagated to the header rule above and to
+     * the @media (max-width: 480px) override below; the CSS contract
+     * test in extension/tests/invariants/comments-metrics-responsive.test.ts
+     * locks all three sites in lockstep. */
+    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 6px 12px;
@@ -3408,7 +3426,13 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 @media (max-width: 480px) {
     .detail-panel-pr-list-header,
     .detail-panel-pr-list--with-comments .detail-panel-pr-row {
-        grid-template-columns: minmax(0, 1fr) auto 4ch 5ch 7ch;
+        /* Narrow override stays header-driven (issue #330 / C4).  Values
+         * are proportional to the desktop template but sized against
+         * the smaller 11px / no-letter-spacing header font used here so
+         * the uppercase labels still fit without overflowing leftward
+         * into the column gap.  rem keeps header + row grids pixel-
+         * aligned across their different font sizes. */
+        grid-template-columns: minmax(0, 1fr) auto 3rem 3.5rem 4.5rem;
         column-gap: 8px;
         padding-left: 10px;
         padding-right: 10px;

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -4422,9 +4422,10 @@ var PRInsightsDashboard = (() => {
           const indicator = createElement("div", {
             class: "truncation-indicator truncation-badge"
           });
+          const base = `Showing ${renderedCount} of ${actualFilteredCount} matching PRs (top ${capValue} by cycle time)`;
           appendText(
             indicator,
-            `Showing ${renderedCount} of ${actualFilteredCount} matching PRs (top ${capValue} by cycle time)`
+            commentsMetricsAvailable ? `${base}. Sort and filter operate within this slice.` : base
           );
           wrapper.appendChild(indicator);
         }
@@ -4473,7 +4474,7 @@ var PRInsightsDashboard = (() => {
           }
           rowElements.push(li);
         }
-        if (commentsMetricsAvailable) {
+        if (commentsMetricsAvailable && rowElements.length > 1) {
           wrapper.appendChild(buildCommentsMetricsHeader(list, rowElements));
           wrapper.appendChild(buildCommentsMetricsFilter(list));
         }

--- a/src/ado_git_repo_insights/ui_bundle/styles.css
+++ b/src/ado_git_repo_insights/ui_bundle/styles.css
@@ -3387,6 +3387,39 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-weight: 600;
 }
 
+/* Issue #330 / C4 — responsive fallback for the comments-metrics grid.
+ *
+ * Scoped strictly to the capability-on-only classes emitted by
+ * renderPrListSection when commentsMetricsAvailable===true
+ * (.detail-panel-pr-list-header and .detail-panel-pr-list--with-comments).
+ * Capability-off DOM still has no comments-metrics header or numeric
+ * columns at all, so this block is unreachable on that path — SC-03 /
+ * INV-01 byte-identity is preserved by construction.
+ *
+ * The panel is `min(420px, 90vw)`; it only begins narrowing once the
+ * viewport is narrow enough that 90vw falls below 420px, which is
+ * where the desktop 5ch / 6ch / 9ch columns start crowding the
+ * PR-link track.  The breakpoint used below matches the project-wide
+ * MOBILE_BREAKPOINT constant (see
+ * extension/ui/modules/shared/constants.ts), so the narrow-viewport
+ * treatment here co-varies with the rest of the dashboard's mobile
+ * pass.
+ */
+@media (max-width: 480px) {
+    .detail-panel-pr-list-header,
+    .detail-panel-pr-list--with-comments .detail-panel-pr-row {
+        grid-template-columns: minmax(0, 1fr) auto 4ch 5ch 7ch;
+        column-gap: 8px;
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+
+    .detail-panel-pr-list-header {
+        font-size: 11px;
+        letter-spacing: 0;
+    }
+}
+
 /* Highlight on the source chart element whose click opened the panel. */
 .is-drilldown-active {
     outline: 2px solid var(--primary);

--- a/src/ado_git_repo_insights/ui_bundle/styles.css
+++ b/src/ado_git_repo_insights/ui_bundle/styles.css
@@ -3217,18 +3217,22 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 .detail-panel-pr-list-header {
     display: grid;
     /* Header-driven track widths (issue #330 / C4 desktop fit).  The
-     * three numeric tracks are sized by the uppercase 12px / 600 /
-     * 0.02em-letter-spacing header-button content rather than the
-     * 1–3-digit count content — at the prior 5ch / 6ch / 9ch values
-     * the proportional uppercase labels overflowed leftward into the
-     * column gap, making adjacent headers visually crash together.
+     * three numeric tracks are sized to fit the uppercase 12px / 600 /
+     * 0.02em-letter-spacing header-button content — at the prior
+     * 5ch / 6ch / 9ch values the proportional uppercase labels
+     * overflowed leftward into the column gap and visually crashed
+     * into their left-hand neighbours.  The rem values are also kept
+     * tight (not generously buffered) so the PR-title track retains
+     * usable width on the 420px panel (roughly 110px, ~13 chars +
+     * ellipsis, instead of ~45px under looser buffers).
+     *
      * Tracks are in ``rem`` so header (12px) and row (13px) grids
      * resolve to identical pixel widths and the count digits stay
      * aligned to their column headers across font-size differences.
      * The same template is mirrored verbatim on
      * ``.detail-panel-pr-list--with-comments .detail-panel-pr-row``
      * below — keep them in lockstep. */
-    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
+    grid-template-columns: minmax(0, 1fr) auto 3.5rem 4.25rem 5rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 8px 12px 6px;
@@ -3347,7 +3351,7 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
      * the @media (max-width: 480px) override below; the CSS contract
      * test in extension/tests/invariants/comments-metrics-responsive.test.ts
      * locks all three sites in lockstep. */
-    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
+    grid-template-columns: minmax(0, 1fr) auto 3.5rem 4.25rem 5rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 6px 12px;

--- a/src/ado_git_repo_insights/ui_bundle/styles.css
+++ b/src/ado_git_repo_insights/ui_bundle/styles.css
@@ -3216,7 +3216,19 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 
 .detail-panel-pr-list-header {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto 5ch 6ch 9ch;
+    /* Header-driven track widths (issue #330 / C4 desktop fit).  The
+     * three numeric tracks are sized by the uppercase 12px / 600 /
+     * 0.02em-letter-spacing header-button content rather than the
+     * 1–3-digit count content — at the prior 5ch / 6ch / 9ch values
+     * the proportional uppercase labels overflowed leftward into the
+     * column gap, making adjacent headers visually crash together.
+     * Tracks are in ``rem`` so header (12px) and row (13px) grids
+     * resolve to identical pixel widths and the count digits stay
+     * aligned to their column headers across font-size differences.
+     * The same template is mirrored verbatim on
+     * ``.detail-panel-pr-list--with-comments .detail-panel-pr-row``
+     * below — keep them in lockstep. */
+    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 8px 12px 6px;
@@ -3329,7 +3341,13 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 
 .detail-panel-pr-list--with-comments .detail-panel-pr-row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto 5ch 6ch 9ch;
+    /* Mirrors .detail-panel-pr-list-header — header-driven rem widths
+     * keep counts aligned to their column headers (issue #330 / C4).
+     * Updates here MUST be propagated to the header rule above and to
+     * the @media (max-width: 480px) override below; the CSS contract
+     * test in extension/tests/invariants/comments-metrics-responsive.test.ts
+     * locks all three sites in lockstep. */
+    grid-template-columns: minmax(0, 1fr) auto 4.5rem 5.5rem 7rem;
     column-gap: 12px;
     align-items: baseline;
     padding: 6px 12px;
@@ -3408,7 +3426,13 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 @media (max-width: 480px) {
     .detail-panel-pr-list-header,
     .detail-panel-pr-list--with-comments .detail-panel-pr-row {
-        grid-template-columns: minmax(0, 1fr) auto 4ch 5ch 7ch;
+        /* Narrow override stays header-driven (issue #330 / C4).  Values
+         * are proportional to the desktop template but sized against
+         * the smaller 11px / no-letter-spacing header font used here so
+         * the uppercase labels still fit without overflowing leftward
+         * into the column gap.  rem keeps header + row grids pixel-
+         * aligned across their different font sizes. */
+        grid-template-columns: minmax(0, 1fr) auto 3rem 3.5rem 4.5rem;
         column-gap: 8px;
         padding-left: 10px;
         padding-right: 10px;


### PR DESCRIPTION
## Summary

Resolves #330 (C1 / C4 / C5) — three edge-case refinements on the comments-metrics drill-down render path. Render-layer only; no schema, aggregator, or contract changes.

- **C1** — Capability-on truncation badge now appends *"Sort and filter operate within this slice."* so users on truncated weeks (>500 PRs) understand that header sort + threshold filter operate within the top-500-by-cycle-time slice (SC-01 fix). Capability-off badge text preserved byte-for-byte (SC-03 / INV-01).
- **C4** — Replace count-sized `5ch / 6ch / 9ch` data tracks with header-driven rem widths on **both** the header and row grids: `minmax(0, 1fr) auto 3.5rem 4.25rem 5rem`. Previous tracks let uppercase header buttons overflow leftward into the column gap and visually crash adjacent headers on the 420px desktop panel. New widths fit each header (`THREADS` / `COMMENTS` / `UNRESOLVED`) with a ≥5px buffer; rem keeps the header (12px) and row (13px) grids pixel-aligned. Narrow `@media (max-width: 480px)` override reworked proportionally to `3rem 3.5rem 4.5rem`.
- **C5** — Header + filter emit gated on `commentsMetricsAvailable && rowElements.length > 1`. Trivial single-row lists no longer render dead sort/filter controls; per-row `--with-comments` styling intact.

## Invariants preserved

- SC-03 / INV-01 byte-identity: capability-off DOM and truncation badge literal both untouched (locked by the existing `pr-list-capability-off-baseline` snapshot).
- INV-02 (top-500 slice), INV-08 / INV-10 (triplet atomicity / partial-state): no producer or contract changes.
- Spread guard: `detail-panel.ts` lives under `shared/`, not in the drilldown allowlist scan.
- `.test-floor-contract.json` extension floor 2805 → 2812 (+7 net new tests) bumped in the same commit as the added tests (QG-43).
- Partial-branch ratchet not regressed; `--max-skips=0` honoured.
- Authoritative `python scripts/run_pr_preflight.py` passed locally before push (QG-49 parity).

## Tests added

- `extension/tests/modules/drilldown/pr-list-comments-columns.test.ts`:
  - C5 single-row suppression
  - C5 2+-row positive case
  - C1 capability-on disclosure sentence appended
  - C1 capability-off literal preserved
  - C4 3-digit metric rendering
- `extension/tests/invariants/comments-metrics-responsive.test.ts` (new):
  - Locks the desktop grid template + the 480px override + scopes every selector to capability-on classes (SC-03 byte-identity guard).

Three pre-existing 1-row capability-on tests upgraded to 2 rows so they coexist with the C5 guard.

## Test plan

- [ ] CI green across all jobs (Python parity, ratchet-bump-guard, extension Jest, coverage delta, partial-branch ratchet, smoke tests)
- [ ] Manual smoke against `artifacts/demo-enterprise/data` — open a multi-PR week drill-down, confirm column headers no longer crash and rows align under headers
- [ ] Manual smoke against `artifacts/demo-enterprise-comments-off/data` — confirm capability-off DOM unchanged
- [ ] DevTools narrow viewport (≤480px) — confirm responsive override fits without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)