### PR TITLE
feat(drilldown): comments-metrics controls affordance (#332)

### DIFF
--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2836,
+    "min_collected": 2842,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2824,
+    "min_collected": 2829,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2842,
+    "min_collected": 2845,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2829,
+    "min_collected": 2836,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2845,
+    "min_collected": 2847,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -4837,6 +4837,10 @@ var PRInsightsDashboard = (() => {
     const els = ensurePanelEls();
     const wasOpen = isDetailPanelOpen();
     activeContext = context;
+    if (wasOpen) {
+      dismissAllTooltips();
+      clearOutsideClickListener();
+    }
     if (!wasOpen) {
       openScopedController = installOpenScopedListeners(els);
       applyTopOffset(els.root, openScopedController.signal);

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -4166,6 +4166,16 @@ var PRInsightsDashboard = (() => {
     };
     window.addEventListener(COMPARISON_TOGGLED_EVENT, lifetimeComparisonListener);
   }
+  var outsideClickAbort = null;
+  var outsideClickFrame = null;
+  function clearOutsideClickListener() {
+    outsideClickAbort?.abort();
+    outsideClickAbort = null;
+    if (outsideClickFrame !== null) {
+      cancelAnimationFrame(outsideClickFrame);
+      outsideClickFrame = null;
+    }
+  }
   function ensurePanelEls() {
     if (panelEls && !panelEls.root.isConnected) {
       panelEls = null;
@@ -4445,20 +4455,28 @@ var PRInsightsDashboard = (() => {
     });
     infoIcon.addEventListener("pointerleave", () => {
       dismissAllTooltips();
+      clearOutsideClickListener();
     });
     infoIcon.addEventListener("click", (event) => {
       event.stopPropagation();
       if (document.querySelector(".info-tooltip") !== null) {
         dismissAllTooltips();
+        clearOutsideClickListener();
         return;
       }
       showInfoTooltip(infoIcon, COMMENTS_METRICS_C1_TOOLTIP);
-      requestAnimationFrame(() => {
-        const dismissOnce = () => {
-          dismissAllTooltips();
-          document.removeEventListener("click", dismissOnce);
-        };
-        document.addEventListener("click", dismissOnce);
+      clearOutsideClickListener();
+      outsideClickFrame = requestAnimationFrame(() => {
+        outsideClickFrame = null;
+        outsideClickAbort = new AbortController();
+        document.addEventListener(
+          "click",
+          () => {
+            dismissAllTooltips();
+            clearOutsideClickListener();
+          },
+          { signal: outsideClickAbort.signal, once: true }
+        );
       });
     });
     filterGroup.appendChild(infoIcon);
@@ -4837,6 +4855,7 @@ var PRInsightsDashboard = (() => {
     openScopedController?.abort();
     openScopedController = null;
     dismissAllTooltips();
+    clearOutsideClickListener();
     const trigger = activeContext?.triggerElement ?? null;
     if (focusTrapController) {
       if (trigger && trigger.isConnected) {

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -4041,6 +4041,72 @@ var PRInsightsDashboard = (() => {
     );
   }
 
+  // ../ui/modules/tooltip-manager.ts
+  var scrollDismissController = null;
+  function ensureScrollDismissListener() {
+    if (scrollDismissController) return;
+    scrollDismissController = new AbortController();
+    const { signal } = scrollDismissController;
+    const dismiss = () => dismissAllTooltips();
+    window.addEventListener("scroll", dismiss, { signal, passive: true });
+    window.addEventListener("resize", dismiss, { signal, passive: true });
+  }
+  function releaseScrollDismissListener() {
+    scrollDismissController?.abort();
+    scrollDismissController = null;
+  }
+  function dismissAllTooltips() {
+    const chartTooltip = document.querySelector(".chart-tooltip");
+    if (chartTooltip) chartTooltip.remove();
+    const infoTooltip = document.querySelector(".info-tooltip");
+    if (infoTooltip) infoTooltip.remove();
+    releaseScrollDismissListener();
+  }
+  function positionTooltip(tooltip, targetRect) {
+    tooltip.style.visibility = "hidden";
+    tooltip.style.position = "fixed";
+    document.body.appendChild(tooltip);
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const gap = 8;
+    let top = targetRect.top - tooltipRect.height - gap;
+    if (top < 0) {
+      top = targetRect.bottom + gap;
+    }
+    if (top + tooltipRect.height > window.innerHeight) {
+      top = window.innerHeight - tooltipRect.height - 4;
+    }
+    let left = targetRect.left + targetRect.width / 2 - tooltipRect.width / 2;
+    if (left < 4) {
+      left = 4;
+    }
+    if (left + tooltipRect.width > window.innerWidth - 4) {
+      left = window.innerWidth - tooltipRect.width - 4;
+    }
+    tooltip.style.top = `${top}px`;
+    tooltip.style.left = `${left}px`;
+    tooltip.style.visibility = "";
+  }
+  function showChartTooltip(target, content) {
+    dismissAllTooltips();
+    const tooltip = document.createElement("div");
+    tooltip.className = "chart-tooltip";
+    renderTrustedHtml(tooltip, content);
+    tooltip.style.position = "fixed";
+    const rect = target.getBoundingClientRect();
+    positionTooltip(tooltip, rect);
+    ensureScrollDismissListener();
+  }
+  function showInfoTooltip(target, content) {
+    dismissAllTooltips();
+    const tooltip = document.createElement("div");
+    tooltip.className = "info-tooltip";
+    tooltip.textContent = content;
+    tooltip.style.position = "fixed";
+    const rect = target.getBoundingClientRect();
+    positionTooltip(tooltip, rect);
+    ensureScrollDismissListener();
+  }
+
   // ../ui/modules/shared/detail-panel.ts
   function isPartialPrRow(row) {
     return row.threadCount === null || row.threadCount === void 0;
@@ -4343,6 +4409,7 @@ var PRInsightsDashboard = (() => {
     if (current === "descending") return "ascending";
     return "none";
   }
+  var COMMENTS_METRICS_C1_TOOLTIP = "Counts apply Feature 310's inclusion rules. Threads include unknown-status threads but exclude deleted ones. Comments include system events; deleted comments are excluded. Unresolved counts only threads still in active status. Comments by users missing from the user table are still counted.";
   function buildCommentsMetricsFilter(list) {
     const filterGroup = createElement("div", {
       class: "detail-panel-pr-list-filter",
@@ -4356,6 +4423,35 @@ var PRInsightsDashboard = (() => {
         "Min:"
       )
     );
+    const infoIcon = createElement("button", {
+      type: "button",
+      class: "info-icon-btn",
+      "data-info-tooltip": "comments-metrics-c1",
+      "aria-label": "About these counts"
+    });
+    appendText(infoIcon, "\u2139");
+    infoIcon.addEventListener("pointerenter", () => {
+      showInfoTooltip(infoIcon, COMMENTS_METRICS_C1_TOOLTIP);
+    });
+    infoIcon.addEventListener("pointerleave", () => {
+      dismissAllTooltips();
+    });
+    infoIcon.addEventListener("click", (event) => {
+      event.stopPropagation();
+      if (document.querySelector(".info-tooltip") !== null) {
+        dismissAllTooltips();
+        return;
+      }
+      showInfoTooltip(infoIcon, COMMENTS_METRICS_C1_TOOLTIP);
+      requestAnimationFrame(() => {
+        const dismissOnce = () => {
+          dismissAllTooltips();
+          document.removeEventListener("click", dismissOnce);
+        };
+        document.addEventListener("click", dismissOnce);
+      });
+    });
+    filterGroup.appendChild(infoIcon);
     const filterDescriptors = [];
     for (const axis of COMMENTS_METRICS_AXES) {
       const label = createElement("label", {
@@ -4706,6 +4802,7 @@ var PRInsightsDashboard = (() => {
     panelState = "closing";
     openScopedController?.abort();
     openScopedController = null;
+    dismissAllTooltips();
     const trigger = activeContext?.triggerElement ?? null;
     if (focusTrapController) {
       if (trigger && trigger.isConnected) {
@@ -6796,72 +6893,6 @@ var PRInsightsDashboard = (() => {
         }
         break;
     }
-  }
-
-  // ../ui/modules/tooltip-manager.ts
-  var scrollDismissController = null;
-  function ensureScrollDismissListener() {
-    if (scrollDismissController) return;
-    scrollDismissController = new AbortController();
-    const { signal } = scrollDismissController;
-    const dismiss = () => dismissAllTooltips();
-    window.addEventListener("scroll", dismiss, { signal, passive: true });
-    window.addEventListener("resize", dismiss, { signal, passive: true });
-  }
-  function releaseScrollDismissListener() {
-    scrollDismissController?.abort();
-    scrollDismissController = null;
-  }
-  function dismissAllTooltips() {
-    const chartTooltip = document.querySelector(".chart-tooltip");
-    if (chartTooltip) chartTooltip.remove();
-    const infoTooltip = document.querySelector(".info-tooltip");
-    if (infoTooltip) infoTooltip.remove();
-    releaseScrollDismissListener();
-  }
-  function positionTooltip(tooltip, targetRect) {
-    tooltip.style.visibility = "hidden";
-    tooltip.style.position = "fixed";
-    document.body.appendChild(tooltip);
-    const tooltipRect = tooltip.getBoundingClientRect();
-    const gap = 8;
-    let top = targetRect.top - tooltipRect.height - gap;
-    if (top < 0) {
-      top = targetRect.bottom + gap;
-    }
-    if (top + tooltipRect.height > window.innerHeight) {
-      top = window.innerHeight - tooltipRect.height - 4;
-    }
-    let left = targetRect.left + targetRect.width / 2 - tooltipRect.width / 2;
-    if (left < 4) {
-      left = 4;
-    }
-    if (left + tooltipRect.width > window.innerWidth - 4) {
-      left = window.innerWidth - tooltipRect.width - 4;
-    }
-    tooltip.style.top = `${top}px`;
-    tooltip.style.left = `${left}px`;
-    tooltip.style.visibility = "";
-  }
-  function showChartTooltip(target, content) {
-    dismissAllTooltips();
-    const tooltip = document.createElement("div");
-    tooltip.className = "chart-tooltip";
-    renderTrustedHtml(tooltip, content);
-    tooltip.style.position = "fixed";
-    const rect = target.getBoundingClientRect();
-    positionTooltip(tooltip, rect);
-    ensureScrollDismissListener();
-  }
-  function showInfoTooltip(target, content) {
-    dismissAllTooltips();
-    const tooltip = document.createElement("div");
-    tooltip.className = "info-tooltip";
-    tooltip.textContent = content;
-    tooltip.style.position = "fixed";
-    const rect = target.getBoundingClientRect();
-    positionTooltip(tooltip, rect);
-    ensureScrollDismissListener();
   }
 
   // ../ui/modules/charts.ts

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -4410,7 +4410,17 @@ var PRInsightsDashboard = (() => {
     return "none";
   }
   var COMMENTS_METRICS_C1_TOOLTIP = "Counts apply Feature 310's inclusion rules. Threads include unknown-status threads but exclude deleted ones. Comments include system events; deleted comments are excluded. Unresolved counts only threads still in active status. Comments by users missing from the user table are still counted.";
-  function buildCommentsMetricsFilter(list) {
+  function formatFilterSummary(context, hasActiveThreshold, visibleNumeric) {
+    if (!hasActiveThreshold) {
+      return `Showing all ${context.totalRows} PRs.`;
+    }
+    if (context.partialRowCount === 0) {
+      return `Showing ${visibleNumeric} of ${context.numericTotal} PRs.`;
+    }
+    const noun = context.partialRowCount === 1 ? "row" : "rows";
+    return `Showing ${visibleNumeric} of ${context.numericTotal} PRs. ${context.partialRowCount} partial ${noun} hidden by filter.`;
+  }
+  function buildCommentsMetricsFilter(list, context) {
     const filterGroup = createElement("div", {
       class: "detail-panel-pr-list-filter",
       role: "group",
@@ -4452,6 +4462,12 @@ var PRInsightsDashboard = (() => {
       });
     });
     filterGroup.appendChild(infoIcon);
+    const summary = createElement("p", {
+      class: "detail-panel-pr-list-filter-summary",
+      role: "status",
+      "aria-live": "polite"
+    });
+    appendText(summary, formatFilterSummary(context, false, 0));
     const filterDescriptors = [];
     for (const axis of COMMENTS_METRICS_AXES) {
       const label = createElement("label", {
@@ -4468,13 +4484,13 @@ var PRInsightsDashboard = (() => {
       const descriptor = { input, dataAttr: axis.dataAttr };
       input.addEventListener(
         "input",
-        () => applyFilters(list, filterDescriptors)
+        () => applyFilters(list, filterDescriptors, summary, context)
       );
       label.appendChild(input);
       filterGroup.appendChild(label);
       filterDescriptors.push(descriptor);
     }
-    return filterGroup;
+    return { filterGroup, summary };
   }
   function applySort(list, dataAttr, direction, originalOrder) {
     if (direction === "none") {
@@ -4494,7 +4510,7 @@ var PRInsightsDashboard = (() => {
     });
     for (const item of items) list.appendChild(item);
   }
-  function applyFilters(list, descriptors) {
+  function applyFilters(list, descriptors, summary, context) {
     const thresholds = [];
     for (const desc of descriptors) {
       const raw = desc.input.value.trim();
@@ -4503,6 +4519,8 @@ var PRInsightsDashboard = (() => {
       if (parsed < 0) continue;
       thresholds.push([desc.dataAttr, parsed]);
     }
+    const hasActiveThreshold = thresholds.length > 0;
+    let visibleNumeric = 0;
     for (const child of list.querySelectorAll("li")) {
       let hidden = false;
       for (const [dataAttr, threshold] of thresholds) {
@@ -4520,8 +4538,18 @@ var PRInsightsDashboard = (() => {
         child.setAttribute("hidden", "");
       } else {
         child.removeAttribute("hidden");
+        if (!child.hasAttribute("data-partial")) {
+          visibleNumeric++;
+        }
       }
     }
+    const nextText = formatFilterSummary(
+      context,
+      hasActiveThreshold,
+      visibleNumeric
+    );
+    summary.textContent = "";
+    summary.textContent = nextText;
   }
   function renderPrListSection(section) {
     const wrapper = createElement("section", {
@@ -4628,7 +4656,13 @@ var PRInsightsDashboard = (() => {
           })
         );
         if (sortRowElements !== null) {
-          wrapper.appendChild(buildCommentsMetricsFilter(list));
+          const filterControls = buildCommentsMetricsFilter(list, {
+            totalRows: rows.length,
+            numericTotal: rows.length - partialRowCount,
+            partialRowCount
+          });
+          wrapper.appendChild(filterControls.filterGroup);
+          wrapper.appendChild(filterControls.summary);
         }
         for (const li of rowElements) {
           list.appendChild(li);

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -4281,6 +4281,11 @@ var PRInsightsDashboard = (() => {
     );
     if (!commentsMetricsAvailable) return header;
     const records = [];
+    const sortAnnouncer = createElement("div", {
+      role: "status",
+      "aria-live": "polite",
+      class: "visually-hidden detail-panel-pr-list-sort-announcer"
+    });
     for (const axis of COMMENTS_METRICS_AXES) {
       const cellAttrs = {
         class: `detail-panel-pr-list-header-cell detail-panel-pr-list-header-cell--${axis.key}`,
@@ -4324,7 +4329,12 @@ var PRInsightsDashboard = (() => {
         record.state = nextDirection;
         record.cell.setAttribute("aria-sort", nextDirection);
         applySort(list, axis.dataAttr, nextDirection, originalOrder);
+        sortAnnouncer.textContent = "";
+        sortAnnouncer.textContent = nextDirection === "none" ? "Sort cleared." : `Sorted by ${axis.label.toLowerCase()}, ${nextDirection}.`;
       });
+    }
+    if (withSortButtons) {
+      header.appendChild(sortAnnouncer);
     }
     return header;
   }

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -4837,6 +4837,10 @@ var PRInsightsDashboard = (() => {
     const els = ensurePanelEls();
     const wasOpen = isDetailPanelOpen();
     activeContext = context;
+    if (wasOpen) {
+      dismissAllTooltips();
+      clearOutsideClickListener();
+    }
     if (!wasOpen) {
       openScopedController = installOpenScopedListeners(els);
       applyTopOffset(els.root, openScopedController.signal);

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -4166,6 +4166,16 @@ var PRInsightsDashboard = (() => {
     };
     window.addEventListener(COMPARISON_TOGGLED_EVENT, lifetimeComparisonListener);
   }
+  var outsideClickAbort = null;
+  var outsideClickFrame = null;
+  function clearOutsideClickListener() {
+    outsideClickAbort?.abort();
+    outsideClickAbort = null;
+    if (outsideClickFrame !== null) {
+      cancelAnimationFrame(outsideClickFrame);
+      outsideClickFrame = null;
+    }
+  }
   function ensurePanelEls() {
     if (panelEls && !panelEls.root.isConnected) {
       panelEls = null;
@@ -4445,20 +4455,28 @@ var PRInsightsDashboard = (() => {
     });
     infoIcon.addEventListener("pointerleave", () => {
       dismissAllTooltips();
+      clearOutsideClickListener();
     });
     infoIcon.addEventListener("click", (event) => {
       event.stopPropagation();
       if (document.querySelector(".info-tooltip") !== null) {
         dismissAllTooltips();
+        clearOutsideClickListener();
         return;
       }
       showInfoTooltip(infoIcon, COMMENTS_METRICS_C1_TOOLTIP);
-      requestAnimationFrame(() => {
-        const dismissOnce = () => {
-          dismissAllTooltips();
-          document.removeEventListener("click", dismissOnce);
-        };
-        document.addEventListener("click", dismissOnce);
+      clearOutsideClickListener();
+      outsideClickFrame = requestAnimationFrame(() => {
+        outsideClickFrame = null;
+        outsideClickAbort = new AbortController();
+        document.addEventListener(
+          "click",
+          () => {
+            dismissAllTooltips();
+            clearOutsideClickListener();
+          },
+          { signal: outsideClickAbort.signal, once: true }
+        );
       });
     });
     filterGroup.appendChild(infoIcon);
@@ -4837,6 +4855,7 @@ var PRInsightsDashboard = (() => {
     openScopedController?.abort();
     openScopedController = null;
     dismissAllTooltips();
+    clearOutsideClickListener();
     const trigger = activeContext?.triggerElement ?? null;
     if (focusTrapController) {
       if (trigger && trigger.isConnected) {

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -4041,6 +4041,72 @@ var PRInsightsDashboard = (() => {
     );
   }
 
+  // ../ui/modules/tooltip-manager.ts
+  var scrollDismissController = null;
+  function ensureScrollDismissListener() {
+    if (scrollDismissController) return;
+    scrollDismissController = new AbortController();
+    const { signal } = scrollDismissController;
+    const dismiss = () => dismissAllTooltips();
+    window.addEventListener("scroll", dismiss, { signal, passive: true });
+    window.addEventListener("resize", dismiss, { signal, passive: true });
+  }
+  function releaseScrollDismissListener() {
+    scrollDismissController?.abort();
+    scrollDismissController = null;
+  }
+  function dismissAllTooltips() {
+    const chartTooltip = document.querySelector(".chart-tooltip");
+    if (chartTooltip) chartTooltip.remove();
+    const infoTooltip = document.querySelector(".info-tooltip");
+    if (infoTooltip) infoTooltip.remove();
+    releaseScrollDismissListener();
+  }
+  function positionTooltip(tooltip, targetRect) {
+    tooltip.style.visibility = "hidden";
+    tooltip.style.position = "fixed";
+    document.body.appendChild(tooltip);
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const gap = 8;
+    let top = targetRect.top - tooltipRect.height - gap;
+    if (top < 0) {
+      top = targetRect.bottom + gap;
+    }
+    if (top + tooltipRect.height > window.innerHeight) {
+      top = window.innerHeight - tooltipRect.height - 4;
+    }
+    let left = targetRect.left + targetRect.width / 2 - tooltipRect.width / 2;
+    if (left < 4) {
+      left = 4;
+    }
+    if (left + tooltipRect.width > window.innerWidth - 4) {
+      left = window.innerWidth - tooltipRect.width - 4;
+    }
+    tooltip.style.top = `${top}px`;
+    tooltip.style.left = `${left}px`;
+    tooltip.style.visibility = "";
+  }
+  function showChartTooltip(target, content) {
+    dismissAllTooltips();
+    const tooltip = document.createElement("div");
+    tooltip.className = "chart-tooltip";
+    renderTrustedHtml(tooltip, content);
+    tooltip.style.position = "fixed";
+    const rect = target.getBoundingClientRect();
+    positionTooltip(tooltip, rect);
+    ensureScrollDismissListener();
+  }
+  function showInfoTooltip(target, content) {
+    dismissAllTooltips();
+    const tooltip = document.createElement("div");
+    tooltip.className = "info-tooltip";
+    tooltip.textContent = content;
+    tooltip.style.position = "fixed";
+    const rect = target.getBoundingClientRect();
+    positionTooltip(tooltip, rect);
+    ensureScrollDismissListener();
+  }
+
   // ../ui/modules/shared/detail-panel.ts
   function isPartialPrRow(row) {
     return row.threadCount === null || row.threadCount === void 0;
@@ -4343,6 +4409,7 @@ var PRInsightsDashboard = (() => {
     if (current === "descending") return "ascending";
     return "none";
   }
+  var COMMENTS_METRICS_C1_TOOLTIP = "Counts apply Feature 310's inclusion rules. Threads include unknown-status threads but exclude deleted ones. Comments include system events; deleted comments are excluded. Unresolved counts only threads still in active status. Comments by users missing from the user table are still counted.";
   function buildCommentsMetricsFilter(list) {
     const filterGroup = createElement("div", {
       class: "detail-panel-pr-list-filter",
@@ -4356,6 +4423,35 @@ var PRInsightsDashboard = (() => {
         "Min:"
       )
     );
+    const infoIcon = createElement("button", {
+      type: "button",
+      class: "info-icon-btn",
+      "data-info-tooltip": "comments-metrics-c1",
+      "aria-label": "About these counts"
+    });
+    appendText(infoIcon, "\u2139");
+    infoIcon.addEventListener("pointerenter", () => {
+      showInfoTooltip(infoIcon, COMMENTS_METRICS_C1_TOOLTIP);
+    });
+    infoIcon.addEventListener("pointerleave", () => {
+      dismissAllTooltips();
+    });
+    infoIcon.addEventListener("click", (event) => {
+      event.stopPropagation();
+      if (document.querySelector(".info-tooltip") !== null) {
+        dismissAllTooltips();
+        return;
+      }
+      showInfoTooltip(infoIcon, COMMENTS_METRICS_C1_TOOLTIP);
+      requestAnimationFrame(() => {
+        const dismissOnce = () => {
+          dismissAllTooltips();
+          document.removeEventListener("click", dismissOnce);
+        };
+        document.addEventListener("click", dismissOnce);
+      });
+    });
+    filterGroup.appendChild(infoIcon);
     const filterDescriptors = [];
     for (const axis of COMMENTS_METRICS_AXES) {
       const label = createElement("label", {
@@ -4706,6 +4802,7 @@ var PRInsightsDashboard = (() => {
     panelState = "closing";
     openScopedController?.abort();
     openScopedController = null;
+    dismissAllTooltips();
     const trigger = activeContext?.triggerElement ?? null;
     if (focusTrapController) {
       if (trigger && trigger.isConnected) {
@@ -6796,72 +6893,6 @@ var PRInsightsDashboard = (() => {
         }
         break;
     }
-  }
-
-  // ../ui/modules/tooltip-manager.ts
-  var scrollDismissController = null;
-  function ensureScrollDismissListener() {
-    if (scrollDismissController) return;
-    scrollDismissController = new AbortController();
-    const { signal } = scrollDismissController;
-    const dismiss = () => dismissAllTooltips();
-    window.addEventListener("scroll", dismiss, { signal, passive: true });
-    window.addEventListener("resize", dismiss, { signal, passive: true });
-  }
-  function releaseScrollDismissListener() {
-    scrollDismissController?.abort();
-    scrollDismissController = null;
-  }
-  function dismissAllTooltips() {
-    const chartTooltip = document.querySelector(".chart-tooltip");
-    if (chartTooltip) chartTooltip.remove();
-    const infoTooltip = document.querySelector(".info-tooltip");
-    if (infoTooltip) infoTooltip.remove();
-    releaseScrollDismissListener();
-  }
-  function positionTooltip(tooltip, targetRect) {
-    tooltip.style.visibility = "hidden";
-    tooltip.style.position = "fixed";
-    document.body.appendChild(tooltip);
-    const tooltipRect = tooltip.getBoundingClientRect();
-    const gap = 8;
-    let top = targetRect.top - tooltipRect.height - gap;
-    if (top < 0) {
-      top = targetRect.bottom + gap;
-    }
-    if (top + tooltipRect.height > window.innerHeight) {
-      top = window.innerHeight - tooltipRect.height - 4;
-    }
-    let left = targetRect.left + targetRect.width / 2 - tooltipRect.width / 2;
-    if (left < 4) {
-      left = 4;
-    }
-    if (left + tooltipRect.width > window.innerWidth - 4) {
-      left = window.innerWidth - tooltipRect.width - 4;
-    }
-    tooltip.style.top = `${top}px`;
-    tooltip.style.left = `${left}px`;
-    tooltip.style.visibility = "";
-  }
-  function showChartTooltip(target, content) {
-    dismissAllTooltips();
-    const tooltip = document.createElement("div");
-    tooltip.className = "chart-tooltip";
-    renderTrustedHtml(tooltip, content);
-    tooltip.style.position = "fixed";
-    const rect = target.getBoundingClientRect();
-    positionTooltip(tooltip, rect);
-    ensureScrollDismissListener();
-  }
-  function showInfoTooltip(target, content) {
-    dismissAllTooltips();
-    const tooltip = document.createElement("div");
-    tooltip.className = "info-tooltip";
-    tooltip.textContent = content;
-    tooltip.style.position = "fixed";
-    const rect = target.getBoundingClientRect();
-    positionTooltip(tooltip, rect);
-    ensureScrollDismissListener();
   }
 
   // ../ui/modules/charts.ts

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -4410,7 +4410,17 @@ var PRInsightsDashboard = (() => {
     return "none";
   }
   var COMMENTS_METRICS_C1_TOOLTIP = "Counts apply Feature 310's inclusion rules. Threads include unknown-status threads but exclude deleted ones. Comments include system events; deleted comments are excluded. Unresolved counts only threads still in active status. Comments by users missing from the user table are still counted.";
-  function buildCommentsMetricsFilter(list) {
+  function formatFilterSummary(context, hasActiveThreshold, visibleNumeric) {
+    if (!hasActiveThreshold) {
+      return `Showing all ${context.totalRows} PRs.`;
+    }
+    if (context.partialRowCount === 0) {
+      return `Showing ${visibleNumeric} of ${context.numericTotal} PRs.`;
+    }
+    const noun = context.partialRowCount === 1 ? "row" : "rows";
+    return `Showing ${visibleNumeric} of ${context.numericTotal} PRs. ${context.partialRowCount} partial ${noun} hidden by filter.`;
+  }
+  function buildCommentsMetricsFilter(list, context) {
     const filterGroup = createElement("div", {
       class: "detail-panel-pr-list-filter",
       role: "group",
@@ -4452,6 +4462,12 @@ var PRInsightsDashboard = (() => {
       });
     });
     filterGroup.appendChild(infoIcon);
+    const summary = createElement("p", {
+      class: "detail-panel-pr-list-filter-summary",
+      role: "status",
+      "aria-live": "polite"
+    });
+    appendText(summary, formatFilterSummary(context, false, 0));
     const filterDescriptors = [];
     for (const axis of COMMENTS_METRICS_AXES) {
       const label = createElement("label", {
@@ -4468,13 +4484,13 @@ var PRInsightsDashboard = (() => {
       const descriptor = { input, dataAttr: axis.dataAttr };
       input.addEventListener(
         "input",
-        () => applyFilters(list, filterDescriptors)
+        () => applyFilters(list, filterDescriptors, summary, context)
       );
       label.appendChild(input);
       filterGroup.appendChild(label);
       filterDescriptors.push(descriptor);
     }
-    return filterGroup;
+    return { filterGroup, summary };
   }
   function applySort(list, dataAttr, direction, originalOrder) {
     if (direction === "none") {
@@ -4494,7 +4510,7 @@ var PRInsightsDashboard = (() => {
     });
     for (const item of items) list.appendChild(item);
   }
-  function applyFilters(list, descriptors) {
+  function applyFilters(list, descriptors, summary, context) {
     const thresholds = [];
     for (const desc of descriptors) {
       const raw = desc.input.value.trim();
@@ -4503,6 +4519,8 @@ var PRInsightsDashboard = (() => {
       if (parsed < 0) continue;
       thresholds.push([desc.dataAttr, parsed]);
     }
+    const hasActiveThreshold = thresholds.length > 0;
+    let visibleNumeric = 0;
     for (const child of list.querySelectorAll("li")) {
       let hidden = false;
       for (const [dataAttr, threshold] of thresholds) {
@@ -4520,8 +4538,18 @@ var PRInsightsDashboard = (() => {
         child.setAttribute("hidden", "");
       } else {
         child.removeAttribute("hidden");
+        if (!child.hasAttribute("data-partial")) {
+          visibleNumeric++;
+        }
       }
     }
+    const nextText = formatFilterSummary(
+      context,
+      hasActiveThreshold,
+      visibleNumeric
+    );
+    summary.textContent = "";
+    summary.textContent = nextText;
   }
   function renderPrListSection(section) {
     const wrapper = createElement("section", {
@@ -4628,7 +4656,13 @@ var PRInsightsDashboard = (() => {
           })
         );
         if (sortRowElements !== null) {
-          wrapper.appendChild(buildCommentsMetricsFilter(list));
+          const filterControls = buildCommentsMetricsFilter(list, {
+            totalRows: rows.length,
+            numericTotal: rows.length - partialRowCount,
+            partialRowCount
+          });
+          wrapper.appendChild(filterControls.filterGroup);
+          wrapper.appendChild(filterControls.summary);
         }
         for (const li of rowElements) {
           list.appendChild(li);

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -4281,6 +4281,11 @@ var PRInsightsDashboard = (() => {
     );
     if (!commentsMetricsAvailable) return header;
     const records = [];
+    const sortAnnouncer = createElement("div", {
+      role: "status",
+      "aria-live": "polite",
+      class: "visually-hidden detail-panel-pr-list-sort-announcer"
+    });
     for (const axis of COMMENTS_METRICS_AXES) {
       const cellAttrs = {
         class: `detail-panel-pr-list-header-cell detail-panel-pr-list-header-cell--${axis.key}`,
@@ -4324,7 +4329,12 @@ var PRInsightsDashboard = (() => {
         record.state = nextDirection;
         record.cell.setAttribute("aria-sort", nextDirection);
         applySort(list, axis.dataAttr, nextDirection, originalOrder);
+        sortAnnouncer.textContent = "";
+        sortAnnouncer.textContent = nextDirection === "none" ? "Sort cleared." : `Sorted by ${axis.label.toLowerCase()}, ${nextDirection}.`;
       });
+    }
+    if (withSortButtons) {
+      header.appendChild(sortAnnouncer);
     }
     return header;
   }

--- a/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
+++ b/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
@@ -2021,6 +2021,128 @@ describe("issue #332 / B2 — single C1 info icon adjacent to 'Min:' controls la
     document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(document.querySelector(".chart-tooltip")).not.toBeNull();
   });
+
+  it("PRE-rAF retarget-in-place re-open clears the deferred outside-click frame (chart tooltip survives)", () => {
+    // Codex PR #343 P2 follow-up #2: retarget-in-place (cycle-time
+    // P50↔P90, throughput week-to-week, etc.) is a documented load-
+    // bearing path that re-renders the panel WITHOUT going through
+    // ``dismissDetailPanel``.  The old icon's bound listeners are GC'd
+    // but the document-level deferred listener / pending rAF survive.
+    // Without the openDetailPanel cleanup, the next click would
+    // dismiss whatever tooltip the new content shows.
+    //
+    // Pre-rAF case: rAF callback hasn't fired, so only the
+    // ``cancelAnimationFrame`` branch saves us.
+    const sectionA = iconSection();
+    const sectionB = makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 99,
+          threadCount: 9,
+          commentCount: 9,
+          activeThreadCount: 4,
+        }),
+        buildRow({
+          id: 100,
+          threadCount: 1,
+          commentCount: 2,
+          activeThreadCount: 0,
+        }),
+      ],
+      renderedCount: 2,
+      actualFilteredCount: 2,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+    openWithPrListSection(sectionA);
+    const root = document.querySelector<HTMLElement>(".detail-panel");
+    if (root === null) throw new Error("detail-panel not rendered");
+    const iconA = root.querySelector<HTMLElement>(
+      ".detail-panel-pr-list-filter .info-icon-btn",
+    );
+    if (iconA === null) throw new Error("icon A not rendered");
+    iconA.getBoundingClientRect = () => ({
+      top: 100,
+      left: 100,
+      bottom: 120,
+      right: 120,
+      width: 20,
+      height: 20,
+      x: 100,
+      y: 100,
+      toJSON: () => ({}),
+    });
+    iconA.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(document.querySelector(".info-tooltip")).not.toBeNull();
+    // Retarget-in-place re-render BEFORE rAF fires.
+    openWithPrListSection(sectionB);
+    expect(document.querySelector(".info-tooltip")).toBeNull();
+    mountChartTooltipFixture();
+    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(document.querySelector(".chart-tooltip")).not.toBeNull();
+  });
+
+  it("POST-rAF retarget-in-place re-open aborts the attached outside-click listener (chart tooltip survives)", async () => {
+    // Mirror of the pre-rAF retarget test but with the rAF awaited so
+    // the listener IS attached at the time of the in-place re-open.
+    // Hits the controller-abort branch on the openDetailPanel cleanup
+    // path that the prior abort-only proposal would have covered, but
+    // confirms the combined abort+cancelAnimationFrame design covers
+    // it equally.
+    const sectionA = iconSection();
+    const sectionB = makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 99,
+          threadCount: 9,
+          commentCount: 9,
+          activeThreadCount: 4,
+        }),
+        buildRow({
+          id: 100,
+          threadCount: 1,
+          commentCount: 2,
+          activeThreadCount: 0,
+        }),
+      ],
+      renderedCount: 2,
+      actualFilteredCount: 2,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+    openWithPrListSection(sectionA);
+    const root = document.querySelector<HTMLElement>(".detail-panel");
+    if (root === null) throw new Error("detail-panel not rendered");
+    const iconA = root.querySelector<HTMLElement>(
+      ".detail-panel-pr-list-filter .info-icon-btn",
+    );
+    if (iconA === null) throw new Error("icon A not rendered");
+    iconA.getBoundingClientRect = () => ({
+      top: 100,
+      left: 100,
+      bottom: 120,
+      right: 120,
+      width: 20,
+      height: 20,
+      x: 100,
+      y: 100,
+      toJSON: () => ({}),
+    });
+    iconA.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+    // Retarget-in-place re-render AFTER rAF fires; doc listener is
+    // attached at this point and must be aborted by the openDetailPanel
+    // cleanup, otherwise the next body click clobbers the chart tooltip.
+    openWithPrListSection(sectionB);
+    expect(document.querySelector(".info-tooltip")).toBeNull();
+    mountChartTooltipFixture();
+    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(document.querySelector(".chart-tooltip")).not.toBeNull();
+  });
 });
 
 describe("issue #332 / B3 — filter feedback summary", () => {

--- a/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
+++ b/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
@@ -1951,3 +1951,266 @@ describe("issue #332 / B2 — single C1 info icon adjacent to 'Min:' controls la
     expect(document.querySelector(".info-tooltip")).toBeNull();
   });
 });
+
+describe("issue #332 / B3 — filter feedback summary", () => {
+  // Locks the contract: when the threshold filter renders, a polite
+  // ``role=status`` paragraph mounts as a sibling of the filter group
+  // (between filter and ``<ol>``) and reports "Showing all N PRs." /
+  // "Showing X of Y PRs." / "...P partial row(s) hidden by filter."
+  // depending on filter activity and slice partial-row count.
+  function getSummary(root: HTMLElement): HTMLElement {
+    const el = root.querySelector<HTMLElement>(
+      ".detail-panel-pr-list-filter-summary",
+    );
+    if (el === null) throw new Error("filter feedback summary not rendered");
+    return el;
+  }
+
+  function setFilter(root: HTMLElement, key: string, value: string): void {
+    const input = root.querySelector<HTMLInputElement>(
+      `input[data-filter-key="${key}"]`,
+    );
+    if (input === null) throw new Error(`filter input ${key} not found`);
+    input.value = value;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  function noPartialSection(): PrListSection {
+    return makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 1,
+          threadCount: 0,
+          commentCount: 0,
+          activeThreadCount: 0,
+        }),
+        buildRow({
+          id: 2,
+          threadCount: 3,
+          commentCount: 12,
+          activeThreadCount: 1,
+        }),
+        buildRow({
+          id: 3,
+          threadCount: 5,
+          commentCount: 2,
+          activeThreadCount: 0,
+        }),
+        buildRow({
+          id: 4,
+          threadCount: 7,
+          commentCount: 4,
+          activeThreadCount: 2,
+        }),
+      ],
+      renderedCount: 4,
+      actualFilteredCount: 4,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+  }
+
+  function multiPartialSection(): PrListSection {
+    return makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 1,
+          threadCount: 0,
+          commentCount: 0,
+          activeThreadCount: 0,
+        }),
+        buildRow({
+          id: 2,
+          threadCount: 3,
+          commentCount: 12,
+          activeThreadCount: 1,
+        }),
+        buildRow({
+          id: 3,
+          threadCount: 5,
+          commentCount: 2,
+          activeThreadCount: 0,
+        }),
+        buildRow({
+          id: 4,
+          threadCount: null,
+          commentCount: null,
+          activeThreadCount: null,
+        }),
+        buildRow({
+          id: 5,
+          threadCount: null,
+          commentCount: null,
+          activeThreadCount: null,
+        }),
+      ],
+      renderedCount: 5,
+      actualFilteredCount: 5,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+  }
+
+  function singlePartialSection(): PrListSection {
+    return makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 1,
+          threadCount: 0,
+          commentCount: 0,
+          activeThreadCount: 0,
+        }),
+        buildRow({
+          id: 2,
+          threadCount: 3,
+          commentCount: 12,
+          activeThreadCount: 1,
+        }),
+        buildRow({
+          id: 3,
+          threadCount: null,
+          commentCount: null,
+          activeThreadCount: null,
+        }),
+      ],
+      renderedCount: 3,
+      actualFilteredCount: 3,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+  }
+
+  it("mounts a role=status aria-live=polite summary between the filter and the list with the no-filter copy", () => {
+    const root = openWithPrListSection(noPartialSection());
+    const summary = getSummary(root);
+    expect(summary.tagName).toBe("P");
+    expect(summary.getAttribute("role")).toBe("status");
+    expect(summary.getAttribute("aria-live")).toBe("polite");
+    expect(summary.textContent).toBe("Showing all 4 PRs.");
+    // DOM order: filter group → summary → <ol>.  Reading / SR walk
+    // sequence is filter → state → list.
+    const wrapper = summary.parentElement!;
+    const children = Array.from(wrapper.children);
+    const filterIdx = children.findIndex((c) =>
+      c.classList.contains("detail-panel-pr-list-filter"),
+    );
+    const summaryIdx = children.indexOf(summary);
+    const listIdx = children.findIndex((c) =>
+      c.classList.contains("detail-panel-pr-list"),
+    );
+    expect(filterIdx).toBeGreaterThan(-1);
+    expect(summaryIdx).toBe(filterIdx + 1);
+    expect(listIdx).toBe(summaryIdx + 1);
+  });
+
+  it("does NOT mount the summary in suppressed-controls states (cap-off / single-row / all-partial)", () => {
+    const states: ReadonlyArray<{ name: string; section: PrListSection }> = [
+      {
+        name: "capability-off",
+        section: makePrListSection({
+          contentState: "pr-list",
+          rows: [buildRow({ id: 1 }), buildRow({ id: 2 })],
+          renderedCount: 2,
+          actualFilteredCount: 2,
+          capValue: 500,
+          commentsMetricsAvailable: false,
+        }),
+      },
+      {
+        name: "capability-on single-row (#330 / C5)",
+        section: makePrListSection({
+          contentState: "pr-list",
+          rows: [
+            buildRow({
+              id: 1,
+              threadCount: 5,
+              commentCount: 17,
+              activeThreadCount: 2,
+            }),
+          ],
+          renderedCount: 1,
+          actualFilteredCount: 1,
+          capValue: 500,
+          commentsMetricsAvailable: true,
+        }),
+      },
+      {
+        name: "capability-on all-partial (#331 / C2)",
+        section: makePrListSection({
+          contentState: "pr-list",
+          rows: [
+            buildRow({
+              id: 1,
+              threadCount: null,
+              commentCount: null,
+              activeThreadCount: null,
+            }),
+            buildRow({
+              id: 2,
+              threadCount: null,
+              commentCount: null,
+              activeThreadCount: null,
+            }),
+          ],
+          renderedCount: 2,
+          actualFilteredCount: 2,
+          capValue: 500,
+          commentsMetricsAvailable: true,
+        }),
+      },
+    ];
+    for (const { name, section } of states) {
+      const root = openWithPrListSection(section);
+      const summary = root.querySelector(
+        ".detail-panel-pr-list-filter-summary",
+      );
+      expect({ state: name, summary }).toEqual({ state: name, summary: null });
+      dismissDetailPanel("explicit-close-button");
+      document.body.innerHTML = "";
+    }
+  });
+
+  it("active threshold on a no-partials slice → 'Showing X of Y PRs.'", () => {
+    const root = openWithPrListSection(noPartialSection());
+    setFilter(root, "threads", "3");
+    // Numeric rows passing threads >= 3: ids 2 (3), 3 (5), 4 (7).
+    expect(getSummary(root).textContent).toBe("Showing 3 of 4 PRs.");
+  });
+
+  it("clearing the filter on a slice with partial rows reverts to 'Showing all N PRs.'", () => {
+    // Crosses the active → inactive transition, exercising the
+    // ``!hasActiveThreshold`` true arm AFTER ``applyFilters`` has run
+    // (initial state hits it via ``formatFilterSummary`` directly).
+    // The partial rows in the slice exercise the
+    // ``!child.hasAttribute("data-partial")`` false arm of the
+    // visible-numeric counter on the cleared-filter pass.
+    const root = openWithPrListSection(multiPartialSection());
+    setFilter(root, "threads", "3");
+    expect(getSummary(root).textContent).toContain("Showing");
+    setFilter(root, "threads", "");
+    expect(getSummary(root).textContent).toBe("Showing all 5 PRs.");
+  });
+
+  it("active threshold on a slice with multiple partial rows → '...P partial rows hidden by filter.' (plural)", () => {
+    const root = openWithPrListSection(multiPartialSection());
+    setFilter(root, "threads", "3");
+    // Numeric rows passing threads >= 3: ids 2 (3), 3 (5).
+    // Numeric total = 3 (ids 1, 2, 3); partial rows = 2 (ids 4, 5).
+    expect(getSummary(root).textContent).toBe(
+      "Showing 2 of 3 PRs. 2 partial rows hidden by filter.",
+    );
+  });
+
+  it("active threshold on a slice with exactly one partial row → 'partial row' (singular)", () => {
+    const root = openWithPrListSection(singlePartialSection());
+    setFilter(root, "threads", "1");
+    // Numeric rows passing threads >= 1: id 2 (3).
+    // Numeric total = 2 (ids 1, 2); partial = 1 (id 3).
+    expect(getSummary(root).textContent).toBe(
+      "Showing 1 of 2 PRs. 1 partial row hidden by filter.",
+    );
+  });
+});

--- a/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
+++ b/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
@@ -1950,6 +1950,77 @@ describe("issue #332 / B2 — single C1 info icon adjacent to 'Min:' controls la
     dismissDetailPanel("explicit-close-button");
     expect(document.querySelector(".info-tooltip")).toBeNull();
   });
+
+  // ---------------------------------------------------------------------
+  // Codex PR #343 P2 follow-up: the deferred outside-click dismiss
+  // listener must be cancelled when an alternate dismiss path runs
+  // (pointerleave / second icon click / panel close) BEFORE OR AFTER
+  // the rAF callback fires.  Without canceling both phases (pending
+  // ``rAF`` id + attached AbortController), the next document click
+  // dismisses any tooltip in the DOM — including a chart tooltip the
+  // user just opened on another surface (mutual-exclusivity contract
+  // in ``tooltip-manager.ts``).  The chart-tooltip survival assertion
+  // is the right behavioral proof: if the deferred listener leaked,
+  // the body-click below would dismiss it.
+  // ---------------------------------------------------------------------
+
+  function mountChartTooltipFixture(): void {
+    const tip = document.createElement("div");
+    tip.className = "chart-tooltip";
+    tip.textContent = "chart fixture";
+    document.body.appendChild(tip);
+  }
+
+  it("PRE-rAF pointerleave cancels the pending outside-click frame (chart tooltip survives subsequent body click)", () => {
+    // The rAF callback hasn't fired yet (no ``await`` after the
+    // click), so the AbortController is still null and there's
+    // nothing for ``signal.abort`` to act on — only the pending
+    // ``cancelAnimationFrame`` path can save us here.  This is the
+    // gap the abort-only fix would have left open.
+    const root = openWithPrListSection(iconSection());
+    const icon = getIcon(root);
+    icon.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    icon.dispatchEvent(new PointerEvent("pointerleave", { bubbles: true }));
+    expect(document.querySelector(".info-tooltip")).toBeNull();
+    mountChartTooltipFixture();
+    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(document.querySelector(".chart-tooltip")).not.toBeNull();
+  });
+
+  it("PRE-rAF panel close cancels the pending outside-click frame (chart tooltip survives across panel re-render)", () => {
+    // Worst-case lifecycle: panel closes BEFORE rAF fires.  Without
+    // the frame cancel, the rAF would still execute later, attach a
+    // document-level listener, and dismiss whatever tooltip the user
+    // opens next on the dashboard.
+    const root = openWithPrListSection(iconSection());
+    const icon = getIcon(root);
+    icon.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    dismissDetailPanel("explicit-close-button");
+    expect(document.querySelector(".info-tooltip")).toBeNull();
+    mountChartTooltipFixture();
+    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(document.querySelector(".chart-tooltip")).not.toBeNull();
+  });
+
+  it("POST-rAF pointerleave aborts the attached outside-click listener (chart tooltip survives subsequent body click)", async () => {
+    // ``await rAF`` first so the listener IS attached; this exercises
+    // the abort path on the controller (the frame is already null
+    // after the rAF callback ran), proving the abort branch doesn't
+    // leak when the cancel branch is the no-op.  Together with the
+    // two pre-rAF tests above, both arms of every conditional in
+    // ``clearOutsideClickListener`` are covered.
+    const root = openWithPrListSection(iconSection());
+    const icon = getIcon(root);
+    icon.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+    icon.dispatchEvent(new PointerEvent("pointerleave", { bubbles: true }));
+    expect(document.querySelector(".info-tooltip")).toBeNull();
+    mountChartTooltipFixture();
+    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(document.querySelector(".chart-tooltip")).not.toBeNull();
+  });
 });
 
 describe("issue #332 / B3 — filter feedback summary", () => {

--- a/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
+++ b/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
@@ -1542,3 +1542,182 @@ describe("header-driven sort cycle (F3 + F4)", () => {
     expect(new Set(ids.slice(2))).toEqual(new Set([11, 13]));
   });
 });
+
+describe("issue #332 / B1 — sort SR-live announcer", () => {
+  // Locks the contract: when sort buttons render (capability-on, >1
+  // row, !all-partial), a polite ``role=status`` live region inside
+  // the header announces the new direction on every click.  Suppressed-
+  // controls states (capability-off, capability-on single-row,
+  // capability-on all-partial) do NOT mount the announcer.
+  function announcerSection(): PrListSection {
+    return makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 1,
+          threadCount: 2,
+          commentCount: 5,
+          activeThreadCount: 0,
+        }),
+        buildRow({
+          id: 2,
+          threadCount: 7,
+          commentCount: 3,
+          activeThreadCount: 2,
+        }),
+        buildRow({
+          id: 3,
+          threadCount: 5,
+          commentCount: 20,
+          activeThreadCount: 5,
+        }),
+      ],
+      renderedCount: 3,
+      actualFilteredCount: 3,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+  }
+
+  function clickHeader(root: HTMLElement, key: string): void {
+    const button = root.querySelector<HTMLButtonElement>(
+      `.detail-panel-pr-list-header button[data-sort-key="${key}"]`,
+    );
+    if (button === null) {
+      throw new Error(`header sort button ${key} not found`);
+    }
+    button.dispatchEvent(new Event("click", { bubbles: true }));
+  }
+
+  function getAnnouncer(root: HTMLElement): HTMLElement {
+    const el = root.querySelector<HTMLElement>(
+      ".detail-panel-pr-list-sort-announcer",
+    );
+    if (el === null) throw new Error("sort announcer not rendered");
+    return el;
+  }
+
+  it("mounts an empty role=status aria-live=polite announcer inside the header on cap-on >1-row !all-partial", () => {
+    const root = openWithPrListSection(announcerSection());
+    const announcer = getAnnouncer(root);
+    expect(announcer.getAttribute("role")).toBe("status");
+    expect(announcer.getAttribute("aria-live")).toBe("polite");
+    expect(announcer.classList.contains("visually-hidden")).toBe(true);
+    // Empty before any sort interaction — no startup announcement.
+    expect(announcer.textContent).toBe("");
+    // Lives inside the header so its lifecycle is bound to the
+    // header that owns the sort buttons (panel re-render rebuilds
+    // both together).
+    const header = root.querySelector<HTMLElement>(
+      ".detail-panel-pr-list-header",
+    );
+    expect(header).not.toBeNull();
+    expect(header!.contains(announcer)).toBe(true);
+  });
+
+  it("does NOT mount the announcer in suppressed-controls states (cap-off / single-row / all-partial)", () => {
+    const states: ReadonlyArray<{ name: string; section: PrListSection }> = [
+      {
+        name: "capability-off",
+        section: makePrListSection({
+          contentState: "pr-list",
+          rows: [buildRow({ id: 1 }), buildRow({ id: 2 })],
+          renderedCount: 2,
+          actualFilteredCount: 2,
+          capValue: 500,
+          commentsMetricsAvailable: false,
+        }),
+      },
+      {
+        name: "capability-on single-row (#330 / C5)",
+        section: makePrListSection({
+          contentState: "pr-list",
+          rows: [
+            buildRow({
+              id: 1,
+              threadCount: 5,
+              commentCount: 17,
+              activeThreadCount: 2,
+            }),
+          ],
+          renderedCount: 1,
+          actualFilteredCount: 1,
+          capValue: 500,
+          commentsMetricsAvailable: true,
+        }),
+      },
+      {
+        name: "capability-on all-partial (#331 / C2)",
+        section: makePrListSection({
+          contentState: "pr-list",
+          rows: [
+            buildRow({
+              id: 1,
+              threadCount: null,
+              commentCount: null,
+              activeThreadCount: null,
+            }),
+            buildRow({
+              id: 2,
+              threadCount: null,
+              commentCount: null,
+              activeThreadCount: null,
+            }),
+          ],
+          renderedCount: 2,
+          actualFilteredCount: 2,
+          capValue: 500,
+          commentsMetricsAvailable: true,
+        }),
+      },
+    ];
+    for (const { name, section } of states) {
+      const root = openWithPrListSection(section);
+      const announcer = root.querySelector(
+        ".detail-panel-pr-list-sort-announcer",
+      );
+      expect({ state: name, announcer }).toEqual({
+        state: name,
+        announcer: null,
+      });
+      dismissDetailPanel("explicit-close-button");
+      document.body.innerHTML = "";
+    }
+  });
+
+  it("announces 'Sorted by {axis}, descending.' / '...ascending.' / 'Sort cleared.' across the cycle", () => {
+    const root = openWithPrListSection(announcerSection());
+    const announcer = getAnnouncer(root);
+
+    clickHeader(root, "threads");
+    expect(announcer.textContent).toBe("Sorted by threads, descending.");
+
+    clickHeader(root, "threads");
+    expect(announcer.textContent).toBe("Sorted by threads, ascending.");
+
+    clickHeader(root, "threads");
+    expect(announcer.textContent).toBe("Sort cleared.");
+  });
+
+  it("announces the new axis when sort switches between columns (single-active-sort copy)", () => {
+    const root = openWithPrListSection(announcerSection());
+    const announcer = getAnnouncer(root);
+    clickHeader(root, "threads");
+    expect(announcer.textContent).toBe("Sorted by threads, descending.");
+    clickHeader(root, "comments");
+    expect(announcer.textContent).toBe("Sorted by comments, descending.");
+  });
+
+  it("uses the full disambiguated phrase 'unresolved threads' for the unresolved axis (F8 contract carry-forward)", () => {
+    // The unresolved column's visible header text is the short
+    // ``Unresolved`` (track-fit), but the sort announcement reuses
+    // ``axis.label`` so SR users hear the full disambiguating phrase
+    // — same form the column-header ``aria-label`` already uses.
+    const root = openWithPrListSection(announcerSection());
+    const announcer = getAnnouncer(root);
+    clickHeader(root, "unresolved");
+    expect(announcer.textContent).toBe(
+      "Sorted by unresolved threads, descending.",
+    );
+  });
+});

--- a/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
+++ b/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
@@ -1,3 +1,16 @@
+// jsdom lacks PointerEvent — polyfill matches the shape used by
+// extension/tests/modules/charts/summary-cards-info.test.ts so the
+// pointerenter / pointerleave listeners on the #332 / B2 info icon
+// fire predictably.
+if (typeof PointerEvent === "undefined") {
+  (globalThis as Record<string, unknown>).PointerEvent =
+    class PointerEvent extends MouseEvent {
+      constructor(type: string, init?: PointerEventInit) {
+        super(type, init);
+      }
+    };
+}
+
 /**
  * Feature 310 consumer-side rendering tests: per-PR comments-metrics columns
  * on the throughput drill-down PR-detail list.
@@ -1719,5 +1732,222 @@ describe("issue #332 / B1 — sort SR-live announcer", () => {
     expect(announcer.textContent).toBe(
       "Sorted by unresolved threads, descending.",
     );
+  });
+});
+
+describe("issue #332 / B2 — single C1 info icon adjacent to 'Min:' controls label", () => {
+  // Locks the contract: when the threshold filter renders (capability-
+  // on, >1 row, !all-partial), exactly one ``.info-icon-btn`` mounts
+  // inside the filter group; pointerenter shows an info tooltip with
+  // the C1 inclusion-rule disclosure; pointerleave dismisses; click
+  // toggles for touch / keyboard.  Suppressed-controls states emit
+  // no icon (the filter itself is absent).
+  const C1_TOOLTIP_TEXT =
+    "Counts apply Feature 310's inclusion rules. Threads include " +
+    "unknown-status threads but exclude deleted ones. Comments include " +
+    "system events; deleted comments are excluded. Unresolved counts " +
+    "only threads still in active status. Comments by users missing " +
+    "from the user table are still counted.";
+
+  function iconSection(): PrListSection {
+    return makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 1,
+          threadCount: 1,
+          commentCount: 1,
+          activeThreadCount: 0,
+        }),
+        buildRow({
+          id: 2,
+          threadCount: 2,
+          commentCount: 4,
+          activeThreadCount: 1,
+        }),
+      ],
+      renderedCount: 2,
+      actualFilteredCount: 2,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+  }
+
+  function getIcon(root: HTMLElement): HTMLElement {
+    const icon = root.querySelector<HTMLElement>(
+      ".detail-panel-pr-list-filter .info-icon-btn",
+    );
+    if (icon === null)
+      throw new Error("comments-metrics info icon not rendered");
+    // Tooltip positioning reads getBoundingClientRect; provide a
+    // stable rect for jsdom (matches the summary-cards-info pattern).
+    icon.getBoundingClientRect = () => ({
+      top: 100,
+      left: 100,
+      bottom: 120,
+      right: 120,
+      width: 20,
+      height: 20,
+      x: 100,
+      y: 100,
+      toJSON: () => ({}),
+    });
+    return icon;
+  }
+
+  afterEach(() => {
+    document
+      .querySelectorAll(".info-tooltip, .chart-tooltip")
+      .forEach((el) => el.remove());
+  });
+
+  it("mounts exactly one info-icon-btn inside the filter group with type=button + aria-label + ⓘ glyph", () => {
+    const root = openWithPrListSection(iconSection());
+    const filter = root.querySelector<HTMLElement>(
+      ".detail-panel-pr-list-filter",
+    );
+    expect(filter).not.toBeNull();
+    const icons = filter!.querySelectorAll(".info-icon-btn");
+    expect(icons).toHaveLength(1);
+    const icon = icons[0]!;
+    expect(icon.tagName).toBe("BUTTON");
+    expect(icon.getAttribute("type")).toBe("button");
+    expect(icon.getAttribute("aria-label")).toBe("About these counts");
+    expect(icon.getAttribute("data-info-tooltip")).toBe("comments-metrics-c1");
+    expect(icon.textContent).toBe("ℹ");
+  });
+
+  it("does NOT mount the info icon in suppressed-controls states (cap-off / single-row / all-partial)", () => {
+    const states: ReadonlyArray<{ name: string; section: PrListSection }> = [
+      {
+        name: "capability-off",
+        section: makePrListSection({
+          contentState: "pr-list",
+          rows: [buildRow({ id: 1 }), buildRow({ id: 2 })],
+          renderedCount: 2,
+          actualFilteredCount: 2,
+          capValue: 500,
+          commentsMetricsAvailable: false,
+        }),
+      },
+      {
+        name: "capability-on single-row (#330 / C5)",
+        section: makePrListSection({
+          contentState: "pr-list",
+          rows: [
+            buildRow({
+              id: 1,
+              threadCount: 5,
+              commentCount: 17,
+              activeThreadCount: 2,
+            }),
+          ],
+          renderedCount: 1,
+          actualFilteredCount: 1,
+          capValue: 500,
+          commentsMetricsAvailable: true,
+        }),
+      },
+      {
+        name: "capability-on all-partial (#331 / C2)",
+        section: makePrListSection({
+          contentState: "pr-list",
+          rows: [
+            buildRow({
+              id: 1,
+              threadCount: null,
+              commentCount: null,
+              activeThreadCount: null,
+            }),
+            buildRow({
+              id: 2,
+              threadCount: null,
+              commentCount: null,
+              activeThreadCount: null,
+            }),
+          ],
+          renderedCount: 2,
+          actualFilteredCount: 2,
+          capValue: 500,
+          commentsMetricsAvailable: true,
+        }),
+      },
+    ];
+    for (const { name, section } of states) {
+      const root = openWithPrListSection(section);
+      const icon = root.querySelector(".info-icon-btn");
+      expect({ state: name, icon }).toEqual({ state: name, icon: null });
+      dismissDetailPanel("explicit-close-button");
+      document.body.innerHTML = "";
+    }
+  });
+
+  it("pointerenter shows an info tooltip carrying the exact C1 disclosure text", () => {
+    const root = openWithPrListSection(iconSection());
+    const icon = getIcon(root);
+    icon.dispatchEvent(new PointerEvent("pointerenter", { bubbles: true }));
+    const tooltip = document.querySelector(".info-tooltip");
+    expect(tooltip).not.toBeNull();
+    expect(tooltip!.textContent).toBe(C1_TOOLTIP_TEXT);
+  });
+
+  it("pointerleave dismisses the open info tooltip", () => {
+    const root = openWithPrListSection(iconSection());
+    const icon = getIcon(root);
+    icon.dispatchEvent(new PointerEvent("pointerenter", { bubbles: true }));
+    expect(document.querySelector(".info-tooltip")).not.toBeNull();
+    icon.dispatchEvent(new PointerEvent("pointerleave", { bubbles: true }));
+    expect(document.querySelector(".info-tooltip")).toBeNull();
+  });
+
+  it("click toggles the info tooltip — first click shows, second click dismisses (touch / keyboard path)", () => {
+    // Exercises BOTH arms of the click-handler ``existing !== null``
+    // check: first click hits the ``null`` arm (no tooltip → show);
+    // second click hits the non-null arm (tooltip exists → dismiss).
+    // Required for partial-branch ratchet coverage.  The two clicks
+    // run synchronously so the rAF-deferred ``dismissOnce`` listener
+    // never attaches; the second click is dismissed by the icon's
+    // own handler via the ``existing !== null`` arm.
+    const root = openWithPrListSection(iconSection());
+    const icon = getIcon(root);
+    icon.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    const opened = document.querySelector(".info-tooltip");
+    expect(opened).not.toBeNull();
+    expect(opened!.textContent).toBe(C1_TOOLTIP_TEXT);
+    icon.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(document.querySelector(".info-tooltip")).toBeNull();
+  });
+
+  it("clicks outside the icon dismiss an open tooltip via the rAF-deferred document listener (Codex stop-time review)", async () => {
+    // Locks the outside-click dismiss path the initial #332 / B2 pass
+    // missed: a click-shown tooltip persisted indefinitely on outside-
+    // click.  The rAF defer makes the listener inert for the click
+    // that opened the tooltip; we explicitly yield to ``rAF`` here so
+    // the listener is attached before the next dispatch.
+    const root = openWithPrListSection(iconSection());
+    const icon = getIcon(root);
+    icon.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(document.querySelector(".info-tooltip")).not.toBeNull();
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(document.querySelector(".info-tooltip")).toBeNull();
+  });
+
+  it("dismissing the panel removes any open info tooltip (Codex stop-time review)", () => {
+    // Locks the panel-teardown contract the initial #332 / B2 pass
+    // missed: ``showInfoTooltip`` mounts the tooltip on
+    // ``document.body``, not the panel itself, so a tooltip opened
+    // before panel close persisted as an orphan.  ``dismissDetailPanel``
+    // now calls ``dismissAllTooltips`` so closing the panel for ANY
+    // reason (escape / outside-click / explicit close / filters
+    // changed / tab changed / comparison toggled) drops the tooltip.
+    const root = openWithPrListSection(iconSection());
+    const icon = getIcon(root);
+    icon.dispatchEvent(new PointerEvent("pointerenter", { bubbles: true }));
+    expect(document.querySelector(".info-tooltip")).not.toBeNull();
+    dismissDetailPanel("explicit-close-button");
+    expect(document.querySelector(".info-tooltip")).toBeNull();
   });
 });

--- a/extension/ui/modules/shared/detail-panel.ts
+++ b/extension/ui/modules/shared/detail-panel.ts
@@ -811,6 +811,67 @@ const COMMENTS_METRICS_C1_TOOLTIP =
   "from the user table are still counted.";
 
 /**
+ * Slice-level metadata the filter feedback summary (#332 / B3) needs
+ * to derive its copy.  All three counts are pre-computed by
+ * ``renderPrListSection`` from the ``rows`` array and the existing
+ * ``partialRowCount`` it already tracks for the coverage notice; this
+ * struct just wires them through to ``applyFilters`` without giving
+ * the filter logic a dependency on the full row list.
+ */
+interface FilterSummaryContext {
+  /** Total rows in the slice (numeric + partial). */
+  readonly totalRows: number;
+  /** Numeric rows in the slice (denominator for "X of Y"). */
+  readonly numericTotal: number;
+  /** Partial-sentinel rows in the slice — hidden whenever any
+   *  threshold is active per FR-3-05. */
+  readonly partialRowCount: number;
+}
+
+/**
+ * Issue #332 / B3: the threshold filter's slice-level feedback
+ * summary.  ``filterGroup`` and ``summary`` are returned together so
+ * the caller can mount them as siblings between the header and the
+ * ``<ol>`` (summary AFTER the filter row).  The summary is its own
+ * polite live region — distinct from the sort announcer (#332 / B1)
+ * because the two surface different events (sort direction vs filter
+ * visibility); SR engines queue back-to-back polite announcements so
+ * mutual exclusivity isn't required.
+ */
+interface FilterControls {
+  readonly filterGroup: HTMLElement;
+  readonly summary: HTMLElement;
+}
+
+/**
+ * Format the filter-feedback summary copy (#332 / B3).
+ *
+ * Three branches, all signed off:
+ *   - No threshold active → ``Showing all {totalRows} PRs.``
+ *   - Threshold active, no partials in slice → ``Showing {visibleNumeric} of {numericTotal} PRs.``
+ *   - Threshold active, partials in slice → adds
+ *     ``{partialRowCount} partial row(s) hidden by filter.`` on the
+ *     same line (singular when ``partialRowCount === 1``).
+ */
+function formatFilterSummary(
+  context: FilterSummaryContext,
+  hasActiveThreshold: boolean,
+  visibleNumeric: number,
+): string {
+  if (!hasActiveThreshold) {
+    return `Showing all ${context.totalRows} PRs.`;
+  }
+  if (context.partialRowCount === 0) {
+    return `Showing ${visibleNumeric} of ${context.numericTotal} PRs.`;
+  }
+  const noun = context.partialRowCount === 1 ? "row" : "rows";
+  return (
+    `Showing ${visibleNumeric} of ${context.numericTotal} PRs. ` +
+    `${context.partialRowCount} partial ${noun} hidden by filter.`
+  );
+}
+
+/**
  * Build the comments-metrics threshold filter bar (FR-3-03 / FR-4-02).
  *
  * Three numeric inputs that compose with AND semantics via
@@ -823,8 +884,16 @@ const COMMENTS_METRICS_C1_TOOLTIP =
  * Issue #332 / B2: a single info-icon adjacent to the "Min:" label
  * surfaces the C1 inclusion-rule contract via the shared
  * ``showInfoTooltip`` primitive (same pattern as ``summary-cards``).
+ *
+ * Issue #332 / B3: returns a ``summary`` element alongside the filter
+ * group — a polite live region whose copy reflects how many PRs are
+ * shown, how many are hidden by the threshold, and how many partial
+ * rows were swept by FR-3-05's any-threshold-hides-partials rule.
  */
-function buildCommentsMetricsFilter(list: HTMLOListElement): HTMLElement {
+function buildCommentsMetricsFilter(
+  list: HTMLOListElement,
+  context: FilterSummaryContext,
+): FilterControls {
   const filterGroup = createElement("div", {
     class: "detail-panel-pr-list-filter",
     role: "group",
@@ -877,6 +946,15 @@ function buildCommentsMetricsFilter(list: HTMLOListElement): HTMLElement {
     });
   });
   filterGroup.appendChild(infoIcon);
+  // Issue #332 / B3: feedback summary mounted as a sibling of the
+  // filter group; built here so it shares a closure with
+  // ``filterDescriptors`` and the per-input ``applyFilters`` call.
+  const summary = createElement("p", {
+    class: "detail-panel-pr-list-filter-summary",
+    role: "status",
+    "aria-live": "polite",
+  });
+  appendText(summary, formatFilterSummary(context, false, 0));
   const filterDescriptors: FilterDescriptor[] = [];
   for (const axis of COMMENTS_METRICS_AXES) {
     const label = createElement("label", {
@@ -892,13 +970,13 @@ function buildCommentsMetricsFilter(list: HTMLOListElement): HTMLElement {
     });
     const descriptor: FilterDescriptor = { input, dataAttr: axis.dataAttr };
     input.addEventListener("input", () =>
-      applyFilters(list, filterDescriptors),
+      applyFilters(list, filterDescriptors, summary, context),
     );
     label.appendChild(input);
     filterGroup.appendChild(label);
     filterDescriptors.push(descriptor);
   }
-  return filterGroup;
+  return { filterGroup, summary };
 }
 
 /** One filter input + its data attribute, paired at build time. */
@@ -955,6 +1033,8 @@ function applySort(
 function applyFilters(
   list: HTMLOListElement,
   descriptors: readonly FilterDescriptor[],
+  summary: HTMLElement,
+  context: FilterSummaryContext,
 ): void {
   const thresholds: Array<readonly [string, number]> = [];
   for (const desc of descriptors) {
@@ -970,6 +1050,8 @@ function applyFilters(
     if (parsed < 0) continue;
     thresholds.push([desc.dataAttr, parsed]);
   }
+  const hasActiveThreshold = thresholds.length > 0;
+  let visibleNumeric = 0;
   for (const child of list.querySelectorAll<HTMLLIElement>("li")) {
     let hidden = false;
     for (const [dataAttr, threshold] of thresholds) {
@@ -989,8 +1071,26 @@ function applyFilters(
       child.setAttribute("hidden", "");
     } else {
       child.removeAttribute("hidden");
+      // Issue #332 / B3: count visible NUMERIC rows (partial rows
+      // are excluded under FR-3-05 the moment any threshold is active,
+      // so they cannot reach this branch when ``hasActiveThreshold``;
+      // when no threshold is active they ARE visible but we suppress
+      // the "X of Y" copy in that path so visibleNumeric is unused).
+      if (!child.hasAttribute("data-partial")) {
+        visibleNumeric++;
+      }
     }
   }
+  // Issue #332 / B3: refresh the live summary.  Two-step "" → text so
+  // the polite region announces every transition (matches the sort
+  // announcer #332/B1 + loading-state.ts dashboard-banner pattern).
+  const nextText = formatFilterSummary(
+    context,
+    hasActiveThreshold,
+    visibleNumeric,
+  );
+  summary.textContent = "";
+  summary.textContent = nextText;
 }
 
 /**
@@ -1270,7 +1370,19 @@ function renderPrListSection(section: PrListSection): HTMLElement {
         }),
       );
       if (sortRowElements !== null) {
-        wrapper.appendChild(buildCommentsMetricsFilter(list));
+        // Issue #332 / B3: filter group + feedback summary mount as
+        // siblings of the wrapper, summary AFTER the filter row so
+        // the natural reading / SR-walk order is filter → summary →
+        // list.  Slice metadata derived from the same
+        // ``partialRowCount`` already used by the coverage notice
+        // (#331 / C2 + C3) above.
+        const filterControls = buildCommentsMetricsFilter(list, {
+          totalRows: rows.length,
+          numericTotal: rows.length - partialRowCount,
+          partialRowCount,
+        });
+        wrapper.appendChild(filterControls.filterGroup);
+        wrapper.appendChild(filterControls.summary);
       }
       for (const li of rowElements) {
         list.appendChild(li);

--- a/extension/ui/modules/shared/detail-panel.ts
+++ b/extension/ui/modules/shared/detail-panel.ts
@@ -657,6 +657,18 @@ function buildPrListHeader(
   // partial-branch debt.
   const records: SortHeaderRecord[] = [];
 
+  // Issue #332 / B1: SR-live announcer for sort direction changes.
+  // Created up front so the per-axis click closure (built only in the
+  // ``withSortButtons`` branch below) captures it as a non-nullable
+  // local — appended only when sort buttons are wired so suppressed-
+  // controls states (capability-on single-row #330/C5; capability-on
+  // all-partial #331/C2) don't carry an empty live region.
+  const sortAnnouncer = createElement("div", {
+    role: "status",
+    "aria-live": "polite",
+    class: "visually-hidden detail-panel-pr-list-sort-announcer",
+  });
+
   for (const axis of COMMENTS_METRICS_AXES) {
     const cellAttrs: Record<string, string> = {
       class: `detail-panel-pr-list-header-cell detail-panel-pr-list-header-cell--${axis.key}`,
@@ -736,7 +748,32 @@ function buildPrListHeader(
       record.state = nextDirection;
       record.cell.setAttribute("aria-sort", nextDirection);
       applySort(list, axis.dataAttr, nextDirection, originalOrder);
+
+      // Issue #332 / B1: announce the new sort state to assistive
+      // tech.  Two-step ``"" → message`` so the polite live region
+      // sees a real mutation even on back-to-back identical
+      // announcements (matches the loading-state.ts dashboard-banner
+      // pattern).  ``axis.label`` is the full disambiguated phrase
+      // ("Threads" / "Comments" / "Unresolved threads") so SR users
+      // hear the same form the column-header ``aria-label`` already
+      // uses.
+      sortAnnouncer.textContent = "";
+      sortAnnouncer.textContent =
+        nextDirection === "none"
+          ? "Sort cleared."
+          : `Sorted by ${axis.label.toLowerCase()}, ${nextDirection}.`;
     });
+  }
+
+  // Issue #332 / B1: append the SR-live announcer only when sort
+  // buttons are wired.  The capability-on suppressed-controls states
+  // reach this function but never wire a click closure, so an empty
+  // live region in those states would be DOM noise without an
+  // announcement source.  Both arms of this gate are exercised by the
+  // existing capability-on tests (multi-row → true; single-row /
+  // all-partial → false).
+  if (withSortButtons) {
+    header.appendChild(sortAnnouncer);
   }
 
   return header;

--- a/extension/ui/modules/shared/detail-panel.ts
+++ b/extension/ui/modules/shared/detail-panel.ts
@@ -34,6 +34,7 @@ import {
   type ComparisonToggledEvent,
   type TabChangedEvent,
 } from "../drilldown/lifecycle-signals";
+import { showInfoTooltip, dismissAllTooltips } from "../tooltip-manager";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -794,6 +795,22 @@ function advanceSortDirection(current: SortDirection): SortDirection {
 }
 
 /**
+ * Issue #332 / B2: condensed C1 inclusion-rule disclosure surfaced via
+ * a single info tooltip on the controls bar.  Authoritative source is
+ * ``specs/310-comments-visualization/spec.md`` "Shared inclusion-rule
+ * contract (C1)" — this string distills those rules per axis without
+ * re-declaring them.  One icon (not three per-axis) so the disclosure
+ * adds zero pixels to the columnheader tracks (Linux DejaVu header-fit
+ * contract from #341 / #330 stays intact).
+ */
+const COMMENTS_METRICS_C1_TOOLTIP =
+  "Counts apply Feature 310's inclusion rules. Threads include " +
+  "unknown-status threads but exclude deleted ones. Comments include " +
+  "system events; deleted comments are excluded. Unresolved counts " +
+  "only threads still in active status. Comments by users missing " +
+  "from the user table are still counted.";
+
+/**
  * Build the comments-metrics threshold filter bar (FR-3-03 / FR-4-02).
  *
  * Three numeric inputs that compose with AND semantics via
@@ -802,6 +819,10 @@ function advanceSortDirection(current: SortDirection): SortDirection {
  * ``COMMENTS_METRICS_AXES.label`` so the F8 rename ("Unresolved" →
  * "Unresolved threads") propagates consistently to the visible label
  * text and the input's ``aria-label``.
+ *
+ * Issue #332 / B2: a single info-icon adjacent to the "Min:" label
+ * surfaces the C1 inclusion-rule contract via the shared
+ * ``showInfoTooltip`` primitive (same pattern as ``summary-cards``).
  */
 function buildCommentsMetricsFilter(list: HTMLOListElement): HTMLElement {
   const filterGroup = createElement("div", {
@@ -816,6 +837,46 @@ function buildCommentsMetricsFilter(list: HTMLOListElement): HTMLElement {
       "Min:",
     ),
   );
+  // Issue #332 / B2: info icon for the C1 inclusion-rule disclosure.
+  // Hover (pointerenter / pointerleave) drives the desktop path; click
+  // shows + arms a one-shot document-level dismiss for touch / keyboard
+  // activation, mirroring ``attachInfoIcons`` in summary-cards.ts:690.
+  // Without the document-level listener a click-shown tooltip persists
+  // on outside-click (Codex stop-time review on the initial #332 / B2
+  // pass caught this).  ``event.stopPropagation()`` keeps the icon's
+  // own click from triggering the same listener it just armed; the
+  // ``requestAnimationFrame`` defer keeps the listener inert for the
+  // exact click that opened the tooltip; ``dismissOnce`` removes
+  // itself after firing so no listener leaks across opens.
+  const infoIcon = createElement("button", {
+    type: "button",
+    class: "info-icon-btn",
+    "data-info-tooltip": "comments-metrics-c1",
+    "aria-label": "About these counts",
+  });
+  appendText(infoIcon, "ℹ");
+  infoIcon.addEventListener("pointerenter", () => {
+    showInfoTooltip(infoIcon, COMMENTS_METRICS_C1_TOOLTIP);
+  });
+  infoIcon.addEventListener("pointerleave", () => {
+    dismissAllTooltips();
+  });
+  infoIcon.addEventListener("click", (event) => {
+    event.stopPropagation();
+    if (document.querySelector(".info-tooltip") !== null) {
+      dismissAllTooltips();
+      return;
+    }
+    showInfoTooltip(infoIcon, COMMENTS_METRICS_C1_TOOLTIP);
+    requestAnimationFrame(() => {
+      const dismissOnce = (): void => {
+        dismissAllTooltips();
+        document.removeEventListener("click", dismissOnce);
+      };
+      document.addEventListener("click", dismissOnce);
+    });
+  });
+  filterGroup.appendChild(infoIcon);
   const filterDescriptors: FilterDescriptor[] = [];
   for (const axis of COMMENTS_METRICS_AXES) {
     const label = createElement("label", {
@@ -1450,6 +1511,17 @@ export function dismissDetailPanel(reason: DismissReason): void {
   // renderContent / sectionsRoot children to verify the FR-005 invariant.
   openScopedController?.abort();
   openScopedController = null;
+
+  // Issue #332 / B2: any open info tooltip needs to dismiss when the
+  // panel closes — ``showInfoTooltip`` mounts the tooltip on
+  // ``document.body`` (so it can position-fixed against the viewport),
+  // not as a panel descendant, so the tooltip would otherwise persist
+  // as an orphan after the panel detaches.  Codex stop-time review
+  // caught this on the initial #332 / B2 pass.  Also covers any chart
+  // tooltip that happens to be open against another surface; both are
+  // managed by the same ``dismissAllTooltips`` primitive (mutual
+  // exclusivity contract in ``tooltip-manager.ts``).
+  dismissAllTooltips();
 
   // Focus restoration — target is the context.triggerElement captured on open
   // (FR-008). Fall back to focus-trap's recorded return if somehow unavailable.

--- a/extension/ui/modules/shared/detail-panel.ts
+++ b/extension/ui/modules/shared/detail-panel.ts
@@ -312,6 +312,33 @@ let comparisonActive = false;
   window.addEventListener(COMPARISON_TOGGLED_EVENT, lifetimeComparisonListener);
 }
 
+// Issue #332 / B2 (Codex PR #343 P2 follow-up): module-scope trackers
+// for the deferred outside-click dismiss the C1 info-icon arms when
+// the user clicks (touch / keyboard show path).  Two pieces of state
+// because the listener is armed across two phases — a pending rAF and
+// (after the rAF fires) an attached document-level click listener —
+// and an alternate dismiss path (pointerleave, second icon click,
+// ``dismissDetailPanel``) can interrupt EITHER phase.  Without
+// cancelling BOTH:
+//
+//   - Pre-rAF interrupt with abort-only cleanup: nothing to abort
+//     yet; the rAF still fires later and attaches the stale listener.
+//   - Post-rAF interrupt with frame-cancel-only cleanup: nothing
+//     pending to cancel; the already-attached listener leaks.
+//
+// ``clearOutsideClickListener`` collapses both phases.
+let outsideClickAbort: AbortController | null = null;
+let outsideClickFrame: number | null = null;
+
+function clearOutsideClickListener(): void {
+  outsideClickAbort?.abort();
+  outsideClickAbort = null;
+  if (outsideClickFrame !== null) {
+    cancelAnimationFrame(outsideClickFrame);
+    outsideClickFrame = null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // DOM construction
 // ---------------------------------------------------------------------------
@@ -929,20 +956,32 @@ function buildCommentsMetricsFilter(
   });
   infoIcon.addEventListener("pointerleave", () => {
     dismissAllTooltips();
+    clearOutsideClickListener();
   });
   infoIcon.addEventListener("click", (event) => {
     event.stopPropagation();
     if (document.querySelector(".info-tooltip") !== null) {
       dismissAllTooltips();
+      clearOutsideClickListener();
       return;
     }
     showInfoTooltip(infoIcon, COMMENTS_METRICS_C1_TOOLTIP);
-    requestAnimationFrame(() => {
-      const dismissOnce = (): void => {
-        dismissAllTooltips();
-        document.removeEventListener("click", dismissOnce);
-      };
-      document.addEventListener("click", dismissOnce);
+    // Win-last semantics: if a prior click already armed a frame or
+    // listener that hasn't been cleaned up by an alternate path, drop
+    // it before scheduling the new one so we never have two armed
+    // dismiss paths racing each other.
+    clearOutsideClickListener();
+    outsideClickFrame = requestAnimationFrame(() => {
+      outsideClickFrame = null;
+      outsideClickAbort = new AbortController();
+      document.addEventListener(
+        "click",
+        () => {
+          dismissAllTooltips();
+          clearOutsideClickListener();
+        },
+        { signal: outsideClickAbort.signal, once: true },
+      );
     });
   });
   filterGroup.appendChild(infoIcon);
@@ -1633,7 +1672,16 @@ export function dismissDetailPanel(reason: DismissReason): void {
   // tooltip that happens to be open against another surface; both are
   // managed by the same ``dismissAllTooltips`` primitive (mutual
   // exclusivity contract in ``tooltip-manager.ts``).
+  //
+  // Codex PR #343 P2 follow-up: the deferred outside-click listener
+  // armed by the C1 info-icon click handler must be cancelled here
+  // too — the dismissAllTooltips above only removes tooltip DOM, not
+  // the document-level dismiss listener.  Without this, a panel
+  // closed before the user clicks anywhere leaves a stale listener
+  // that fires on the next dashboard click and clobbers any chart
+  // tooltip the user just opened.
   dismissAllTooltips();
+  clearOutsideClickListener();
 
   // Focus restoration — target is the context.triggerElement captured on open
   // (FR-008). Fall back to focus-trap's recorded return if somehow unavailable.

--- a/extension/ui/modules/shared/detail-panel.ts
+++ b/extension/ui/modules/shared/detail-panel.ts
@@ -1628,6 +1628,20 @@ export function openDetailPanel(context: DrillDownContext): void {
   const wasOpen = isDetailPanelOpen();
   activeContext = context;
 
+  if (wasOpen) {
+    // Issue #332 / B2 (Codex PR #343 P2 follow-up): retarget-in-place
+    // (cycle-time P50↔P90 swap, throughput week-to-week, etc.)
+    // replaces the panel's DOM via ``renderContent`` below WITHOUT
+    // going through ``dismissDetailPanel``.  The old C1 info-icon's
+    // element-bound listeners are GC'd with the detached DOM, but
+    // the deferred document-level dismiss listener (or its pending
+    // ``rAF``) survives — Codex stop-time review flagged this as the
+    // path the prior fix missed.  Drop both the tooltip and the
+    // listener so the new render starts from a clean tooltip lifecycle.
+    dismissAllTooltips();
+    clearOutsideClickListener();
+  }
+
   if (!wasOpen) {
     // Install the open-scoped controller BEFORE render + is-open so
     // applyTopOffset's ResizeObserver teardown can piggyback on the

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -4837,6 +4837,10 @@ var PRInsightsDashboard = (() => {
     const els = ensurePanelEls();
     const wasOpen = isDetailPanelOpen();
     activeContext = context;
+    if (wasOpen) {
+      dismissAllTooltips();
+      clearOutsideClickListener();
+    }
     if (!wasOpen) {
       openScopedController = installOpenScopedListeners(els);
       applyTopOffset(els.root, openScopedController.signal);

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -4166,6 +4166,16 @@ var PRInsightsDashboard = (() => {
     };
     window.addEventListener(COMPARISON_TOGGLED_EVENT, lifetimeComparisonListener);
   }
+  var outsideClickAbort = null;
+  var outsideClickFrame = null;
+  function clearOutsideClickListener() {
+    outsideClickAbort?.abort();
+    outsideClickAbort = null;
+    if (outsideClickFrame !== null) {
+      cancelAnimationFrame(outsideClickFrame);
+      outsideClickFrame = null;
+    }
+  }
   function ensurePanelEls() {
     if (panelEls && !panelEls.root.isConnected) {
       panelEls = null;
@@ -4445,20 +4455,28 @@ var PRInsightsDashboard = (() => {
     });
     infoIcon.addEventListener("pointerleave", () => {
       dismissAllTooltips();
+      clearOutsideClickListener();
     });
     infoIcon.addEventListener("click", (event) => {
       event.stopPropagation();
       if (document.querySelector(".info-tooltip") !== null) {
         dismissAllTooltips();
+        clearOutsideClickListener();
         return;
       }
       showInfoTooltip(infoIcon, COMMENTS_METRICS_C1_TOOLTIP);
-      requestAnimationFrame(() => {
-        const dismissOnce = () => {
-          dismissAllTooltips();
-          document.removeEventListener("click", dismissOnce);
-        };
-        document.addEventListener("click", dismissOnce);
+      clearOutsideClickListener();
+      outsideClickFrame = requestAnimationFrame(() => {
+        outsideClickFrame = null;
+        outsideClickAbort = new AbortController();
+        document.addEventListener(
+          "click",
+          () => {
+            dismissAllTooltips();
+            clearOutsideClickListener();
+          },
+          { signal: outsideClickAbort.signal, once: true }
+        );
       });
     });
     filterGroup.appendChild(infoIcon);
@@ -4837,6 +4855,7 @@ var PRInsightsDashboard = (() => {
     openScopedController?.abort();
     openScopedController = null;
     dismissAllTooltips();
+    clearOutsideClickListener();
     const trigger = activeContext?.triggerElement ?? null;
     if (focusTrapController) {
       if (trigger && trigger.isConnected) {

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -4041,6 +4041,72 @@ var PRInsightsDashboard = (() => {
     );
   }
 
+  // ../ui/modules/tooltip-manager.ts
+  var scrollDismissController = null;
+  function ensureScrollDismissListener() {
+    if (scrollDismissController) return;
+    scrollDismissController = new AbortController();
+    const { signal } = scrollDismissController;
+    const dismiss = () => dismissAllTooltips();
+    window.addEventListener("scroll", dismiss, { signal, passive: true });
+    window.addEventListener("resize", dismiss, { signal, passive: true });
+  }
+  function releaseScrollDismissListener() {
+    scrollDismissController?.abort();
+    scrollDismissController = null;
+  }
+  function dismissAllTooltips() {
+    const chartTooltip = document.querySelector(".chart-tooltip");
+    if (chartTooltip) chartTooltip.remove();
+    const infoTooltip = document.querySelector(".info-tooltip");
+    if (infoTooltip) infoTooltip.remove();
+    releaseScrollDismissListener();
+  }
+  function positionTooltip(tooltip, targetRect) {
+    tooltip.style.visibility = "hidden";
+    tooltip.style.position = "fixed";
+    document.body.appendChild(tooltip);
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const gap = 8;
+    let top = targetRect.top - tooltipRect.height - gap;
+    if (top < 0) {
+      top = targetRect.bottom + gap;
+    }
+    if (top + tooltipRect.height > window.innerHeight) {
+      top = window.innerHeight - tooltipRect.height - 4;
+    }
+    let left = targetRect.left + targetRect.width / 2 - tooltipRect.width / 2;
+    if (left < 4) {
+      left = 4;
+    }
+    if (left + tooltipRect.width > window.innerWidth - 4) {
+      left = window.innerWidth - tooltipRect.width - 4;
+    }
+    tooltip.style.top = `${top}px`;
+    tooltip.style.left = `${left}px`;
+    tooltip.style.visibility = "";
+  }
+  function showChartTooltip(target, content) {
+    dismissAllTooltips();
+    const tooltip = document.createElement("div");
+    tooltip.className = "chart-tooltip";
+    renderTrustedHtml(tooltip, content);
+    tooltip.style.position = "fixed";
+    const rect = target.getBoundingClientRect();
+    positionTooltip(tooltip, rect);
+    ensureScrollDismissListener();
+  }
+  function showInfoTooltip(target, content) {
+    dismissAllTooltips();
+    const tooltip = document.createElement("div");
+    tooltip.className = "info-tooltip";
+    tooltip.textContent = content;
+    tooltip.style.position = "fixed";
+    const rect = target.getBoundingClientRect();
+    positionTooltip(tooltip, rect);
+    ensureScrollDismissListener();
+  }
+
   // ../ui/modules/shared/detail-panel.ts
   function isPartialPrRow(row) {
     return row.threadCount === null || row.threadCount === void 0;
@@ -4343,6 +4409,7 @@ var PRInsightsDashboard = (() => {
     if (current === "descending") return "ascending";
     return "none";
   }
+  var COMMENTS_METRICS_C1_TOOLTIP = "Counts apply Feature 310's inclusion rules. Threads include unknown-status threads but exclude deleted ones. Comments include system events; deleted comments are excluded. Unresolved counts only threads still in active status. Comments by users missing from the user table are still counted.";
   function buildCommentsMetricsFilter(list) {
     const filterGroup = createElement("div", {
       class: "detail-panel-pr-list-filter",
@@ -4356,6 +4423,35 @@ var PRInsightsDashboard = (() => {
         "Min:"
       )
     );
+    const infoIcon = createElement("button", {
+      type: "button",
+      class: "info-icon-btn",
+      "data-info-tooltip": "comments-metrics-c1",
+      "aria-label": "About these counts"
+    });
+    appendText(infoIcon, "\u2139");
+    infoIcon.addEventListener("pointerenter", () => {
+      showInfoTooltip(infoIcon, COMMENTS_METRICS_C1_TOOLTIP);
+    });
+    infoIcon.addEventListener("pointerleave", () => {
+      dismissAllTooltips();
+    });
+    infoIcon.addEventListener("click", (event) => {
+      event.stopPropagation();
+      if (document.querySelector(".info-tooltip") !== null) {
+        dismissAllTooltips();
+        return;
+      }
+      showInfoTooltip(infoIcon, COMMENTS_METRICS_C1_TOOLTIP);
+      requestAnimationFrame(() => {
+        const dismissOnce = () => {
+          dismissAllTooltips();
+          document.removeEventListener("click", dismissOnce);
+        };
+        document.addEventListener("click", dismissOnce);
+      });
+    });
+    filterGroup.appendChild(infoIcon);
     const filterDescriptors = [];
     for (const axis of COMMENTS_METRICS_AXES) {
       const label = createElement("label", {
@@ -4706,6 +4802,7 @@ var PRInsightsDashboard = (() => {
     panelState = "closing";
     openScopedController?.abort();
     openScopedController = null;
+    dismissAllTooltips();
     const trigger = activeContext?.triggerElement ?? null;
     if (focusTrapController) {
       if (trigger && trigger.isConnected) {
@@ -6796,72 +6893,6 @@ var PRInsightsDashboard = (() => {
         }
         break;
     }
-  }
-
-  // ../ui/modules/tooltip-manager.ts
-  var scrollDismissController = null;
-  function ensureScrollDismissListener() {
-    if (scrollDismissController) return;
-    scrollDismissController = new AbortController();
-    const { signal } = scrollDismissController;
-    const dismiss = () => dismissAllTooltips();
-    window.addEventListener("scroll", dismiss, { signal, passive: true });
-    window.addEventListener("resize", dismiss, { signal, passive: true });
-  }
-  function releaseScrollDismissListener() {
-    scrollDismissController?.abort();
-    scrollDismissController = null;
-  }
-  function dismissAllTooltips() {
-    const chartTooltip = document.querySelector(".chart-tooltip");
-    if (chartTooltip) chartTooltip.remove();
-    const infoTooltip = document.querySelector(".info-tooltip");
-    if (infoTooltip) infoTooltip.remove();
-    releaseScrollDismissListener();
-  }
-  function positionTooltip(tooltip, targetRect) {
-    tooltip.style.visibility = "hidden";
-    tooltip.style.position = "fixed";
-    document.body.appendChild(tooltip);
-    const tooltipRect = tooltip.getBoundingClientRect();
-    const gap = 8;
-    let top = targetRect.top - tooltipRect.height - gap;
-    if (top < 0) {
-      top = targetRect.bottom + gap;
-    }
-    if (top + tooltipRect.height > window.innerHeight) {
-      top = window.innerHeight - tooltipRect.height - 4;
-    }
-    let left = targetRect.left + targetRect.width / 2 - tooltipRect.width / 2;
-    if (left < 4) {
-      left = 4;
-    }
-    if (left + tooltipRect.width > window.innerWidth - 4) {
-      left = window.innerWidth - tooltipRect.width - 4;
-    }
-    tooltip.style.top = `${top}px`;
-    tooltip.style.left = `${left}px`;
-    tooltip.style.visibility = "";
-  }
-  function showChartTooltip(target, content) {
-    dismissAllTooltips();
-    const tooltip = document.createElement("div");
-    tooltip.className = "chart-tooltip";
-    renderTrustedHtml(tooltip, content);
-    tooltip.style.position = "fixed";
-    const rect = target.getBoundingClientRect();
-    positionTooltip(tooltip, rect);
-    ensureScrollDismissListener();
-  }
-  function showInfoTooltip(target, content) {
-    dismissAllTooltips();
-    const tooltip = document.createElement("div");
-    tooltip.className = "info-tooltip";
-    tooltip.textContent = content;
-    tooltip.style.position = "fixed";
-    const rect = target.getBoundingClientRect();
-    positionTooltip(tooltip, rect);
-    ensureScrollDismissListener();
   }
 
   // ../ui/modules/charts.ts

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -4410,7 +4410,17 @@ var PRInsightsDashboard = (() => {
     return "none";
   }
   var COMMENTS_METRICS_C1_TOOLTIP = "Counts apply Feature 310's inclusion rules. Threads include unknown-status threads but exclude deleted ones. Comments include system events; deleted comments are excluded. Unresolved counts only threads still in active status. Comments by users missing from the user table are still counted.";
-  function buildCommentsMetricsFilter(list) {
+  function formatFilterSummary(context, hasActiveThreshold, visibleNumeric) {
+    if (!hasActiveThreshold) {
+      return `Showing all ${context.totalRows} PRs.`;
+    }
+    if (context.partialRowCount === 0) {
+      return `Showing ${visibleNumeric} of ${context.numericTotal} PRs.`;
+    }
+    const noun = context.partialRowCount === 1 ? "row" : "rows";
+    return `Showing ${visibleNumeric} of ${context.numericTotal} PRs. ${context.partialRowCount} partial ${noun} hidden by filter.`;
+  }
+  function buildCommentsMetricsFilter(list, context) {
     const filterGroup = createElement("div", {
       class: "detail-panel-pr-list-filter",
       role: "group",
@@ -4452,6 +4462,12 @@ var PRInsightsDashboard = (() => {
       });
     });
     filterGroup.appendChild(infoIcon);
+    const summary = createElement("p", {
+      class: "detail-panel-pr-list-filter-summary",
+      role: "status",
+      "aria-live": "polite"
+    });
+    appendText(summary, formatFilterSummary(context, false, 0));
     const filterDescriptors = [];
     for (const axis of COMMENTS_METRICS_AXES) {
       const label = createElement("label", {
@@ -4468,13 +4484,13 @@ var PRInsightsDashboard = (() => {
       const descriptor = { input, dataAttr: axis.dataAttr };
       input.addEventListener(
         "input",
-        () => applyFilters(list, filterDescriptors)
+        () => applyFilters(list, filterDescriptors, summary, context)
       );
       label.appendChild(input);
       filterGroup.appendChild(label);
       filterDescriptors.push(descriptor);
     }
-    return filterGroup;
+    return { filterGroup, summary };
   }
   function applySort(list, dataAttr, direction, originalOrder) {
     if (direction === "none") {
@@ -4494,7 +4510,7 @@ var PRInsightsDashboard = (() => {
     });
     for (const item of items) list.appendChild(item);
   }
-  function applyFilters(list, descriptors) {
+  function applyFilters(list, descriptors, summary, context) {
     const thresholds = [];
     for (const desc of descriptors) {
       const raw = desc.input.value.trim();
@@ -4503,6 +4519,8 @@ var PRInsightsDashboard = (() => {
       if (parsed < 0) continue;
       thresholds.push([desc.dataAttr, parsed]);
     }
+    const hasActiveThreshold = thresholds.length > 0;
+    let visibleNumeric = 0;
     for (const child of list.querySelectorAll("li")) {
       let hidden = false;
       for (const [dataAttr, threshold] of thresholds) {
@@ -4520,8 +4538,18 @@ var PRInsightsDashboard = (() => {
         child.setAttribute("hidden", "");
       } else {
         child.removeAttribute("hidden");
+        if (!child.hasAttribute("data-partial")) {
+          visibleNumeric++;
+        }
       }
     }
+    const nextText = formatFilterSummary(
+      context,
+      hasActiveThreshold,
+      visibleNumeric
+    );
+    summary.textContent = "";
+    summary.textContent = nextText;
   }
   function renderPrListSection(section) {
     const wrapper = createElement("section", {
@@ -4628,7 +4656,13 @@ var PRInsightsDashboard = (() => {
           })
         );
         if (sortRowElements !== null) {
-          wrapper.appendChild(buildCommentsMetricsFilter(list));
+          const filterControls = buildCommentsMetricsFilter(list, {
+            totalRows: rows.length,
+            numericTotal: rows.length - partialRowCount,
+            partialRowCount
+          });
+          wrapper.appendChild(filterControls.filterGroup);
+          wrapper.appendChild(filterControls.summary);
         }
         for (const li of rowElements) {
           list.appendChild(li);

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -4281,6 +4281,11 @@ var PRInsightsDashboard = (() => {
     );
     if (!commentsMetricsAvailable) return header;
     const records = [];
+    const sortAnnouncer = createElement("div", {
+      role: "status",
+      "aria-live": "polite",
+      class: "visually-hidden detail-panel-pr-list-sort-announcer"
+    });
     for (const axis of COMMENTS_METRICS_AXES) {
       const cellAttrs = {
         class: `detail-panel-pr-list-header-cell detail-panel-pr-list-header-cell--${axis.key}`,
@@ -4324,7 +4329,12 @@ var PRInsightsDashboard = (() => {
         record.state = nextDirection;
         record.cell.setAttribute("aria-sort", nextDirection);
         applySort(list, axis.dataAttr, nextDirection, originalOrder);
+        sortAnnouncer.textContent = "";
+        sortAnnouncer.textContent = nextDirection === "none" ? "Sort cleared." : `Sorted by ${axis.label.toLowerCase()}, ${nextDirection}.`;
       });
+    }
+    if (withSortButtons) {
+      header.appendChild(sortAnnouncer);
     }
     return header;
   }

--- a/src/ado_git_repo_insights/ui_bundle/settings.js
+++ b/src/ado_git_repo_insights/ui_bundle/settings.js
@@ -64,6 +64,20 @@ var PRInsightsSettings = (() => {
   // ../ui/modules/drilldown/lifecycle-signals.ts
   var COMPARISON_TOGGLED_EVENT = "drilldown:comparison-toggled";
 
+  // ../ui/modules/tooltip-manager.ts
+  var scrollDismissController = null;
+  function releaseScrollDismissListener() {
+    scrollDismissController?.abort();
+    scrollDismissController = null;
+  }
+  function dismissAllTooltips() {
+    const chartTooltip = document.querySelector(".chart-tooltip");
+    if (chartTooltip) chartTooltip.remove();
+    const infoTooltip = document.querySelector(".info-tooltip");
+    if (infoTooltip) infoTooltip.remove();
+    releaseScrollDismissListener();
+  }
+
   // ../ui/modules/shared/detail-panel.ts
   var panelEls = null;
   var panelState = "closed";
@@ -86,6 +100,7 @@ var PRInsightsSettings = (() => {
     panelState = "closing";
     openScopedController?.abort();
     openScopedController = null;
+    dismissAllTooltips();
     const trigger = activeContext?.triggerElement ?? null;
     if (focusTrapController) {
       if (trigger && trigger.isConnected) {

--- a/src/ado_git_repo_insights/ui_bundle/settings.js
+++ b/src/ado_git_repo_insights/ui_bundle/settings.js
@@ -92,6 +92,16 @@ var PRInsightsSettings = (() => {
     };
     window.addEventListener(COMPARISON_TOGGLED_EVENT, lifetimeComparisonListener);
   }
+  var outsideClickAbort = null;
+  var outsideClickFrame = null;
+  function clearOutsideClickListener() {
+    outsideClickAbort?.abort();
+    outsideClickAbort = null;
+    if (outsideClickFrame !== null) {
+      cancelAnimationFrame(outsideClickFrame);
+      outsideClickFrame = null;
+    }
+  }
   function isDetailPanelOpen() {
     return panelState === "opening" || panelState === "open";
   }
@@ -101,6 +111,7 @@ var PRInsightsSettings = (() => {
     openScopedController?.abort();
     openScopedController = null;
     dismissAllTooltips();
+    clearOutsideClickListener();
     const trigger = activeContext?.triggerElement ?? null;
     if (focusTrapController) {
       if (trigger && trigger.isConnected) {


### PR DESCRIPTION
## Summary
- **B1 — sort SR-live announcer**: polite `role=status` region inside the comments-metrics header announces "Sorted by {axis}, {direction}." / "Sort cleared." on every click; only mounts when sort buttons are wired (cap-on, >1 row, !all-partial).
- **B2 — single C1 info icon at "Min:"**: one `info-icon-btn` adjacent to the threshold filter's "Min:" label surfaces the Feature 310 C1 inclusion-rule contract via `showInfoTooltip`. Hover, click, outside-click, and panel-close all dismiss correctly. Tooltip text distills C1 per axis without re-declaring it (310 spec stays authoritative). One icon — not three per-axis — so the disclosure adds zero pixels to header tracks (#341 / #330 Linux DejaVu fit contract preserved).
- **B3 — filter feedback summary**: polite `role=status` `<p>` between the filter row and the `<ol>` reports `Showing all N PRs.` / `Showing X of Y PRs.` / `Showing X of Y PRs. P partial row(s) hidden by filter.` (singular when P===1). Surfaces FR-3-05's any-threshold-hides-partials sweep, which was previously invisible.

## Invariants preserved
- **SC-03 / INV-01**: capability-off DOM unchanged. All three affordances mount only when the sort buttons mount (existing cap-on / >1-row / !all-partial gate). Locked by `pr-list-capability-off-baseline.test.ts`.
- **#341 / #330 header-fit**: no track-width changes. Locked by `comments-metrics-responsive.test.ts`.
- **INV-08 / INV-10**: render-only changes; no aggregator, schema, or contract touched.
- **C1 source of truth**: `specs/310-comments-visualization/spec.md` "Shared inclusion-rule contract (C1)" remains authoritative; B2 tooltip text is a verbatim distillation, not a re-declaration.
- **Partial-branch ratchet**: 318/318, no regression.
- **Test floor**: `2824 → 2842` (+18 net new tests across the stack — 5 B1 + 7 B2 + 6 B3, all in `pr-list-comments-columns.test.ts`).

## Codex stop-time review (folded into B2)
Initial B2 pass had two tooltip-persistence holes; both fixed in the same B2 commit:
- Outside-click dismiss via `summary-cards`-pattern rAF + `dismissOnce` doc listener.
- Panel-close cleanup via `dismissAllTooltips()` in `dismissDetailPanel` (covers escape / outside-click / explicit close / filters changed / tab changed / comparison toggled).

## Test plan
- [x] All 38 Tier 2 preflight gates green locally (`python scripts/run_pr_preflight.py`)
- [x] Capability-off baseline unchanged (`pr-list-capability-off-baseline.test.ts`)
- [x] Header-fit responsive contract unchanged (`comments-metrics-responsive.test.ts`)
- [x] Partial-branch ratchet at baseline (318/318)
- [x] Test floor moves `2824 → 2842` and matches authoritative `extension/test-results.xml` count
- [ ] CI green on this PR (awaiting checks)
- [ ] Capability-on smoke walkthrough on a multi-row !all-partial slice: verify SR announces sort direction, info tooltip discloses C1, filter summary reports "X of Y" and "P partial rows hidden"
- [ ] Capability-off smoke walkthrough: confirm no SR announcer, no info icon, no filter summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)