### PR TITLE
fix(drilldown): info-tooltip z-index + plain-language copy (#332/B2 follow-up)

### DIFF
--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2847,
+    "min_collected": 2848,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -4419,7 +4419,7 @@ var PRInsightsDashboard = (() => {
     if (current === "descending") return "ascending";
     return "none";
   }
-  var COMMENTS_METRICS_C1_TOOLTIP = "Counts apply Feature 310's inclusion rules. Threads include unknown-status threads but exclude deleted ones. Comments include system events; deleted comments are excluded. Unresolved counts only threads still in active status. Comments by users missing from the user table are still counted.";
+  var COMMENTS_METRICS_C1_TOOLTIP = "How counts are tallied: The Threads count includes every review thread on this PR, including threads with no recorded status. The Comments count includes every comment, including automated build or CI notifications. The Unresolved count includes only threads currently in the Active state. Deleted threads and comments are not counted. Comments and threads from users who have left the organization are still counted.";
   function formatFilterSummary(context, hasActiveThreshold, visibleNumeric) {
     if (!hasActiveThreshold) {
       return `Showing all ${context.totalRows} PRs.`;
@@ -7103,11 +7103,11 @@ var PRInsightsDashboard = (() => {
     ],
     [
       "cycleP50",
-      "Median time from PR creation to merge. Half of all PRs completed faster than this. (Aggregated from weekly values.)"
+      "Median time from PR creation to merge. Half of all PRs completed faster than this. Calculated from weekly summaries."
     ],
     [
       "cycleP90",
-      "90th percentile cycle time. 90% of PRs completed faster. High values may indicate bottlenecks. (Aggregated from weekly values.)"
+      "90th percentile cycle time. 90% of PRs completed faster. High values may indicate bottlenecks. Calculated from weekly summaries."
     ],
     [
       "authorsCount",
@@ -7119,11 +7119,11 @@ var PRInsightsDashboard = (() => {
     ],
     [
       "reviewTimeP50",
-      "Median time from first review request to review completion. Half of all reviews completed faster than this. (Aggregated from weekly values.)"
+      "Median time from first review request to review completion. Half of all reviews completed faster than this. Calculated from weekly summaries."
     ],
     [
       "reviewTimeP90",
-      "90th percentile review time. 90% of reviews completed faster. High values may indicate review bottlenecks. (Aggregated from weekly values.)"
+      "90th percentile review time. 90% of reviews completed faster. High values may indicate review bottlenecks. Calculated from weekly summaries."
     ]
   ]);
   function renderSummaryCards(options) {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1333,7 +1333,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     white-space: nowrap;
 }
 
-/* Info Tooltip (summary card metric explanations) */
+/* Info Tooltip (summary card metric explanations + #332/B2 drill-down
+ * panel info-icon disclosure) */
 .info-tooltip {
     position: fixed;
     background: var(--bg-primary);
@@ -1343,7 +1344,13 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     box-shadow: var(--shadow-md);
     font-size: 12px;
     pointer-events: none;
-    z-index: 150;
+    /* #332/B2 follow-up: must sit above .detail-panel (1050, PR #302
+     * P1.C) so the C1 info-icon's tooltip renders in front of the
+     * drill-down panel rather than occluded behind it.  Stays BELOW
+     * .comparison-advisory-toast (1060) so the higher-priority
+     * "drill-down disabled" advisory always wins on overlap.  Locked
+     * in tests/unit/css-contract.test.ts. */
+    z-index: 1055;
     max-width: min(280px, calc(100vw - 16px));
     white-space: normal;
     line-height: 1.4;

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -4419,7 +4419,7 @@ var PRInsightsDashboard = (() => {
     if (current === "descending") return "ascending";
     return "none";
   }
-  var COMMENTS_METRICS_C1_TOOLTIP = "Counts apply Feature 310's inclusion rules. Threads include unknown-status threads but exclude deleted ones. Comments include system events; deleted comments are excluded. Unresolved counts only threads still in active status. Comments by users missing from the user table are still counted.";
+  var COMMENTS_METRICS_C1_TOOLTIP = "How counts are tallied: The Threads count includes every review thread on this PR, including threads with no recorded status. The Comments count includes every comment, including automated build or CI notifications. The Unresolved count includes only threads currently in the Active state. Deleted threads and comments are not counted. Comments and threads from users who have left the organization are still counted.";
   function formatFilterSummary(context, hasActiveThreshold, visibleNumeric) {
     if (!hasActiveThreshold) {
       return `Showing all ${context.totalRows} PRs.`;
@@ -7103,11 +7103,11 @@ var PRInsightsDashboard = (() => {
     ],
     [
       "cycleP50",
-      "Median time from PR creation to merge. Half of all PRs completed faster than this. (Aggregated from weekly values.)"
+      "Median time from PR creation to merge. Half of all PRs completed faster than this. Calculated from weekly summaries."
     ],
     [
       "cycleP90",
-      "90th percentile cycle time. 90% of PRs completed faster. High values may indicate bottlenecks. (Aggregated from weekly values.)"
+      "90th percentile cycle time. 90% of PRs completed faster. High values may indicate bottlenecks. Calculated from weekly summaries."
     ],
     [
       "authorsCount",
@@ -7119,11 +7119,11 @@ var PRInsightsDashboard = (() => {
     ],
     [
       "reviewTimeP50",
-      "Median time from first review request to review completion. Half of all reviews completed faster than this. (Aggregated from weekly values.)"
+      "Median time from first review request to review completion. Half of all reviews completed faster than this. Calculated from weekly summaries."
     ],
     [
       "reviewTimeP90",
-      "90th percentile review time. 90% of reviews completed faster. High values may indicate review bottlenecks. (Aggregated from weekly values.)"
+      "90th percentile review time. 90% of reviews completed faster. High values may indicate review bottlenecks. Calculated from weekly summaries."
     ]
   ]);
   function renderSummaryCards(options) {

--- a/extension/tests/fixtures/broken-docs/styles.css
+++ b/extension/tests/fixtures/broken-docs/styles.css
@@ -1333,7 +1333,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     white-space: nowrap;
 }
 
-/* Info Tooltip (summary card metric explanations) */
+/* Info Tooltip (summary card metric explanations + #332/B2 drill-down
+ * panel info-icon disclosure) */
 .info-tooltip {
     position: fixed;
     background: var(--bg-primary);
@@ -1343,7 +1344,13 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     box-shadow: var(--shadow-md);
     font-size: 12px;
     pointer-events: none;
-    z-index: 150;
+    /* #332/B2 follow-up: must sit above .detail-panel (1050, PR #302
+     * P1.C) so the C1 info-icon's tooltip renders in front of the
+     * drill-down panel rather than occluded behind it.  Stays BELOW
+     * .comparison-advisory-toast (1060) so the higher-priority
+     * "drill-down disabled" advisory always wins on overlap.  Locked
+     * in tests/unit/css-contract.test.ts. */
+    z-index: 1055;
     max-width: min(280px, calc(100vw - 16px));
     white-space: normal;
     line-height: 1.4;

--- a/extension/tests/modules/charts/summary-cards-info.test.ts
+++ b/extension/tests/modules/charts/summary-cards-info.test.ts
@@ -412,14 +412,14 @@ describe("Summary Cards Info Icons (attachInfoIcons)", () => {
         "reviewTimeP90",
       ]) {
         const text = METRIC_EXPLANATIONS.get(key) ?? "";
-        expect(text).toContain("Aggregated from weekly values");
+        expect(text).toContain("Calculated from weekly summaries");
       }
     });
 
     it("non-median metrics do NOT include aggregation disclosure", () => {
       for (const key of ["totalPrs", "authorsCount", "reviewersCount"]) {
         const text = METRIC_EXPLANATIONS.get(key) ?? "";
-        expect(text).not.toContain("Aggregated");
+        expect(text).not.toContain("Calculated from weekly summaries");
       }
     });
   });

--- a/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
+++ b/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
@@ -1743,11 +1743,13 @@ describe("issue #332 / B2 — single C1 info icon adjacent to 'Min:' controls la
   // toggles for touch / keyboard.  Suppressed-controls states emit
   // no icon (the filter itself is absent).
   const C1_TOOLTIP_TEXT =
-    "Counts apply Feature 310's inclusion rules. Threads include " +
-    "unknown-status threads but exclude deleted ones. Comments include " +
-    "system events; deleted comments are excluded. Unresolved counts " +
-    "only threads still in active status. Comments by users missing " +
-    "from the user table are still counted.";
+    "How counts are tallied: The Threads count includes every review " +
+    "thread on this PR, including threads with no recorded status. The " +
+    "Comments count includes every comment, including automated build " +
+    "or CI notifications. The Unresolved count includes only threads " +
+    "currently in the Active state. Deleted threads and comments are " +
+    "not counted. Comments and threads from users who have left the " +
+    "organization are still counted.";
 
   function iconSection(): PrListSection {
     return makePrListSection({

--- a/extension/tests/unit/css-contract.test.ts
+++ b/extension/tests/unit/css-contract.test.ts
@@ -219,6 +219,22 @@ describe("CSS Contract: z-index stacking (PR #302 P1.C)", () => {
     expect(zIndexOf(".comparison-advisory-toast")).toBe(1060);
   });
 
+  it("sets .info-tooltip z-index to 1055 — above .detail-panel, below .comparison-advisory-toast (#332/B2 follow-up)", () => {
+    // The C1 info icon introduced in #332/B2 lives inside the drill-
+    // down panel.  ``showInfoTooltip`` mounts the tooltip on
+    // ``document.body`` (sibling of the panel root), so sibling z-
+    // index decides paint order: the prior 150 was occluded behind
+    // the panel's 1050.  1055 sits above the panel but stays below
+    // the advisory toast (1060) so a "drill-down disabled" cue still
+    // wins on overlap with an info-icon tooltip.  Locks BOTH
+    // relationships explicitly so a future bump to either neighbour
+    // surfaces here as a contract failure.
+    const infoTooltip = zIndexOf(".info-tooltip");
+    expect(infoTooltip).toBe(1055);
+    expect(infoTooltip).toBeGreaterThan(zIndexOf(".detail-panel"));
+    expect(infoTooltip).toBeLessThan(zIndexOf(".comparison-advisory-toast"));
+  });
+
   it("stacks advisory-toast > detail-panel > pre-existing toast", () => {
     const toast = zIndexOf(".toast");
     const panel = zIndexOf(".detail-panel");

--- a/extension/ui/modules/charts/summary-cards.ts
+++ b/extension/ui/modules/charts/summary-cards.ts
@@ -37,11 +37,11 @@ export const METRIC_EXPLANATIONS = new Map<string, string>([
   ],
   [
     "cycleP50",
-    "Median time from PR creation to merge. Half of all PRs completed faster than this. (Aggregated from weekly values.)",
+    "Median time from PR creation to merge. Half of all PRs completed faster than this. Calculated from weekly summaries.",
   ],
   [
     "cycleP90",
-    "90th percentile cycle time. 90% of PRs completed faster. High values may indicate bottlenecks. (Aggregated from weekly values.)",
+    "90th percentile cycle time. 90% of PRs completed faster. High values may indicate bottlenecks. Calculated from weekly summaries.",
   ],
   [
     "authorsCount",
@@ -53,11 +53,11 @@ export const METRIC_EXPLANATIONS = new Map<string, string>([
   ],
   [
     "reviewTimeP50",
-    "Median time from first review request to review completion. Half of all reviews completed faster than this. (Aggregated from weekly values.)",
+    "Median time from first review request to review completion. Half of all reviews completed faster than this. Calculated from weekly summaries.",
   ],
   [
     "reviewTimeP90",
-    "90th percentile review time. 90% of reviews completed faster. High values may indicate review bottlenecks. (Aggregated from weekly values.)",
+    "90th percentile review time. 90% of reviews completed faster. High values may indicate review bottlenecks. Calculated from weekly summaries.",
   ],
 ]);
 

--- a/extension/ui/modules/shared/detail-panel.ts
+++ b/extension/ui/modules/shared/detail-panel.ts
@@ -825,17 +825,27 @@ function advanceSortDirection(current: SortDirection): SortDirection {
  * Issue #332 / B2: condensed C1 inclusion-rule disclosure surfaced via
  * a single info tooltip on the controls bar.  Authoritative source is
  * ``specs/310-comments-visualization/spec.md`` "Shared inclusion-rule
- * contract (C1)" — this string distills those rules per axis without
- * re-declaring them.  One icon (not three per-axis) so the disclosure
- * adds zero pixels to the columnheader tracks (Linux DejaVu header-fit
- * contract from #341 / #330 stays intact).
+ * contract (C1)" — this string distills those rules per axis in user-
+ * facing language without re-declaring them.  One icon (not three per-
+ * axis) so the disclosure adds zero pixels to the columnheader tracks
+ * (Linux DejaVu header-fit contract from #341 / #330 stays intact).
+ *
+ * Copy review (post-#343 merge): the prior version leaked the internal
+ * "Feature 310" label and data-model terms ("user table", "system
+ * events") into a user-facing tooltip.  This rewrite preserves the
+ * full C1 contract — exclude-deleted-threads / include-unknown-status
+ * / include-system-comments / exclude-deleted-comments / count-rows-
+ * from-deprovisioned-users — while replacing developer vocabulary
+ * with prose users of an Azure DevOps extension recognise.
  */
 const COMMENTS_METRICS_C1_TOOLTIP =
-  "Counts apply Feature 310's inclusion rules. Threads include " +
-  "unknown-status threads but exclude deleted ones. Comments include " +
-  "system events; deleted comments are excluded. Unresolved counts " +
-  "only threads still in active status. Comments by users missing " +
-  "from the user table are still counted.";
+  "How counts are tallied: The Threads count includes every review " +
+  "thread on this PR, including threads with no recorded status. The " +
+  "Comments count includes every comment, including automated build " +
+  "or CI notifications. The Unresolved count includes only threads " +
+  "currently in the Active state. Deleted threads and comments are " +
+  "not counted. Comments and threads from users who have left the " +
+  "organization are still counted.";
 
 /**
  * Slice-level metadata the filter feedback summary (#332 / B3) needs

--- a/extension/ui/styles.css
+++ b/extension/ui/styles.css
@@ -1333,7 +1333,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     white-space: nowrap;
 }
 
-/* Info Tooltip (summary card metric explanations) */
+/* Info Tooltip (summary card metric explanations + #332/B2 drill-down
+ * panel info-icon disclosure) */
 .info-tooltip {
     position: fixed;
     background: var(--bg-primary);
@@ -1343,7 +1344,13 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     box-shadow: var(--shadow-md);
     font-size: 12px;
     pointer-events: none;
-    z-index: 150;
+    /* #332/B2 follow-up: must sit above .detail-panel (1050, PR #302
+     * P1.C) so the C1 info-icon's tooltip renders in front of the
+     * drill-down panel rather than occluded behind it.  Stays BELOW
+     * .comparison-advisory-toast (1060) so the higher-priority
+     * "drill-down disabled" advisory always wins on overlap.  Locked
+     * in tests/unit/css-contract.test.ts. */
+    z-index: 1055;
     max-width: min(280px, calc(100vw - 16px));
     white-space: normal;
     line-height: 1.4;

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -4419,7 +4419,7 @@ var PRInsightsDashboard = (() => {
     if (current === "descending") return "ascending";
     return "none";
   }
-  var COMMENTS_METRICS_C1_TOOLTIP = "Counts apply Feature 310's inclusion rules. Threads include unknown-status threads but exclude deleted ones. Comments include system events; deleted comments are excluded. Unresolved counts only threads still in active status. Comments by users missing from the user table are still counted.";
+  var COMMENTS_METRICS_C1_TOOLTIP = "How counts are tallied: The Threads count includes every review thread on this PR, including threads with no recorded status. The Comments count includes every comment, including automated build or CI notifications. The Unresolved count includes only threads currently in the Active state. Deleted threads and comments are not counted. Comments and threads from users who have left the organization are still counted.";
   function formatFilterSummary(context, hasActiveThreshold, visibleNumeric) {
     if (!hasActiveThreshold) {
       return `Showing all ${context.totalRows} PRs.`;
@@ -7103,11 +7103,11 @@ var PRInsightsDashboard = (() => {
     ],
     [
       "cycleP50",
-      "Median time from PR creation to merge. Half of all PRs completed faster than this. (Aggregated from weekly values.)"
+      "Median time from PR creation to merge. Half of all PRs completed faster than this. Calculated from weekly summaries."
     ],
     [
       "cycleP90",
-      "90th percentile cycle time. 90% of PRs completed faster. High values may indicate bottlenecks. (Aggregated from weekly values.)"
+      "90th percentile cycle time. 90% of PRs completed faster. High values may indicate bottlenecks. Calculated from weekly summaries."
     ],
     [
       "authorsCount",
@@ -7119,11 +7119,11 @@ var PRInsightsDashboard = (() => {
     ],
     [
       "reviewTimeP50",
-      "Median time from first review request to review completion. Half of all reviews completed faster than this. (Aggregated from weekly values.)"
+      "Median time from first review request to review completion. Half of all reviews completed faster than this. Calculated from weekly summaries."
     ],
     [
       "reviewTimeP90",
-      "90th percentile review time. 90% of reviews completed faster. High values may indicate review bottlenecks. (Aggregated from weekly values.)"
+      "90th percentile review time. 90% of reviews completed faster. High values may indicate review bottlenecks. Calculated from weekly summaries."
     ]
   ]);
   function renderSummaryCards(options) {

--- a/src/ado_git_repo_insights/ui_bundle/styles.css
+++ b/src/ado_git_repo_insights/ui_bundle/styles.css
@@ -1333,7 +1333,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     white-space: nowrap;
 }
 
-/* Info Tooltip (summary card metric explanations) */
+/* Info Tooltip (summary card metric explanations + #332/B2 drill-down
+ * panel info-icon disclosure) */
 .info-tooltip {
     position: fixed;
     background: var(--bg-primary);
@@ -1343,7 +1344,13 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     box-shadow: var(--shadow-md);
     font-size: 12px;
     pointer-events: none;
-    z-index: 150;
+    /* #332/B2 follow-up: must sit above .detail-panel (1050, PR #302
+     * P1.C) so the C1 info-icon's tooltip renders in front of the
+     * drill-down panel rather than occluded behind it.  Stays BELOW
+     * .comparison-advisory-toast (1060) so the higher-priority
+     * "drill-down disabled" advisory always wins on overlap.  Locked
+     * in tests/unit/css-contract.test.ts. */
+    z-index: 1055;
     max-width: min(280px, calc(100vw - 16px));
     white-space: normal;
     line-height: 1.4;


### PR DESCRIPTION
## Summary
Two post-merge follow-ups to the C1 info-icon disclosure that shipped in PR #343 (#332/B2). Both surfaced after merge — first via direct user report, second via copy review.

1. **z-index occlusion fix** — `.info-tooltip` was at z-index 150 from its original summary-card use. The drill-down panel sits at z-index 1050 (PR #302 P1.C, locked in `css-contract.test.ts`), and both elements `position: fixed` mount as siblings on `document.body`, so 1050 > 150 caused the panel to paint over the tooltip — user hovers the icon, nothing visible. Bump tooltip to **1055**: above the panel, but still below `.comparison-advisory-toast` (1060) so the higher-priority "drill-down disabled" cue still wins on overlap.

2. **Plain-language copy rewrite** — the tooltip introduced in #332/B2 leaked developer vocabulary ("Feature 310", "system events", "user table") into prose users see in the UI. Rewrite preserves the full C1 contract — exclude-deleted-threads, include-unknown-status, include-system-comments, exclude-deleted-comments, count-rows-from-deprovisioned-users — while replacing internal terms with phrasing users of an Azure DevOps extension recognise. Same softening to the four median-metric summary-card parentheticals: `(Aggregated from weekly values.)` → `Calculated from weekly summaries.`

## Locked invariants
- **z-index ordering:** new test in `css-contract.test.ts` `CSS Contract: z-index stacking` describe asserts `.info-tooltip === 1055` AND `.info-tooltip > .detail-panel` AND `.info-tooltip < .comparison-advisory-toast`. A future bump to either neighbour surfaces here as a contract failure rather than silent z-index drift.
- **No behaviour change** beyond the visual/copy fixes.
- **All #332/B2 tooltip-lifecycle invariants preserved** — Codex P2 rounds 1 + 2 (outside-click, pointerleave, second-click, panel-close, retarget-in-place cleanup) untouched.
- **Test fixtures synchronised** — `C1_TOOLTIP_TEXT` constant in `pr-list-comments-columns.test.ts` (used by 3 tests) and the median-of-medians positive/negative assertions in `summary-cards-info.test.ts` updated to match the new copy.

## Test plan
- [x] Full Tier 2 preflight passes locally (38/38 gates) including the new `.info-tooltip` z-index contract test
- [x] Partial-branch ratchet steady at 318/318
- [x] Test floor 2847 → 2848 (+1 for the contract test in commit 1; commit 2 is text-only, no floor change)
- [x] Targeted Jest on touched files passes (78/78 across `summary-cards-info.test.ts` + `pr-list-comments-columns.test.ts`)
- [ ] CI green on this PR
- [ ] Manual smoke: open drill-down on a multi-row !all-partial week, hover the C1 info icon — tooltip renders in front of the panel; copy reads in plain language

Closes #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)