### PR TITLE
feat: #334 per-author comments-density chart + dashboard wiring

### DIFF
--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
   "python": {
-    "min_collected": 2311,
+    "min_collected": 2312,
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2956,
+    "min_collected": 2959,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2959,
+    "min_collected": 2962,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
   "python": {
-    "min_collected": 2295,
+    "min_collected": 2311,
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2908,
+    "min_collected": 2915,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2938,
+    "min_collected": 2946,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2946,
+    "min_collected": 2956,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 2915,
+    "min_collected": 2938,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/docs/artifact-client.js
+++ b/docs/artifact-client.js
@@ -1330,7 +1330,11 @@ var PRInsightsArtifactClient = (() => {
     "_prs_cap",
     // Feature 333 weekly comments-aggregate (gated on capabilities.comments_metrics).
     // Atomic when present per INV-1-08; absent entirely when capability-off (FR-3-03).
-    "comments"
+    "comments",
+    // Feature 334 per-author comments-density (gated on capabilities.comments_metrics).
+    // Outer dict at rollup root; per-entry atomic per INV-2-08; absent entirely
+    // when capability-off (FR-3-03 + INV-2-09).
+    "by_author_comments"
   ]);
   var PR_RECORD_REQUIRED_FIELDS = [
     "id",
@@ -1742,6 +1746,126 @@ var PRInsightsArtifactClient = (() => {
     }
     return { errors };
   }
+  function validateAuthorCommentsDensity(data, path) {
+    const errors = [];
+    if (!isObject(data)) {
+      errors.push(createError(path, "object", getTypeName(data)));
+      return { errors };
+    }
+    const entries = Object.entries(
+      data
+    );
+    if (entries.length === 0) {
+      errors.push(
+        createError(
+          path,
+          "non-empty Record<string, AuthorCommentsDensityEntry>",
+          "{}",
+          `by_author_comments MUST be omitted entirely when no per-author buckets exist (FR-3-03 + INV-2-09); empty object is a contract violation`
+        )
+      );
+      return { errors };
+    }
+    const requiredFields = [
+      "thread_count",
+      "comment_count",
+      "active_thread_count",
+      "coverage_partial"
+    ];
+    for (const [key, entry] of entries) {
+      const entryPath = buildPath(path, key);
+      if (!isObject(entry)) {
+        errors.push(createError(entryPath, "object", getTypeName(entry)));
+        continue;
+      }
+      const missing = requiredFields.filter(
+        (field) => !Object.prototype.hasOwnProperty.call(entry, field)
+      );
+      if (missing.length > 0) {
+        errors.push(
+          createError(
+            entryPath,
+            "all four of thread_count / comment_count / active_thread_count / coverage_partial",
+            `missing: ${missing.join(", ")}`,
+            `by_author_comments[${key}] atomicity violated (INV-2-08): expected all four of thread_count / comment_count / active_thread_count / coverage_partial; missing: ${missing.join(", ")}`
+          )
+        );
+      }
+      const numericFieldChecks = [
+        { name: "thread_count", value: entry.thread_count },
+        { name: "comment_count", value: entry.comment_count },
+        { name: "active_thread_count", value: entry.active_thread_count }
+      ];
+      for (const { name, value } of numericFieldChecks) {
+        if (!Object.prototype.hasOwnProperty.call(entry, name)) {
+          continue;
+        }
+        if (value === null) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number (non-null per INV-2-08; zero is the valid sum over an empty extracted-subset)",
+              "null",
+              `by_author_comments[${key}].${name} MUST be a non-null number (INV-2-08); null is not a valid sentinel \u2014 use 0 for an empty extracted-subset`
+            )
+          );
+        } else if (!isNumber(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number",
+              getTypeName(value),
+              `expected number at 'by_author_comments[${key}].${name}', got ${getTypeName(value)}`
+            )
+          );
+        } else if (value < 0) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "non-negative number (counts cannot be negative)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be non-negative; got ${value}`
+            )
+          );
+        } else if (!Number.isInteger(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "integer (counts must be whole numbers)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be an integer; got ${value}`
+            )
+          );
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, "coverage_partial")) {
+        const coveragePartial = entry.coverage_partial;
+        if (!isBoolean(coveragePartial)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, "coverage_partial"),
+              "boolean",
+              getTypeName(coveragePartial),
+              `expected boolean at 'by_author_comments[${key}].coverage_partial', got ${getTypeName(coveragePartial)}`
+            )
+          );
+        }
+      }
+      const entryThread = entry.thread_count;
+      const entryActive = entry.active_thread_count;
+      if (isNumber(entryThread) && isNumber(entryActive) && Number.isInteger(entryThread) && Number.isInteger(entryActive) && entryThread >= 0 && entryActive >= 0 && entryActive > entryThread) {
+        errors.push(
+          createError(
+            buildPath(entryPath, "active_thread_count"),
+            "<= thread_count (INV-2-07; active is a subset of total)",
+            `${entryActive} > ${entryThread}`,
+            `by_author_comments[${key}] ordering violated (INV-2-07): active_thread_count (${entryActive}) MUST NOT exceed thread_count (${entryThread})`
+          )
+        );
+      }
+    }
+    return { errors };
+  }
   function validateRollup(data, strict) {
     const errors = [];
     const warnings = [];
@@ -1892,6 +2016,13 @@ var PRInsightsArtifactClient = (() => {
     if (Object.prototype.hasOwnProperty.call(data, "comments") && data.comments !== void 0) {
       const commentsResult = validateCommentsAggregate(data.comments, "comments");
       errors.push(...commentsResult.errors);
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "by_author_comments") && data.by_author_comments !== void 0) {
+      const byAuthorCommentsResult = validateAuthorCommentsDensity(
+        data.by_author_comments,
+        "by_author_comments"
+      );
+      errors.push(...byAuthorCommentsResult.errors);
     }
     const unknown = findUnknownFields(data, KNOWN_ROOT_FIELDS2, "", strict);
     errors.push(...unknown.errors);

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -8782,12 +8782,11 @@ var PRInsightsDashboard = (() => {
   function renderSortControls(activeMetric) {
     const buttons = COMMENTS_AUTHOR_DENSITY_SORT_METRICS.map((metric) => {
       const checked = metric === activeMetric;
-      const ariaChecked = checked ? "true" : "false";
-      const tabIndex = checked ? "0" : "-1";
+      const ariaPressed = checked ? "true" : "false";
       const label = metricLabel(metric);
-      return `<button type="button" class="comments-author-density-sort-btn${checked ? " is-active" : ""}" role="radio" aria-checked="${ariaChecked}" tabindex="${tabIndex}" data-sort-metric="${escapeHtml(metric)}">${escapeHtml(label)}</button>`;
+      return `<button type="button" class="comments-author-density-sort-btn${checked ? " is-active" : ""}" aria-pressed="${ariaPressed}" data-sort-metric="${escapeHtml(metric)}">${escapeHtml(label)}</button>`;
     }).join("");
-    return `<div class="comments-author-density-sort" role="radiogroup" aria-label="Sort author rows by metric">${buttons}</div>`;
+    return `<div class="comments-author-density-sort" role="toolbar" aria-label="Sort author rows by metric">${buttons}</div>`;
   }
   function renderTable(rows) {
     const rowsHtml = rows.map((row) => renderRow(row)).join("");

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -8665,6 +8665,53 @@ var PRInsightsDashboard = (() => {
     if (displayCmp !== 0) return displayCmp;
     return a2.authorKey < b2.authorKey ? -1 : 1;
   }
+  var sortMetricByContainer = /* @__PURE__ */ new WeakMap();
+  var sortListenerControllers = /* @__PURE__ */ new WeakMap();
+  function attachSortToggleListeners(container, rollups, options) {
+    sortListenerControllers.get(container)?.abort();
+    const controller = new AbortController();
+    sortListenerControllers.set(container, controller);
+    const { signal } = controller;
+    const resolveMetric = (raw) => {
+      return COMMENTS_AUTHOR_DENSITY_SORT_METRICS.find((m2) => m2 === raw);
+    };
+    const activate = (metric) => {
+      sortMetricByContainer.set(container, metric);
+      renderCommentsAuthorDensityChart(container, rollups, {
+        ...options,
+        sortMetric: metric
+      });
+    };
+    const findSortButton = (event) => {
+      const target = event.target;
+      return target.closest(".comments-author-density-sort-btn");
+    };
+    container.addEventListener(
+      "click",
+      (event) => {
+        const button = findSortButton(event);
+        if (!button) return;
+        const metric = resolveMetric(button.dataset.sortMetric);
+        if (!metric) return;
+        activate(metric);
+      },
+      { signal }
+    );
+    container.addEventListener(
+      "keydown",
+      (event) => {
+        const button = findSortButton(event);
+        if (!button) return;
+        const key = event.key;
+        if (key !== "Enter" && key !== " ") return;
+        const metric = resolveMetric(button.dataset.sortMetric);
+        if (!metric) return;
+        event.preventDefault();
+        activate(metric);
+      },
+      { signal }
+    );
+  }
   function renderCommentsAuthorDensityChart(container, rollups, options) {
     if (!container) return;
     if (options?.filters && hasActiveFilters2(options.filters)) {
@@ -8697,7 +8744,13 @@ var PRInsightsDashboard = (() => {
         coverage_partial: bucket.coverage_partial
       });
     }
-    const activeMetric = options?.sortMetric ?? "comment_count";
+    let activeMetric;
+    if (options?.sortMetric) {
+      activeMetric = options.sortMetric;
+      sortMetricByContainer.set(container, activeMetric);
+    } else {
+      activeMetric = sortMetricByContainer.get(container) ?? "comment_count";
+    }
     rows.sort((a2, b2) => compareRows(a2, b2, activeMetric));
     const truncated = rows.length > MAX_COMMENTS_AUTHOR_DENSITY_ROWS;
     const display = truncated ? rows.slice(0, MAX_COMMENTS_AUTHOR_DENSITY_ROWS) : rows;
@@ -8714,6 +8767,7 @@ var PRInsightsDashboard = (() => {
       container,
       `${truncationHtml}${sortControlsHtml}${tableHtml}${partialLegendHtml}`
     );
+    attachSortToggleListeners(container, rollups, options);
   }
   function metricLabel(metric) {
     switch (metric) {

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -8596,6 +8596,8 @@ var PRInsightsDashboard = (() => {
 
   // ../ui/modules/charts/comments-author-density.ts
   var MAX_COMMENTS_AUTHOR_DENSITY_ROWS = 50;
+  var FORMER_OR_UNAVAILABLE_AUTHOR_KEY = "__former_or_unavailable_author__";
+  var FORMER_OR_UNAVAILABLE_AUTHOR_LABEL = "Former / unavailable author";
   var COMMENTS_AUTHOR_DENSITY_SORT_METRICS = [
     "comment_count",
     "thread_count",
@@ -8640,6 +8642,9 @@ var PRInsightsDashboard = (() => {
     return map;
   }
   function resolveDisplayName(authorKey, directory) {
+    if (authorKey === FORMER_OR_UNAVAILABLE_AUTHOR_KEY) {
+      return FORMER_OR_UNAVAILABLE_AUTHOR_LABEL;
+    }
     if (directory) {
       const found = directory.get(authorKey);
       if (typeof found === "string" && found.length > 0) {

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1312,7 +1312,11 @@ var PRInsightsDashboard = (() => {
     "_prs_cap",
     // Feature 333 weekly comments-aggregate (gated on capabilities.comments_metrics).
     // Atomic when present per INV-1-08; absent entirely when capability-off (FR-3-03).
-    "comments"
+    "comments",
+    // Feature 334 per-author comments-density (gated on capabilities.comments_metrics).
+    // Outer dict at rollup root; per-entry atomic per INV-2-08; absent entirely
+    // when capability-off (FR-3-03 + INV-2-09).
+    "by_author_comments"
   ]);
   var PR_RECORD_REQUIRED_FIELDS = [
     "id",
@@ -1724,6 +1728,126 @@ var PRInsightsDashboard = (() => {
     }
     return { errors };
   }
+  function validateAuthorCommentsDensity(data, path) {
+    const errors = [];
+    if (!isObject(data)) {
+      errors.push(createError(path, "object", getTypeName(data)));
+      return { errors };
+    }
+    const entries = Object.entries(
+      data
+    );
+    if (entries.length === 0) {
+      errors.push(
+        createError(
+          path,
+          "non-empty Record<string, AuthorCommentsDensityEntry>",
+          "{}",
+          `by_author_comments MUST be omitted entirely when no per-author buckets exist (FR-3-03 + INV-2-09); empty object is a contract violation`
+        )
+      );
+      return { errors };
+    }
+    const requiredFields = [
+      "thread_count",
+      "comment_count",
+      "active_thread_count",
+      "coverage_partial"
+    ];
+    for (const [key, entry] of entries) {
+      const entryPath = buildPath(path, key);
+      if (!isObject(entry)) {
+        errors.push(createError(entryPath, "object", getTypeName(entry)));
+        continue;
+      }
+      const missing = requiredFields.filter(
+        (field) => !Object.prototype.hasOwnProperty.call(entry, field)
+      );
+      if (missing.length > 0) {
+        errors.push(
+          createError(
+            entryPath,
+            "all four of thread_count / comment_count / active_thread_count / coverage_partial",
+            `missing: ${missing.join(", ")}`,
+            `by_author_comments[${key}] atomicity violated (INV-2-08): expected all four of thread_count / comment_count / active_thread_count / coverage_partial; missing: ${missing.join(", ")}`
+          )
+        );
+      }
+      const numericFieldChecks = [
+        { name: "thread_count", value: entry.thread_count },
+        { name: "comment_count", value: entry.comment_count },
+        { name: "active_thread_count", value: entry.active_thread_count }
+      ];
+      for (const { name, value } of numericFieldChecks) {
+        if (!Object.prototype.hasOwnProperty.call(entry, name)) {
+          continue;
+        }
+        if (value === null) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number (non-null per INV-2-08; zero is the valid sum over an empty extracted-subset)",
+              "null",
+              `by_author_comments[${key}].${name} MUST be a non-null number (INV-2-08); null is not a valid sentinel \u2014 use 0 for an empty extracted-subset`
+            )
+          );
+        } else if (!isNumber(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number",
+              getTypeName(value),
+              `expected number at 'by_author_comments[${key}].${name}', got ${getTypeName(value)}`
+            )
+          );
+        } else if (value < 0) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "non-negative number (counts cannot be negative)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be non-negative; got ${value}`
+            )
+          );
+        } else if (!Number.isInteger(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "integer (counts must be whole numbers)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be an integer; got ${value}`
+            )
+          );
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, "coverage_partial")) {
+        const coveragePartial = entry.coverage_partial;
+        if (!isBoolean(coveragePartial)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, "coverage_partial"),
+              "boolean",
+              getTypeName(coveragePartial),
+              `expected boolean at 'by_author_comments[${key}].coverage_partial', got ${getTypeName(coveragePartial)}`
+            )
+          );
+        }
+      }
+      const entryThread = entry.thread_count;
+      const entryActive = entry.active_thread_count;
+      if (isNumber(entryThread) && isNumber(entryActive) && Number.isInteger(entryThread) && Number.isInteger(entryActive) && entryThread >= 0 && entryActive >= 0 && entryActive > entryThread) {
+        errors.push(
+          createError(
+            buildPath(entryPath, "active_thread_count"),
+            "<= thread_count (INV-2-07; active is a subset of total)",
+            `${entryActive} > ${entryThread}`,
+            `by_author_comments[${key}] ordering violated (INV-2-07): active_thread_count (${entryActive}) MUST NOT exceed thread_count (${entryThread})`
+          )
+        );
+      }
+    }
+    return { errors };
+  }
   function validateRollup(data, strict) {
     const errors = [];
     const warnings = [];
@@ -1874,6 +1998,13 @@ var PRInsightsDashboard = (() => {
     if (Object.prototype.hasOwnProperty.call(data, "comments") && data.comments !== void 0) {
       const commentsResult = validateCommentsAggregate(data.comments, "comments");
       errors.push(...commentsResult.errors);
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "by_author_comments") && data.by_author_comments !== void 0) {
+      const byAuthorCommentsResult = validateAuthorCommentsDensity(
+        data.by_author_comments,
+        "by_author_comments"
+      );
+      errors.push(...byAuthorCommentsResult.errors);
     }
     const unknown = findUnknownFields(data, KNOWN_ROOT_FIELDS2, "", strict);
     errors.push(...unknown.errors);

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -6365,7 +6365,7 @@ var PRInsightsDashboard = (() => {
     const historicalPath = calculateLinePath(historicalPoints);
     const forecastPath = calculateLinePath(forecastPoints);
     const bandPath = calculateBandPath(upperPoints, lowerPoints);
-    const metricLabel = forecast.metric.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+    const metricLabel2 = forecast.metric.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
     const allWeeks = [];
     if (historicalData) {
       historicalData.forEach((h2) => allWeeks.push(h2.week));
@@ -6379,12 +6379,12 @@ var PRInsightsDashboard = (() => {
     }).join("");
     const latestValue = values[values.length - 1];
     const rangeClause = latestValue.lower_bound != null && latestValue.upper_bound != null ? ` (range ${latestValue.lower_bound.toFixed(1)} to ${latestValue.upper_bound.toFixed(1)})` : "";
-    const accessibleSummary = `${metricLabel} forecast: ${latestValue.predicted.toFixed(1)} ${forecast.unit}${rangeClause}`;
+    const accessibleSummary = `${metricLabel2} forecast: ${latestValue.predicted.toFixed(1)} ${forecast.unit}${rangeClause}`;
     const safeMetricId = sanitizeForId(forecast.metric);
     return `
-    <div class="forecast-chart" role="region" aria-label="${escapeHtml(metricLabel)} forecast">
+    <div class="forecast-chart" role="region" aria-label="${escapeHtml(metricLabel2)} forecast">
       <div class="chart-header">
-        <h4 id="chart-${safeMetricId}">${escapeHtml(metricLabel)}</h4>
+        <h4 id="chart-${safeMetricId}">${escapeHtml(metricLabel2)}</h4>
         <span class="chart-unit">(${escapeHtml(forecast.unit)})</span>
         ${wasTruncated ? `<span class="truncation-badge" title="Showing last ${MAX_CHART_POINTS} data points">Partial history</span>` : ""}
       </div>
@@ -6920,14 +6920,14 @@ var PRInsightsDashboard = (() => {
   }
   function renderInsightDataSection(data) {
     if (!data) return "";
-    const metricLabel = data.metric.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+    const metricLabel2 = data.metric.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
     const trendIcon = TREND_ICONS[data.trend_direction] || "";
     const trendClass = `trend-${data.trend_direction}`;
     const changeDisplay = data.change_percent !== void 0 ? `${data.change_percent > 0 ? "+" : ""}${data.change_percent.toFixed(1)}%` : "";
     return `
     <div class="insight-data-section">
       <div class="insight-metric">
-        <span class="metric-label">${escapeHtml(metricLabel)}</span>
+        <span class="metric-label">${escapeHtml(metricLabel2)}</span>
         <span class="metric-value">${escapeHtml(String(data.current_value))}</span>
         ${changeDisplay ? `<span class="metric-change ${trendClass}">${trendIcon} ${escapeHtml(changeDisplay)}</span>` : ""}
       </div>
@@ -8594,6 +8594,159 @@ var PRInsightsDashboard = (() => {
           ${partialNote}`;
   }
 
+  // ../ui/modules/charts/comments-author-density.ts
+  var MAX_COMMENTS_AUTHOR_DENSITY_ROWS = 50;
+  var COMMENTS_AUTHOR_DENSITY_SORT_METRICS = [
+    "comment_count",
+    "thread_count",
+    "active_thread_count"
+  ];
+  function hasByAuthorComments(rollup) {
+    const value = rollup.by_author_comments;
+    return value !== void 0 && value !== null && typeof value === "object";
+  }
+  function reducePerAuthor(rollups) {
+    const reduced = /* @__PURE__ */ new Map();
+    for (const rollup of rollups) {
+      for (const entry of Object.entries(rollup.by_author_comments)) {
+        const key = entry[0];
+        const bucket = entry[1];
+        const existing = reduced.get(key);
+        if (existing) {
+          existing.thread_count += bucket.thread_count;
+          existing.comment_count += bucket.comment_count;
+          existing.active_thread_count += bucket.active_thread_count;
+          existing.coverage_partial = existing.coverage_partial || bucket.coverage_partial;
+        } else {
+          reduced.set(key, {
+            thread_count: bucket.thread_count,
+            comment_count: bucket.comment_count,
+            active_thread_count: bucket.active_thread_count,
+            coverage_partial: bucket.coverage_partial
+          });
+        }
+      }
+    }
+    return reduced;
+  }
+  function buildAuthorsDirectory(authorsDimension) {
+    if (!authorsDimension) return null;
+    const map = /* @__PURE__ */ new Map();
+    for (const entry of authorsDimension) {
+      if (typeof entry.author_id === "string" && typeof entry.author_name === "string") {
+        map.set(entry.author_id, entry.author_name);
+      }
+    }
+    return map;
+  }
+  function resolveDisplayName(authorKey, directory) {
+    if (directory) {
+      const found = directory.get(authorKey);
+      if (typeof found === "string" && found.length > 0) {
+        return found;
+      }
+    }
+    return authorKey;
+  }
+  function metricValue(row, metric) {
+    switch (metric) {
+      case "comment_count":
+        return row.comment_count;
+      case "thread_count":
+        return row.thread_count;
+      case "active_thread_count":
+        return row.active_thread_count;
+    }
+  }
+  function compareRows(a2, b2, metric) {
+    const primary = metricValue(b2, metric) - metricValue(a2, metric);
+    if (primary !== 0) return primary;
+    const displayCmp = a2.displayName.localeCompare(b2.displayName);
+    if (displayCmp !== 0) return displayCmp;
+    return a2.authorKey < b2.authorKey ? -1 : 1;
+  }
+  function renderCommentsAuthorDensityChart(container, rollups, options) {
+    if (!container) return;
+    if (options?.filters && hasActiveFilters2(options.filters)) {
+      renderNoData(
+        container,
+        "Comments density is not yet filterable",
+        "Clear repo / team / author / reviewer filters to view per-author review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+      );
+      return;
+    }
+    const withByAuthor = rollups.filter(hasByAuthorComments);
+    const reduced = reducePerAuthor(withByAuthor);
+    if (reduced.size === 0) {
+      renderNoData(
+        container,
+        "No comments data for selected range",
+        "Try widening the date range, or confirm comments extraction is enabled for this dataset."
+      );
+      return;
+    }
+    const directory = buildAuthorsDirectory(options?.authorsDimension);
+    const rows = [];
+    for (const [key, bucket] of reduced) {
+      rows.push({
+        authorKey: key,
+        displayName: resolveDisplayName(key, directory),
+        thread_count: bucket.thread_count,
+        comment_count: bucket.comment_count,
+        active_thread_count: bucket.active_thread_count,
+        coverage_partial: bucket.coverage_partial
+      });
+    }
+    const activeMetric = options?.sortMetric ?? "comment_count";
+    rows.sort((a2, b2) => compareRows(a2, b2, activeMetric));
+    const truncated = rows.length > MAX_COMMENTS_AUTHOR_DENSITY_ROWS;
+    const display = truncated ? rows.slice(0, MAX_COMMENTS_AUTHOR_DENSITY_ROWS) : rows;
+    const truncationHtml = renderTruncationIndicator(
+      truncated,
+      MAX_COMMENTS_AUTHOR_DENSITY_ROWS,
+      "authors"
+    );
+    const sortControlsHtml = renderSortControls(activeMetric);
+    const tableHtml = renderTable(display);
+    const anyPartial = display.some((r2) => r2.coverage_partial);
+    const partialLegendHtml = anyPartial ? `<div class="chart-legend"><div class="legend-item legend-coverage-partial-item"><span class="legend-bar legend-bar-coverage-partial"></span><span>Partial coverage</span></div></div>` : "";
+    renderTrustedHtml(
+      container,
+      `${truncationHtml}${sortControlsHtml}${tableHtml}${partialLegendHtml}`
+    );
+  }
+  function metricLabel(metric) {
+    switch (metric) {
+      case "comment_count":
+        return "Comments";
+      case "thread_count":
+        return "Threads";
+      case "active_thread_count":
+        return "Active threads";
+    }
+  }
+  function renderSortControls(activeMetric) {
+    const buttons = COMMENTS_AUTHOR_DENSITY_SORT_METRICS.map((metric) => {
+      const checked = metric === activeMetric;
+      const ariaChecked = checked ? "true" : "false";
+      const tabIndex = checked ? "0" : "-1";
+      const label = metricLabel(metric);
+      return `<button type="button" class="comments-author-density-sort-btn${checked ? " is-active" : ""}" role="radio" aria-checked="${ariaChecked}" tabindex="${tabIndex}" data-sort-metric="${escapeHtml(metric)}">${escapeHtml(label)}</button>`;
+    }).join("");
+    return `<div class="comments-author-density-sort" role="radiogroup" aria-label="Sort author rows by metric">${buttons}</div>`;
+  }
+  function renderTable(rows) {
+    const rowsHtml = rows.map((row) => renderRow(row)).join("");
+    return `<div class="comments-author-density-table" role="table" aria-label="Per-author comment density"><div class="comments-author-density-thead" role="row"><div role="columnheader">Author</div><div role="columnheader" class="comments-author-density-numeric">Threads</div><div role="columnheader" class="comments-author-density-numeric">Active threads</div><div role="columnheader" class="comments-author-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+  }
+  function renderRow(row) {
+    const partialClass = row.coverage_partial ? " coverage-partial" : "";
+    const partialAttr = row.coverage_partial ? ' data-coverage-partial="true"' : "";
+    const partialNote = row.coverage_partial ? " (partial coverage)" : "";
+    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
+    return `<div class="comments-author-density-row${partialClass}" role="row" data-author-key="${escapeHtml(row.authorKey)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-author-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+  }
+
   // ../ui/modules/filter-constraint-resolver.ts
   function resolveFilterConstraints(raw, lastChanged) {
     const notices = [];
@@ -9281,7 +9434,7 @@ var PRInsightsDashboard = (() => {
   window.addEventListener(COMPARISON_TOGGLED_EVENT, comparisonListener);
 
   // ../ui/modules/shared/identity-fallback.ts
-  function resolveDisplayName(id, map) {
+  function resolveDisplayName2(id, map) {
     const mapped = map.get(id);
     return mapped !== void 0 ? mapped : id;
   }
@@ -9320,7 +9473,7 @@ var PRInsightsDashboard = (() => {
       return makeEmptyState(title, emptyDetail);
     }
     const rows = Object.entries(entries).sort((a2, b2) => b2[1].pr_count - a2[1].pr_count).map(([key, entry]) => ({
-      label: nameByKey ? resolveDisplayName(key, nameByKey) : key,
+      label: nameByKey ? resolveDisplayName2(key, nameByKey) : key,
       values: [String(entry.pr_count)]
     }));
     return makeBreakdownTable(title, columns, rows);
@@ -9705,7 +9858,7 @@ var PRInsightsDashboard = (() => {
   function buildPanelContent3(rollups, reviewerId, reviewerNameByKey) {
     const stats = buildStatRow(rollups, reviewerId);
     const subtitle = `${stats.totalPrs} ${stats.totalPrs === 1 ? "PR" : "PRs"} reviewed`;
-    const displayName = resolveDisplayName(reviewerId, reviewerNameByKey);
+    const displayName = resolveDisplayName2(reviewerId, reviewerNameByKey);
     return makePanelContent(displayName, subtitle, [
       stats.section,
       buildWeeklyTable(rollups, reviewerId)
@@ -10493,6 +10646,17 @@ var PRInsightsDashboard = (() => {
       } else {
         removeCommentsTrendContainer();
       }
+      if (loader?.getCapabilityState?.()?.commentsMetricsAvailable === true) {
+        const cadContainer = ensureCommentsAuthorDensityContainer();
+        if (cadContainer) {
+          renderCommentsAuthorDensityChart(cadContainer, rollups, {
+            filters: currentFilters,
+            authorsDimension: currentDimensions?.authors
+          });
+        }
+      } else {
+        removeCommentsAuthorDensityContainer();
+      }
       const throughputContainer = document.getElementById("throughput-chart");
       if (throughputContainer) {
         activeDrilldownHandles.push(
@@ -10719,7 +10883,7 @@ var PRInsightsDashboard = (() => {
         r2.reviewer_name
       ])
     );
-    const filterReviewerName = filterReviewerId !== void 0 ? resolveDisplayName(filterReviewerId, reviewerNameByKey) : void 0;
+    const filterReviewerName = filterReviewerId !== void 0 ? resolveDisplayName2(filterReviewerId, reviewerNameByKey) : void 0;
     renderReviewerActivity(
       elements.get("reviewer-activity") ?? null,
       rollups,
@@ -10762,6 +10926,41 @@ var PRInsightsDashboard = (() => {
     if (heading instanceof HTMLElement) {
       detachCommentsTrendInfoIcon(heading);
     }
+    row.parentElement?.removeChild(row);
+  }
+  function ensureCommentsAuthorDensityContainer() {
+    const existing = document.getElementById("comments-author-density");
+    if (existing) return existing;
+    const commentsTrendRow = document.querySelector(
+      '[data-comments-trend-row="true"]'
+    );
+    let anchorRow = commentsTrendRow;
+    if (!anchorRow) {
+      const cycleDist = document.getElementById("cycle-distribution");
+      anchorRow = cycleDist?.closest(".charts-row") ?? null;
+    }
+    if (!anchorRow || !anchorRow.parentElement) return null;
+    const row = document.createElement("div");
+    row.className = "charts-row";
+    row.setAttribute("data-comments-author-density-row", "true");
+    const containerCell = document.createElement("div");
+    containerCell.className = "chart-container";
+    const heading = document.createElement("h3");
+    heading.textContent = "Comment Density by Author";
+    containerCell.appendChild(heading);
+    const chart = document.createElement("div");
+    chart.id = "comments-author-density";
+    chart.className = "chart";
+    containerCell.appendChild(chart);
+    row.appendChild(containerCell);
+    anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+    return chart;
+  }
+  function removeCommentsAuthorDensityContainer() {
+    const row = document.querySelector(
+      '[data-comments-author-density-row="true"]'
+    );
+    if (!row) return;
     row.parentElement?.removeChild(row);
   }
   function toArtifactLoadResult(loaderResult, artifactPath) {

--- a/docs/data/aggregates/weekly_rollups/2021-W01.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W01.json
@@ -947,6 +947,200 @@
       }
     }
   },
+  "by_author_comments": {
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 2,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 7,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 13,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 5,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 12,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 12,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 12,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 14,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 17,
+      "comment_count": 116,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 5,
+      "comment_count": 85,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 8,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 14,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 13,
+      "comment_count": 79,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 14,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 0,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 7,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 9,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 0,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 17,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 33
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W02.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W02.json
@@ -880,6 +880,206 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 18,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 6,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 10,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 23,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 11,
+      "comment_count": 57,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 12,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 10,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 12,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 11,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 12,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 10,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 20,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 7,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 7,
+      "comment_count": 90,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 15,
+      "comment_count": 142,
+      "coverage_partial": false,
+      "thread_count": 35
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W03.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W03.json
@@ -920,6 +920,218 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 10,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 7,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 6,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 15,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 9,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 3,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 14,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 4,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 8,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 6,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 17,
+      "comment_count": 137,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 10,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 11,
+      "comment_count": 143,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 19,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 6,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 13,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W04.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W04.json
@@ -971,6 +971,230 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 9,
+      "comment_count": 62,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 5,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 4,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 1,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 1,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 10,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 7,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 9,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 10,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 10,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 2,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 6,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 14,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 6,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 6,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 6,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 8,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 9,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 4,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 13,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 4,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 2,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 10,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 14
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W05.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W05.json
@@ -1056,6 +1056,242 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 3,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 13,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 29,
+      "comment_count": 138,
+      "coverage_partial": true,
+      "thread_count": 43
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 13,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 1,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 6,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 9,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 12,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 26,
+      "comment_count": 122,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 10,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 7,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 0,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 13,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 12,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 14,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 11,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 12,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 5,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 6,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 1,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W06.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W06.json
@@ -1002,6 +1002,242 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 15,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 9,
+      "comment_count": 79,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 12,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 13,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 15,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 7,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 6,
+      "comment_count": 37,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 5,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 21,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 11,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 0,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 20,
+      "comment_count": 189,
+      "coverage_partial": false,
+      "thread_count": 49
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 8,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W07.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W07.json
@@ -998,6 +998,242 @@
       }
     }
   },
+  "by_author_comments": {
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 2,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 6,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 3,
+      "comment_count": 19,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 15,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 8,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 4,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 15,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 4,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 14,
+      "comment_count": 143,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 24,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 3,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 16,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 4,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 20,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 13,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 16,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 11,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 11,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 17,
+      "comment_count": 92,
+      "coverage_partial": true,
+      "thread_count": 24
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W08.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W08.json
@@ -1073,6 +1073,230 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 8,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 9,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 14,
+      "comment_count": 83,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 9,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 26,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 3,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 0,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 3,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 14,
+      "comment_count": 112,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 8,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 5,
+      "comment_count": 119,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 12,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 6,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 5,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 10,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 3,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 24
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W09.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W09.json
@@ -960,6 +960,230 @@
       }
     }
   },
+  "by_author_comments": {
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 15,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 18,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 9,
+      "comment_count": 91,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 2,
+      "comment_count": 153,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 1,
+      "comment_count": 7,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 9,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 6,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 13,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 8,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W10.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W10.json
@@ -1007,6 +1007,218 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 19,
+      "comment_count": 154,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 17,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 9,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 1,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 5,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 6,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 25,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 10,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 0,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 5,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 20,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 8,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 6,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 12,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 6,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 4,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 13,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 3,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 5,
+      "comment_count": 47,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 10,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 16,
+      "comment_count": 78,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 21,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 42
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W11.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W11.json
@@ -1109,6 +1109,254 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 12,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 12,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 10,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 12,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 10,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 5,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 9,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 9,
+      "comment_count": 98,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 2,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 7,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 23,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 4,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 4,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 12,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 3,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 7,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 5,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 9,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 16,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 17,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 1,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 3,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 0,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 15,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 16
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W12.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W12.json
@@ -1018,6 +1018,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 18,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 15,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 5,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 6,
+      "comment_count": 57,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 4,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 7,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 4,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 17,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 2,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 5,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 6,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 6,
+      "comment_count": 19,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 22,
+      "comment_count": 152,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 7,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 9,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 7,
+      "comment_count": 61,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 4,
+      "comment_count": 86,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W13.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W13.json
@@ -1149,6 +1149,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 3,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 2,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 11,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 21,
+      "comment_count": 167,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 9,
+      "comment_count": 141,
+      "coverage_partial": false,
+      "thread_count": 44
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 20,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 6,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 14,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 9,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 19,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 15,
+      "comment_count": 59,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 1,
+      "comment_count": 63,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 6,
+      "comment_count": 62,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 17,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 13,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 19,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 26,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 16,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W14.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W14.json
@@ -1125,6 +1125,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 12,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 12,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 3,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 25,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 11,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 9,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 16,
+      "comment_count": 53,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 5,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 9,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 9,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 24,
+      "comment_count": 127,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 10,
+      "comment_count": 76,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 13,
+      "comment_count": 95,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 14,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 7,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 17,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 21,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 10,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 12,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 12,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W15.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W15.json
@@ -987,6 +987,230 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 3,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 8,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 9,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 30,
+      "comment_count": 199,
+      "coverage_partial": true,
+      "thread_count": 58
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 5,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 17,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 50
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 1,
+      "comment_count": 97,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 11,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 4,
+      "comment_count": 93,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 27,
+      "comment_count": 149,
+      "coverage_partial": false,
+      "thread_count": 50
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 8,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 5,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 14,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 3,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 1,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 6,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 5,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 15,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 4,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 12,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 42
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W16.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W16.json
@@ -1249,6 +1249,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 9,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 9,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 17,
+      "comment_count": 122,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 8,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 10,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 7,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 17,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 13,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 23,
+      "comment_count": 136,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 26,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 10,
+      "comment_count": 167,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 1,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 13,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 7,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 13,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 12,
+      "comment_count": 94,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 10,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 22,
+      "comment_count": 165,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W17.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W17.json
@@ -1096,6 +1096,224 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 11,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 10,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 24,
+      "comment_count": 128,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 7,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 11,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 21,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 17,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 8,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 11,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 13,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 10,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 23,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 11,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 13,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 3,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 10,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 24,
+      "comment_count": 105,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 8,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 10,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 5,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 13,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 7,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 17
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2021-W18.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W18.json
@@ -1083,6 +1083,248 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 1,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 19,
+      "comment_count": 151,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 22,
+      "comment_count": 86,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 14,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 10,
+      "comment_count": 63,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 10,
+      "comment_count": 128,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 12,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 12,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 18,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 13,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 11,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 6,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 4,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 11,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 11,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 15,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 12,
+      "comment_count": 100,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 10,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 2,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 8,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 7,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 5,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 6,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 16,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 8,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 29
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W19.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W19.json
@@ -1163,6 +1163,254 @@
       }
     }
   },
+  "by_author_comments": {
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 26,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 4,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 34,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 49
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 13,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 13,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 23,
+      "comment_count": 167,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 1,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 8,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 3,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 8,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 12,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 7,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 4,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 9,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 5,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 6,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 15,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 14,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 12,
+      "comment_count": 82,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 7,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 9,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 23
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W20.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W20.json
@@ -1220,6 +1220,278 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 8,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 2,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 16,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 1,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 14,
+      "comment_count": 97,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 9,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 7,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 8,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 2,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 5,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 13,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 5,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 15,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 16,
+      "comment_count": 189,
+      "coverage_partial": false,
+      "thread_count": 55
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 11,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 18,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 12,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 9,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 5,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 12,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 7,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 19,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 23
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W21.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W21.json
@@ -1349,6 +1349,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 18,
+      "comment_count": 132,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 3,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 14,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 10,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 2,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 20,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 5,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 10,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 8,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 36,
+      "comment_count": 183,
+      "coverage_partial": false,
+      "thread_count": 48
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 21,
+      "comment_count": 144,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 9,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 13,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 5,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 10,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 10,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 1,
+      "comment_count": 7,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 3,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 19,
+      "comment_count": 189,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 9,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 4,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 9,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 14,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 4,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 19,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 21
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2021-W22.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W22.json
@@ -1305,6 +1305,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 12,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 16,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 11,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 9,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 13,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 5,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 11,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 6,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 9,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 16,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 12,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 30,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 14,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 14,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 7,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 8,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 5,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 1,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 2,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 11,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 13,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 14,
+      "comment_count": 138,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 1,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 9,
+      "comment_count": 129,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 27,
+      "comment_count": 107,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 21,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 5,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 1,
+      "comment_count": 78,
+      "coverage_partial": true,
+      "thread_count": 20
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2021-W23.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W23.json
@@ -1243,6 +1243,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 4,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 7,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 17,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 4,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 4,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 14,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 1,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 1,
+      "comment_count": 7,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 13,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 20,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 18,
+      "comment_count": 145,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 0,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 11,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 10,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 8,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 7,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 1,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 9,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 27,
+      "comment_count": 130,
+      "coverage_partial": true,
+      "thread_count": 41
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 0,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 6,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 18,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 9,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 19,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 12,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 14,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 19
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W24.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W24.json
@@ -1239,6 +1239,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 12,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 9,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 18,
+      "comment_count": 154,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 5,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 9,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 13,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 4,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 12,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 19,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 18,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 1,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 7,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 20,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 51
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 15,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 8,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 30,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 16,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 26,
+      "comment_count": 117,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 15,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 18,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 7,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 3,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 0,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 6,
+      "comment_count": 69,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W25.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W25.json
@@ -1318,6 +1318,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 5,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 9,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 6,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 7,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 14,
+      "comment_count": 41,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 13,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 11,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 1,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 2,
+      "comment_count": 17,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 19,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 6,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 8,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 22,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 6,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 8,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 13,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 17,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 1,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 14,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 28,
+      "comment_count": 154,
+      "coverage_partial": false,
+      "thread_count": 49
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 2,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 2,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 16,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 0,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W26.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W26.json
@@ -1127,6 +1127,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 12,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 3,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 7,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 5,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 15,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 6,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 11,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 7,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 14,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 30,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 24,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 7,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 10,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 6,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 6,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 12,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 13,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 3,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 21,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 8,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 9,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 12,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W27.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W27.json
@@ -1192,6 +1192,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 7,
+      "comment_count": 49,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 11,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 1,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 0,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 3,
+      "comment_count": 43,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 5,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 19,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 8,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 5,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 9,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 7,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 15,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 8,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 9,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 11,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 5,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 11,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 6,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 1,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W28.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W28.json
@@ -1276,6 +1276,284 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 5,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 9,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 4,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 15,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 14,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 3,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 11,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 14,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 8,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 21,
+      "comment_count": 134,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 12,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 2,
+      "comment_count": 11,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 7,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 12,
+      "comment_count": 59,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 3,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 10,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 10,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 12,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 6,
+      "comment_count": 99,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 1,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 27,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 6,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 17,
+      "comment_count": 160,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 2,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 16,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 12,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 12
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2021-W29.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W29.json
@@ -1251,6 +1251,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 11,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 12,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 13,
+      "comment_count": 184,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 11,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 14,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 3,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 6,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 13,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 14,
+      "comment_count": 119,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 10,
+      "comment_count": 97,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 2,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 6,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 3,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 15,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 19,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 23,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 11,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 10,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W30.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W30.json
@@ -1088,6 +1088,248 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 30,
+      "comment_count": 170,
+      "coverage_partial": false,
+      "thread_count": 50
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 13,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 25,
+      "comment_count": 187,
+      "coverage_partial": false,
+      "thread_count": 48
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 17,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 19,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 15,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 14,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 12,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 17,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 22,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 9,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 26,
+      "comment_count": 147,
+      "coverage_partial": false,
+      "thread_count": 44
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 12,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 9,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 22,
+      "comment_count": 110,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 4,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 4,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 6,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 3,
+      "comment_count": 31,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 10,
+      "comment_count": 142,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 3,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 17,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 10,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 5,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W31.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W31.json
@@ -1214,6 +1214,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 16,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 4,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 12,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 15,
+      "comment_count": 110,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 9,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 15,
+      "comment_count": 144,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 3,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 1,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 4,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 5,
+      "comment_count": 34,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 18,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 6,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 2,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 10,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 11,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 13,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 12,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 22,
+      "comment_count": 152,
+      "coverage_partial": true,
+      "thread_count": 37
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 11,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 13
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W32.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W32.json
@@ -1165,6 +1165,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 18,
+      "comment_count": 165,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 15,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 17,
+      "comment_count": 106,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 10,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 5,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 17,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 15,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 11,
+      "comment_count": 90,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 8,
+      "comment_count": 69,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 16,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 18,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 9,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 7,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 11,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 7,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 12,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 10,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 0,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 7,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 1,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W33.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W33.json
@@ -1138,6 +1138,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 6,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 20,
+      "comment_count": 151,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 17,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 18,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 33,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 5,
+      "comment_count": 53,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 10,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 10,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 8,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 6,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 1,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 10,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 18,
+      "comment_count": 170,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 18,
+      "comment_count": 87,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 7,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 9,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 7,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W34.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W34.json
@@ -1245,6 +1245,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 16,
+      "comment_count": 108,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 15,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 17,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 8,
+      "comment_count": 77,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 4,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 13,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 17,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 28,
+      "comment_count": 188,
+      "coverage_partial": true,
+      "thread_count": 54
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 5,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 16,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 3,
+      "comment_count": 34,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 18,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 18,
+      "comment_count": 122,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 2,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 6,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 10,
+      "comment_count": 107,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 5,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 13,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 6,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 14,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 8,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 11,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 16,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 9,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 20,
+      "comment_count": 92,
+      "coverage_partial": true,
+      "thread_count": 26
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W35.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W35.json
@@ -1185,6 +1185,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 6,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 3,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 3,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 12,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 6,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 10,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 5,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 16,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 3,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 17,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 8,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 4,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 1,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 11,
+      "comment_count": 84,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 6,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 23,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 32,
+      "comment_count": 158,
+      "coverage_partial": false,
+      "thread_count": 51
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 5,
+      "comment_count": 100,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 10,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 15,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 19,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 24,
+      "comment_count": 181,
+      "coverage_partial": false,
+      "thread_count": 54
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W36.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W36.json
@@ -1116,6 +1116,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 29,
+      "comment_count": 148,
+      "coverage_partial": false,
+      "thread_count": 53
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 8,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 4,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 8,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 17,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 4,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 14,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 7,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 8,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 2,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 16,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 21,
+      "comment_count": 146,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 11,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 17,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 7,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 6,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 2,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 2,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 5,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 14,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W37.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W37.json
@@ -1185,6 +1185,284 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 7,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 10,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 19,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 12,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 18,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 4,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 20,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 6,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 11,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 16,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 13,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 2,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 3,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 9,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 16,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 6,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 20,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 8,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 12,
+      "comment_count": 154,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 7,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 14,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 13,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 13,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 21,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 28
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W38.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W38.json
@@ -1001,6 +1001,224 @@
       }
     }
   },
+  "by_author_comments": {
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 22,
+      "comment_count": 78,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 3,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 12,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 15,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 13,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 28,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 4,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 15,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 8,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 11,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 0,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 13,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 7,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 13,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 8,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 30,
+      "comment_count": 136,
+      "coverage_partial": true,
+      "thread_count": 43
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 15,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 18,
+      "comment_count": 136,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 42,
+      "comment_count": 204,
+      "coverage_partial": false,
+      "thread_count": 70
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 10,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 26
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W39.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W39.json
@@ -1058,6 +1058,230 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 2,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 11,
+      "comment_count": 51,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 16,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 3,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 14,
+      "comment_count": 99,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 15,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 17,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 16,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 24,
+      "comment_count": 148,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 9,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 23,
+      "comment_count": 144,
+      "coverage_partial": true,
+      "thread_count": 36
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 9,
+      "comment_count": 69,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 6,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 1,
+      "comment_count": 31,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 10,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 13,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W40.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W40.json
@@ -1100,6 +1100,224 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 4,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 7,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 11,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 10,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 4,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 5,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 9,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 20,
+      "comment_count": 219,
+      "coverage_partial": false,
+      "thread_count": 56
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 6,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 7,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 11,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 15,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 7,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 24,
+      "comment_count": 181,
+      "coverage_partial": true,
+      "thread_count": 53
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 12,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 29,
+      "comment_count": 146,
+      "coverage_partial": true,
+      "thread_count": 53
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 5,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 8,
+      "comment_count": 137,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 8,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 6,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 21
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W41.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W41.json
@@ -958,6 +958,248 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 9,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 7,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 11,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 6,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 12,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 13,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 16,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 10,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 10,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 9,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 1,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 14,
+      "comment_count": 160,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 15,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 4,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W42.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W42.json
@@ -1202,6 +1202,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 0,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 16,
+      "comment_count": 93,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 7,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 11,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 9,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 25,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 13,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 7,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 15,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 12,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 7,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 10,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 19,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 13,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 18,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 9,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 10,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 6,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 2,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2021-W43.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W43.json
@@ -1213,6 +1213,284 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 8,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 11,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 7,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 24,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 11,
+      "comment_count": 105,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 6,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 20,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 14,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 12,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 13,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 3,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 13,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 22,
+      "comment_count": 187,
+      "coverage_partial": false,
+      "thread_count": 49
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2021-W44.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W44.json
@@ -987,6 +987,200 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 5,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 7,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 24,
+      "comment_count": 167,
+      "coverage_partial": false,
+      "thread_count": 44
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 17,
+      "comment_count": 122,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 11,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 14,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 8,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 7,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 8,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 8,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 8,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 13,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 18,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 15,
+      "comment_count": 177,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 15,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 6,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 6,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 3,
+      "comment_count": 41,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 26,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 7
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W45.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W45.json
@@ -907,6 +907,200 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 6,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 21,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 17,
+      "comment_count": 143,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 2,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 19,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 7,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 18,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 13,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 8,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 16,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 2,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 12,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 13,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 7,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 21
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W46.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W46.json
@@ -902,6 +902,194 @@
       }
     }
   },
+  "by_author_comments": {
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 20,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 6,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 4,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 5,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 1,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 13,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 12,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 17,
+      "comment_count": 189,
+      "coverage_partial": false,
+      "thread_count": 52
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 15,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 4,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 18,
+      "comment_count": 141,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 13,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 15,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 6,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 7,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 15,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 18
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W47.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W47.json
@@ -900,6 +900,194 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 9,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 14,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 17,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 1,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 5,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 38,
+      "comment_count": 167,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 9,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 20,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 15,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 17,
+      "comment_count": 158,
+      "coverage_partial": false,
+      "thread_count": 48
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 12,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 4,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 6,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 5,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W48.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W48.json
@@ -1020,6 +1020,230 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 13,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 11,
+      "comment_count": 97,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 7,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 10,
+      "comment_count": 61,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 2,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 6,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 0,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 5,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 0,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 1,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 9,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 2,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 3,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 9,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 16,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 3,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 12,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 3,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 9,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 11,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 11
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W49.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W49.json
@@ -1042,6 +1042,224 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 6,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 10,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 13,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 23,
+      "comment_count": 138,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 19,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 6,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 14,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 14,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 4,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 1,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 11,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 13,
+      "comment_count": 137,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 28,
+      "comment_count": 84,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 8,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 9,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 12,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 7,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 23
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W50.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W50.json
@@ -949,6 +949,224 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 2,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 12,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 7,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 8,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 15,
+      "comment_count": 61,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 5,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 12,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 24,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 23,
+      "comment_count": 164,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 2,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 10,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 8,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 9,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 13,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 14,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 14,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 16,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 9,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W51.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W51.json
@@ -982,6 +982,236 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 6,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 21,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 4,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 3,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 19,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 16,
+      "comment_count": 167,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 12,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 2,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 12,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 15,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 2,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 4,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 8,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 20,
+      "comment_count": 129,
+      "coverage_partial": true,
+      "thread_count": 43
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 14,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 23,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 0,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2021-W52.json
+++ b/docs/data/aggregates/weekly_rollups/2021-W52.json
@@ -455,6 +455,110 @@
       }
     }
   },
+  "by_author_comments": {
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 15,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 10,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 11,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 14,
+      "comment_count": 89,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 16,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W01.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W01.json
@@ -927,6 +927,212 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 2,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 10,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 7,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 7,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 13,
+      "comment_count": 51,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 24,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 18,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 13,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 8,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 15,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 5,
+      "comment_count": 79,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 10,
+      "comment_count": 108,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 11,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 16,
+      "comment_count": 148,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 9,
+      "comment_count": 124,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 9,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 11,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W02.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W02.json
@@ -991,6 +991,218 @@
       }
     }
   },
+  "by_author_comments": {
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 10,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 7,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 14,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 13,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 13,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 31,
+      "comment_count": 161,
+      "coverage_partial": true,
+      "thread_count": 40
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 6,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 20,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 35
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 1,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 1,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 7,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 22,
+      "comment_count": 138,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 10,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 14,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 12,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 15,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 14,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 11,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 23
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W03.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W03.json
@@ -1027,6 +1027,254 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 7,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 3,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 10,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 6,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 8,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 12,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 3,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 9,
+      "comment_count": 71,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 8,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 12,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 11,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 16,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 9,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 6,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 1,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 20,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 3,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 21,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 10,
+      "comment_count": 124,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 40,
+      "comment_count": 196,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 11,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 6,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 8,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W04.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W04.json
@@ -1069,6 +1069,254 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 10,
+      "comment_count": 87,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 3,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 13,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 15,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 6,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 11,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 20,
+      "comment_count": 80,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 3,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 7,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 6,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 5,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 1,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 11,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 14,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 29
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W05.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W05.json
@@ -1031,6 +1031,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 11,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 13,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 2,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 22,
+      "comment_count": 163,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 17,
+      "comment_count": 160,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 11,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 1,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 11,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 2,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 2,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 4,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 9,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 34,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 49
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 4,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 20,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 1,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 11,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 1,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W06.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W06.json
@@ -1085,6 +1085,242 @@
       }
     }
   },
+  "by_author_comments": {
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 2,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 10,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 5,
+      "comment_count": 31,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 6,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 23,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 5,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 2,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 16,
+      "comment_count": 165,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 7,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 18,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 2,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 4,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 5,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 3,
+      "comment_count": 62,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 6,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 1,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 18,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 16,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 11,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W07.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W07.json
@@ -1123,6 +1123,242 @@
       }
     }
   },
+  "by_author_comments": {
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 3,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 13,
+      "comment_count": 158,
+      "coverage_partial": true,
+      "thread_count": 40
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 19,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 9,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 1,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 12,
+      "comment_count": 89,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 29,
+      "comment_count": 141,
+      "coverage_partial": true,
+      "thread_count": 43
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 3,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 11,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 2,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 13,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 13,
+      "comment_count": 162,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 8,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 8,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 21,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 7,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 5,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 4,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 8,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 14,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 14,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 4,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 6,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 15,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 28
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W08.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W08.json
@@ -1065,6 +1065,236 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 7,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 1,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 12,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 7,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 4,
+      "comment_count": 91,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 14,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 15,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 3,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 18,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 23,
+      "comment_count": 103,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 6,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 3,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 8,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 10,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 18,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 4,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W09.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W09.json
@@ -1091,6 +1091,230 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 10,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 19,
+      "comment_count": 153,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 15,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 13,
+      "comment_count": 108,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 4,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 21,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 28,
+      "comment_count": 124,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 5,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 1,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 12,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 8,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 3,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 2,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 13,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 7,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 6,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 15,
+      "comment_count": 87,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 9,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 12,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 5,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2022-W10.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W10.json
@@ -1060,6 +1060,230 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 5,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 9,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 10,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 24,
+      "comment_count": 189,
+      "coverage_partial": false,
+      "thread_count": 54
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 10,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 14,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 12,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 11,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 21,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 5,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 10,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 79,
+      "coverage_partial": true,
+      "thread_count": 35
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 51,
+      "comment_count": 312,
+      "coverage_partial": false,
+      "thread_count": 78
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 9,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 13,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 2,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 19,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 6,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 11
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W11.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W11.json
@@ -1109,6 +1109,242 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 5,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 13,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 34,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 15,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 18,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 16,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 22,
+      "comment_count": 149,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 17,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 21,
+      "comment_count": 122,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 5,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 9,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 7,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 1,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 4,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 2,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 15,
+      "comment_count": 86,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 8,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 16,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 20,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 21,
+      "comment_count": 120,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W12.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W12.json
@@ -1196,6 +1196,248 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 11,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 9,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 13,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 1,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 16,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 16,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 13,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 22,
+      "comment_count": 137,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 1,
+      "comment_count": 76,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 7,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 15,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 11,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 2,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 11,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 17,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 17,
+      "comment_count": 110,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 0,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 9,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 15,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 4,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 5,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 13,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 4,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 12
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W13.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W13.json
@@ -1034,6 +1034,236 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 2,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 6,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 8,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 4,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 7,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 13,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 14,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 1,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 8,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 12,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 17,
+      "comment_count": 88,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 9,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 3,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 9,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 12,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 10,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 15,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 15,
+      "comment_count": 90,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 12,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 11,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 10,
+      "comment_count": 109,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 8,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 7,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 5,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 2,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W14.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W14.json
@@ -1345,6 +1345,338 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 5,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 11,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 28,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 10,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 30,
+      "comment_count": 225,
+      "coverage_partial": false,
+      "thread_count": 59
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 0,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 11,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 4,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 7,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 14,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 3,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 4,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 5,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 12,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 11,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 11,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 19,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 22,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 11,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 10,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 7,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 10,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 23,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 16,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 6,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 5,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 15,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 27
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W15.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W15.json
@@ -1218,6 +1218,284 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 23,
+      "comment_count": 210,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 30,
+      "comment_count": 201,
+      "coverage_partial": true,
+      "thread_count": 58
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 3,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 12,
+      "comment_count": 92,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 5,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 16,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 4,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 0,
+      "comment_count": 29,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 13,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 22,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 24,
+      "comment_count": 62,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 8,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 4,
+      "comment_count": 80,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 11,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 12,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 7,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 13,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 12,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 13,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 7,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W16.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W16.json
@@ -1238,6 +1238,284 @@
       }
     }
   },
+  "by_author_comments": {
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 11,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 16,
+      "comment_count": 122,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 11,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 18,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 36,
+      "comment_count": 247,
+      "coverage_partial": false,
+      "thread_count": 63
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 1,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 15,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 8,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 18,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 2,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 13,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 11,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 22,
+      "comment_count": 98,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 2,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 12,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 1,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 1,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 10,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 7,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 16,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 15,
+      "comment_count": 151,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 15,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 8,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W17.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W17.json
@@ -1232,6 +1232,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 4,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 17,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 9,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 5,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 4,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 3,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 15,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 11,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 7,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 11,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 14,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 4,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 6,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 7,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 4,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 6,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 13,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 3,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 10,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 13,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 10,
+      "comment_count": 96,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 5,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 12,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 14,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 1,
+      "comment_count": 128,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 9,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 7,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 18,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 21,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 17,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 19
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W18.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W18.json
@@ -1223,6 +1223,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 14,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 16,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 12,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 11,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 18,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 1,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 5,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 12,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 13,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 0,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 9,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 10,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 9,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 10,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 5,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 3,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 0,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 16,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 31,
+      "comment_count": 203,
+      "coverage_partial": true,
+      "thread_count": 54
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 16,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 6,
+      "comment_count": 94,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 11,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 7,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W19.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W19.json
@@ -1307,6 +1307,326 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 9,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 0,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 10,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 1,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 14,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 13,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 4,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 8,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 8,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 10,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 9,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 14,
+      "comment_count": 100,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 15,
+      "comment_count": 163,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 10,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 1,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 3,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 4,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 11,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 8,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 7,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 11,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 13,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2022-W20.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W20.json
@@ -1384,6 +1384,344 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 5,
+      "comment_count": 29,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 10,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 15,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 7,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 15,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 10,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 22,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 14,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 4,
+      "comment_count": 91,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 7,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 9,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 7,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 2,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 2,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 16,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 20,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 5,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 1,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 20,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 0,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 11,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 9,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 15,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 8,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2022-W21.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W21.json
@@ -1297,6 +1297,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 11,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 5,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 18,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 0,
+      "comment_count": 19,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 9,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 7,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 36,
+      "comment_count": 197,
+      "coverage_partial": true,
+      "thread_count": 47
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 5,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 0,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 12,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 0,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 22,
+      "comment_count": 137,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 24,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 20,
+      "comment_count": 233,
+      "coverage_partial": false,
+      "thread_count": 49
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 14,
+      "comment_count": 122,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 7,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 7,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 5,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 7,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 13,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 13,
+      "comment_count": 153,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 7,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 6,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 4,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 11,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 15,
+      "comment_count": 142,
+      "coverage_partial": true,
+      "thread_count": 43
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 5,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 6,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 11,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 8,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 12
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W22.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W22.json
@@ -1316,6 +1316,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 6,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 28,
+      "comment_count": 118,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 10,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 8,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 12,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 9,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 11,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 11,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 27,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 48
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 9,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 9,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 8,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 10,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 1,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 6,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 2,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 13,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 7,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 16,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 25,
+      "comment_count": 150,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 8,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 4,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 6,
+      "comment_count": 43,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 15,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 13,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 2,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 13,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 7,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 18
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2022-W23.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W23.json
@@ -1423,6 +1423,314 @@
       }
     }
   },
+  "by_author_comments": {
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 12,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 6,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 11,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 11,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 9,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 5,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 21,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 16,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 17,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 10,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 4,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 2,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 12,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 4,
+      "comment_count": 82,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 17,
+      "comment_count": 94,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 22,
+      "comment_count": 217,
+      "coverage_partial": true,
+      "thread_count": 60
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 10,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 11,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 3,
+      "comment_count": 81,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 2,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 20,
+      "comment_count": 100,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 4,
+      "comment_count": 31,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 1,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 14,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 13,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 10,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 10,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 10,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 2,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 9,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 20
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2022-W24.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W24.json
@@ -1292,6 +1292,326 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 8,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 10,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 23,
+      "comment_count": 168,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 14,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 9,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 16,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 19,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 2,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 4,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 10,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 24,
+      "comment_count": 123,
+      "coverage_partial": true,
+      "thread_count": 36
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 3,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 15,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 5,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 3,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 11,
+      "comment_count": 140,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 18,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 8,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 13,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 8,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 15,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 11,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W25.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W25.json
@@ -1403,6 +1403,320 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 5,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 12,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 9,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 15,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 8,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 14,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 13,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 1,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 7,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 7,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 7,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 11,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 14,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 11,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 6,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 4,
+      "comment_count": 76,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 8,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 18,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 2,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 3,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 13,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 12,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 10,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 1,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 11,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 1,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 17,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 7,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 18,
+      "comment_count": 110,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 12,
+      "comment_count": 132,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 24,
+      "comment_count": 98,
+      "coverage_partial": true,
+      "thread_count": 32
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2022-W26.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W26.json
@@ -1121,6 +1121,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 10,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 12,
+      "comment_count": 43,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 12,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 18,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 35,
+      "comment_count": 185,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 16,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 13,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 3,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 13,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 8,
+      "comment_count": 93,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 9,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 13,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 9,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 25,
+      "comment_count": 166,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 15,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 3,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 14,
+      "comment_count": 118,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 16,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 15,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 12,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 4,
+      "comment_count": 47,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 10,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 7,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 15,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 4,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 13,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 21,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 13,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W27.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W27.json
@@ -1243,6 +1243,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 12,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 13,
+      "comment_count": 163,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 5,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 4,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 10,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 18,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 16,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 10,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 17,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 22,
+      "comment_count": 157,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 9,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 10,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 21,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 6,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 5,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 9,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 9,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 17,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 6,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 2,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 11,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 4,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 20
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W28.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W28.json
@@ -1352,6 +1352,320 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 2,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 5,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 16,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 5,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 2,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 8,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 12,
+      "comment_count": 95,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 14,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 17,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 10,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 14,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 15,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 15,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 17,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 13,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 2,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 4,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 27,
+      "comment_count": 154,
+      "coverage_partial": true,
+      "thread_count": 43
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 1,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 17,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 16,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 12,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 6,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 5,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 13,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 6,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 8,
+      "comment_count": 67,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 4,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 11,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 17,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W29.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W29.json
@@ -1445,6 +1445,374 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 3,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 4,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 15,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 9,
+      "comment_count": 68,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 4,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 4,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 22,
+      "comment_count": 94,
+      "coverage_partial": true,
+      "thread_count": 36
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 8,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 12,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 3,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 8,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 6,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 11,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 6,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 5,
+      "comment_count": 63,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 11,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 17,
+      "comment_count": 68,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 6,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 8,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 8,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 2,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 8,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 6,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W30.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W30.json
@@ -1312,6 +1312,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 2,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 19,
+      "comment_count": 146,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 13,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 3,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 6,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 24,
+      "comment_count": 182,
+      "coverage_partial": false,
+      "thread_count": 52
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 22,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 17,
+      "comment_count": 96,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 12,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 13,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 18,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 16,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 5,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 18,
+      "comment_count": 136,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 17,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 18,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 18,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 1,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 5,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 7,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 12,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 10,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 7,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 14,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 11,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2022-W31.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W31.json
@@ -1325,6 +1325,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 13,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 3,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 11,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 8,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 9,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 13,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 7,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 21,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 11,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 8,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 34,
+      "comment_count": 255,
+      "coverage_partial": false,
+      "thread_count": 62
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 15,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 20,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 12,
+      "comment_count": 112,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 6,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 16,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 12,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 7,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 11,
+      "comment_count": 94,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 6,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 9,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 14,
+      "comment_count": 79,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 2,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 6,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 10,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 2,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 6,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 2,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 18
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2022-W32.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W32.json
@@ -1323,6 +1323,308 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 12,
+      "comment_count": 99,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 13,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 1,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 21,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 0,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 20,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 15,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 15,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 2,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 3,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 10,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 14,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 18,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 6,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 13,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 22,
+      "comment_count": 141,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 6,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 32,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 7,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 1,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 7,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 9,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 14,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 13,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 1,
+      "comment_count": 7,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2022-W33.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W33.json
@@ -1469,6 +1469,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 6,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 0,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 14,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 8,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 15,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 24,
+      "comment_count": 166,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 13,
+      "comment_count": 83,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 7,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 12,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 0,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 7,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 13,
+      "comment_count": 63,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 11,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 15,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 12,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 1,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 7,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 5,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 2,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 15,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 2,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 0,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 3,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 15,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 28
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W34.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W34.json
@@ -1207,6 +1207,284 @@
       }
     }
   },
+  "by_author_comments": {
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 5,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 5,
+      "comment_count": 167,
+      "coverage_partial": true,
+      "thread_count": 36
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 2,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 13,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 4,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 12,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 2,
+      "comment_count": 47,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 23,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 12,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 9,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 0,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 6,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 5,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 13,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 46,
+      "comment_count": 152,
+      "coverage_partial": false,
+      "thread_count": 59
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 14,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 14,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 21,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 2,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 21,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 2,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 14,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 9,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 6,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W35.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W35.json
@@ -1318,6 +1318,314 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 9,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 16,
+      "comment_count": 137,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 17,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 13,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 11,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 12,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 15,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 16,
+      "comment_count": 162,
+      "coverage_partial": true,
+      "thread_count": 41
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 0,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 18,
+      "comment_count": 174,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 10,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 4,
+      "comment_count": 82,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 14,
+      "comment_count": 164,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 3,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 13,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 6,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 13,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 1,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 15,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 21,
+      "comment_count": 171,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 3,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 61,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 19,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 12,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2022-W36.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W36.json
@@ -1136,6 +1136,284 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 16,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 12,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 20,
+      "comment_count": 128,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 13,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 8,
+      "comment_count": 136,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 5,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 1,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 10,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 1,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 0,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 17,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 16,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 8,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 16,
+      "comment_count": 105,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 12,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 7,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 4,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 15,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 21,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W37.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W37.json
@@ -1238,6 +1238,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 4,
+      "comment_count": 97,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 18,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 5,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 13,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 9,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 10,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 1,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 13,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 12,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 10,
+      "comment_count": 110,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 14,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 10,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 6,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 15,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 27,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 3,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 12,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 19,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 18,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 12,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 17,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 1,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 1,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 1,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W38.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W38.json
@@ -1327,6 +1327,326 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 11,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 13,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 7,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 18,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 5,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 9,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 15,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 13,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 27,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 11,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 3,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 4,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 11,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 10,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 4,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 4,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 12,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 4,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 0,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 21,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 12,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 9,
+      "comment_count": 34,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 13,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 12,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 1,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 21,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 9,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W39.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W39.json
@@ -1143,6 +1143,254 @@
       }
     }
   },
+  "by_author_comments": {
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 4,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 21,
+      "comment_count": 143,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 18,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 24,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 18,
+      "comment_count": 183,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 15,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 0,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 9,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 13,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 9,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 9,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 9,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 12,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 2,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 6,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 6,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 5,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 19,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 20,
+      "comment_count": 194,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 7,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 7,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 18,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 23
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W40.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W40.json
@@ -1089,6 +1089,242 @@
       }
     }
   },
+  "by_author_comments": {
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 8,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 14,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 15,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 7,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 6,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 18,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 4,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 20,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 10,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 19,
+      "comment_count": 130,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 9,
+      "comment_count": 165,
+      "coverage_partial": true,
+      "thread_count": 36
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 6,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 14,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 10,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 11,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 2,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 5,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 9,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 1,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 6,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 10,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 11
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W41.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W41.json
@@ -1167,6 +1167,278 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 12,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 23,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 8,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 10,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 13,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 13,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 9,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 23,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 6,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 11,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 8,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 7,
+      "comment_count": 171,
+      "coverage_partial": false,
+      "thread_count": 52
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 11,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 5,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 6,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 6,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 14,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 13,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 5,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 0,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 14,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 0,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 8,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 5,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 22
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W42.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W42.json
@@ -1271,6 +1271,278 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 10,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 8,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 10,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 14,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 6,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 3,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 10,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 11,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 1,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 7,
+      "comment_count": 76,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 4,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 15,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 14,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 12,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 0,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 5,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 7,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 3,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 9,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 21,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 3,
+      "comment_count": 13,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 8,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 3,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 4,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 8,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 8,
+      "comment_count": 138,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 8,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 16,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 12,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W43.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W43.json
@@ -1076,6 +1076,254 @@
       }
     }
   },
+  "by_author_comments": {
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 9,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 18,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 7,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 3,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 13,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 7,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 2,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 17,
+      "comment_count": 159,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 9,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 19,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 4,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 14,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 3,
+      "comment_count": 61,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 13,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 5,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 9,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 1,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 19
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W44.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W44.json
@@ -1145,6 +1145,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 9,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 3,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 15,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 17,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 7,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 3,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 1,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 13,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 11,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 17,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 5,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 4,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 6,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 10,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 7,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 11,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 3,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 11,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 11,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 34,
+      "comment_count": 172,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 13,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 13,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 1,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 6
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W45.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W45.json
@@ -1089,6 +1089,236 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 8,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 5,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 15,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 2,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 8,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 23,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 6,
+      "comment_count": 62,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 13,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 5,
+      "comment_count": 62,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 5,
+      "comment_count": 43,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 13,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 5,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 6,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 16,
+      "comment_count": 69,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 17,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 12,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 24,
+      "comment_count": 144,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 6,
+      "comment_count": 37,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 13,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 3,
+      "comment_count": 19,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 6,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 21
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W46.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W46.json
@@ -1073,6 +1073,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 6,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 17,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 8,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 12,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 0,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 4,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 16,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 3,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 1,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 22,
+      "comment_count": 176,
+      "coverage_partial": false,
+      "thread_count": 53
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 10,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 26,
+      "comment_count": 93,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 12,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 9,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 7,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W47.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W47.json
@@ -1018,6 +1018,224 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 10,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 9,
+      "comment_count": 34,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 5,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 9,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 18,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 9,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 11,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 2,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 9,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 12,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 13,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 6,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 13,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 9,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 15,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 14,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 14,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W48.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W48.json
@@ -938,6 +938,212 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 7,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 14,
+      "comment_count": 93,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 4,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 20,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 7,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 8,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 8,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 11,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 2,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 9,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 13,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 4,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 5,
+      "comment_count": 68,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 4,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 14,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 5,
+      "comment_count": 82,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W49.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W49.json
@@ -1082,6 +1082,254 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 19,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 21,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 9,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 14,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 1,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 31,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 13,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 15,
+      "comment_count": 124,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 6,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 3,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 3,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 8,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 11,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 2,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 0,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 13,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 5,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 2,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 11,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 5,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 4,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W50.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W50.json
@@ -951,6 +951,230 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 4,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 20,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 13,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 20,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 2,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 3,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 2,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 12,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 8,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 5,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 10,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 22,
+      "comment_count": 147,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 9,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W51.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W51.json
@@ -1034,6 +1034,206 @@
       }
     }
   },
+  "by_author_comments": {
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 13,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 10,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 22,
+      "comment_count": 155,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 13,
+      "comment_count": 122,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 11,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 21,
+      "comment_count": 138,
+      "coverage_partial": true,
+      "thread_count": 37
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 11,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 6,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 18,
+      "comment_count": 128,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 13,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 5,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 5,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 15,
+      "comment_count": 97,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 16,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 18,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 5,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 10,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 20,
+      "comment_count": 180,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2022-W52.json
+++ b/docs/data/aggregates/weekly_rollups/2022-W52.json
@@ -535,6 +535,122 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 4,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 8,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 2,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 11,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 7,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 11,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 17,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 20,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 29
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W01.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W01.json
@@ -1280,6 +1280,284 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 11,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 10,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 7,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 0,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 0,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 6,
+      "comment_count": 97,
+      "coverage_partial": true,
+      "thread_count": 35
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 5,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 8,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 8,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 12,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 16,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 12,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 10,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 2,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 2,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 2,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 13,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 4,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 7,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 10,
+      "comment_count": 112,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 11,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 10,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 14,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 5,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 4,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 20
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W02.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W02.json
@@ -1009,6 +1009,230 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 18,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 6,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 1,
+      "comment_count": 34,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 15,
+      "comment_count": 132,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 8,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 6,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 8,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 6,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 16,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 11,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 13,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 15,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 10,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 5,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 7,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 9,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 8,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W03.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W03.json
@@ -1044,6 +1044,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 10,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 6,
+      "comment_count": 172,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 15,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 4,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 3,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 13,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 6,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 9,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 14,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 7,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 30,
+      "comment_count": 199,
+      "coverage_partial": true,
+      "thread_count": 62
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 4,
+      "comment_count": 61,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 0,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 6,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 11,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 13,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 17,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 7,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 7,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W04.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W04.json
@@ -1032,6 +1032,248 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 7,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 26,
+      "comment_count": 182,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 7,
+      "comment_count": 31,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 7,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 4,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 22,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 14,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 0,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 5,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 2,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 9,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 8,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 1,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 26,
+      "comment_count": 152,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 14,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W05.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W05.json
@@ -1018,6 +1018,230 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 6,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 8,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 12,
+      "comment_count": 96,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 15,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 8,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 18,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 3,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 13,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 18,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 13,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 1,
+      "comment_count": 100,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 19,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 9,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 19,
+      "comment_count": 109,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 7,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 2,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 17,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 21
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W06.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W06.json
@@ -1196,6 +1196,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 2,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 3,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 3,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 15,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 23,
+      "comment_count": 97,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 8,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 24,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 9,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 0,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 6,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 3,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 21,
+      "comment_count": 116,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 10,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 12,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 4,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 8,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 14,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 13,
+      "comment_count": 34,
+      "coverage_partial": true,
+      "thread_count": 17
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W07.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W07.json
@@ -1159,6 +1159,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 10,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 5,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 13,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 19,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 13,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 15,
+      "comment_count": 140,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 12,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 14,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 9,
+      "comment_count": 118,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 14,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 14,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 7,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 0,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 2,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 5,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 7,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 16,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 10,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 1,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 15,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 7,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 13,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 17,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 6,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 11,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 16
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W08.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W08.json
@@ -1173,6 +1173,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 13,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 18,
+      "comment_count": 115,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 25,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 19,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 6,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 8,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 15,
+      "comment_count": 87,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 17,
+      "comment_count": 140,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 12,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 7,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 11,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 7,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 18,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 9,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 3,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 16,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 20,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 20,
+      "comment_count": 62,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 30,
+      "comment_count": 156,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W09.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W09.json
@@ -1207,6 +1207,278 @@
       }
     }
   },
+  "by_author_comments": {
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 11,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 13,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 7,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 2,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 11,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 8,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 11,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 11,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 9,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 1,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 15,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 12,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 2,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 14,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 2,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 5,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 3,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 11,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 9,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 16,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 18,
+      "comment_count": 84,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 18,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 11,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 15,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 14,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W10.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W10.json
@@ -1218,6 +1218,284 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 15,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 3,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 1,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 16,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 10,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 28,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 5,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 4,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 20,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 4,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 4,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 16,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 4,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 4,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 8,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 10,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 12,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 16,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 17,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 8,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 12,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 14,
+      "comment_count": 43,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 4,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 4,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 13,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W11.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W11.json
@@ -1149,6 +1149,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 2,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 3,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 8,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 13,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 18,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 10,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 10,
+      "comment_count": 87,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 14,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 20,
+      "comment_count": 157,
+      "coverage_partial": false,
+      "thread_count": 48
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 7,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 14,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 11,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 0,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 15,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 0,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 5,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 19
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2023-W12.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W12.json
@@ -1296,6 +1296,326 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 3,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 9,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 10,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 6,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 5,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 7,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 18,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 13,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 8,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 4,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 15,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 10,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 6,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 20,
+      "comment_count": 128,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 13,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 12,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 14,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 10,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 20,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 4,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 16,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 19,
+      "comment_count": 124,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 11,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 2,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 7,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 0,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 9,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W13.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W13.json
@@ -1185,6 +1185,254 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 10,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 9,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 4,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 9,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 12,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 26,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 1,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 5,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 2,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 6,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 1,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 9,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 6,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 30,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 3,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 0,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 6,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 9,
+      "comment_count": 89,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 5,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 9,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 5,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 18
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W14.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W14.json
@@ -1341,6 +1341,320 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 17,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 13,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 11,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 14,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 25,
+      "comment_count": 170,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 5,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 0,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 12,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 6,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 14,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 12,
+      "comment_count": 104,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 12,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 15,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 6,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 17,
+      "comment_count": 176,
+      "coverage_partial": true,
+      "thread_count": 47
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 13,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 12,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 6,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 12,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 3,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 10,
+      "comment_count": 147,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 15,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 8,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 17,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 0,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 1,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W15.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W15.json
@@ -1287,6 +1287,308 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 16,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 27,
+      "comment_count": 181,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 8,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 4,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 12,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 13,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 10,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 8,
+      "comment_count": 41,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 7,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 20,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 7,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 3,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 18,
+      "comment_count": 153,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 15,
+      "comment_count": 105,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 10,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 0,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 18,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 10,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 13,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 14,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 15,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 6,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 23,
+      "comment_count": 221,
+      "coverage_partial": false,
+      "thread_count": 52
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 12,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W16.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W16.json
@@ -1445,6 +1445,332 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 8,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 4,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 10,
+      "comment_count": 62,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 8,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 6,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 10,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 12,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 6,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 16,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 5,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 19,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 24,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 20,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 11,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 8,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 25,
+      "comment_count": 149,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 10,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 7,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 10,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 16,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 26,
+      "comment_count": 170,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 8,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 10,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 17,
+      "comment_count": 175,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 13,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 12,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 13,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 18,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 5,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 9,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 4,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W17.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W17.json
@@ -1321,6 +1321,314 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 9,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 21,
+      "comment_count": 127,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 5,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 20,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 10,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 11,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 16,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 21,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 13,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 11,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 16,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 16,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 3,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 16,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 7,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 6,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 6,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 20,
+      "comment_count": 121,
+      "coverage_partial": true,
+      "thread_count": 40
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 4,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 2,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 1,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 15,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 8,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 1,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 12,
+      "comment_count": 141,
+      "coverage_partial": false,
+      "thread_count": 35
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2023-W18.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W18.json
@@ -1357,6 +1357,326 @@
       }
     }
   },
+  "by_author_comments": {
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 5,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 11,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 8,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 3,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 17,
+      "comment_count": 141,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 13,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 13,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 4,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 15,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 2,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 11,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 20,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 6,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 13,
+      "comment_count": 77,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 12,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 8,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 3,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 6,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 11,
+      "comment_count": 37,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 14,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 17,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 0,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 2,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 10,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 7,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 16,
+      "comment_count": 62,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 8,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 6,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W19.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W19.json
@@ -1370,6 +1370,332 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 8,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 13,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 16,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 13,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 12,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 11,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 9,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 2,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 8,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 14,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 2,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 6,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 16,
+      "comment_count": 92,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 8,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 8,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 8,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 7,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 14,
+      "comment_count": 140,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 15,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 23,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 5,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 21,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 4,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 14,
+      "comment_count": 122,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 0,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 2,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 11,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 6,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 20,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 10,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 7,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 9,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 0,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W20.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W20.json
@@ -1345,6 +1345,326 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 16,
+      "comment_count": 53,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 0,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 13,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 11,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 8,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 0,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 8,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 18,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 2,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 13,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 12,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 5,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 2,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 17,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 19,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 11,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 16,
+      "comment_count": 142,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 9,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 4,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 6,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 16,
+      "comment_count": 143,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 7,
+      "comment_count": 114,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 11,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 3,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 9,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 5,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 38,
+      "comment_count": 141,
+      "coverage_partial": false,
+      "thread_count": 45
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 10,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 15,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 10,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 15,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 6,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 22
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W21.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W21.json
@@ -1423,6 +1423,338 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 1,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 16,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 16,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 6,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 6,
+      "comment_count": 85,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 9,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 12,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 12,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 4,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 15,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 0,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 23,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 24,
+      "comment_count": 154,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 11,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 11,
+      "comment_count": 51,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 11,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 18,
+      "comment_count": 125,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 12,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 3,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 16,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 4,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 6,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 13,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 10,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 3,
+      "comment_count": 76,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 18,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 29
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2023-W22.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W22.json
@@ -1463,6 +1463,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 10,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 9,
+      "comment_count": 71,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 29,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 5,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 12,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 1,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 12,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 10,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 5,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 2,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 10,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 4,
+      "comment_count": 59,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 12,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 8,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 24,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 15,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 1,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 21,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 44
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 7,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 8,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 0,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 3,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 10,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 15,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 18,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 27,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 12,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 16,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 5,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 17,
+      "comment_count": 83,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 16,
+      "comment_count": 118,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 13,
+      "comment_count": 71,
+      "coverage_partial": true,
+      "thread_count": 20
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W23.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W23.json
@@ -1518,6 +1518,368 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 32,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 25,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 5,
+      "comment_count": 37,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 12,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 9,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 2,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 0,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 7,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 5,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 1,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 22,
+      "comment_count": 131,
+      "coverage_partial": true,
+      "thread_count": 37
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 20,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 11,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 12,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 6,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 0,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 8,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 6,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 12,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 10,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 4,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 14,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 7,
+      "comment_count": 82,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 28,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 22,
+      "comment_count": 193,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 6,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 13,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2023-W24.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W24.json
@@ -1443,6 +1443,338 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 1,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 9,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 21,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 19,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 20,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 23,
+      "comment_count": 124,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 9,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 17,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 1,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 17,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 16,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 13,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 45,
+      "comment_count": 244,
+      "coverage_partial": false,
+      "thread_count": 59
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 9,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 1,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 11,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 11,
+      "comment_count": 41,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 6,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 1,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 14,
+      "comment_count": 219,
+      "coverage_partial": true,
+      "thread_count": 47
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 9,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 11,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 10,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 10,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 12,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 19,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 15,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 6,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 11,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 9,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 4,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 7
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2023-W25.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W25.json
@@ -1428,6 +1428,314 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 8,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 9,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 15,
+      "comment_count": 118,
+      "coverage_partial": true,
+      "thread_count": 37
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 12,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 34,
+      "comment_count": 213,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 5,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 16,
+      "comment_count": 78,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 8,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 10,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 14,
+      "comment_count": 162,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 7,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 4,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 2,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 10,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 16,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 7,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 19,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 3,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 12,
+      "comment_count": 87,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 20,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 5,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 19,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 32,
+      "comment_count": 181,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 6,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 11,
+      "comment_count": 76,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 15,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 11,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 31
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2023-W26.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W26.json
@@ -1503,6 +1503,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 3,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 4,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 7,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 21,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 16,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 13,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 11,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 21,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 9,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 7,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 8,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 9,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 10,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 14,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 7,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 25,
+      "comment_count": 173,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 19,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 16,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 22,
+      "comment_count": 138,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 5,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 5,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 10,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 8,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 3,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 2,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 8,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 12,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2023-W27.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W27.json
@@ -1412,6 +1412,368 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 3,
+      "comment_count": 63,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 7,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 9,
+      "comment_count": 102,
+      "coverage_partial": true,
+      "thread_count": 39
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 6,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 3,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 9,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 10,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 22,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 4,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 10,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 20,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 15,
+      "comment_count": 108,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 13,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 4,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 6,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 22,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 7,
+      "comment_count": 63,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 13,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 4,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 13,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 9,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 1,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 21,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 15,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 20,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 12,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 23
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W28.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W28.json
@@ -1308,6 +1308,278 @@
       }
     }
   },
+  "by_author_comments": {
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 13,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 17,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 19,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 0,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 16,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 15,
+      "comment_count": 112,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 14,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 20,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 15,
+      "comment_count": 132,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 10,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 14,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 13,
+      "comment_count": 118,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 6,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 15,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 20,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 1,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 24,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 6,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 17,
+      "comment_count": 98,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 11,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 0,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 5,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 25,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 3,
+      "comment_count": 151,
+      "coverage_partial": false,
+      "thread_count": 37
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W29.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W29.json
@@ -1394,6 +1394,332 @@
       }
     }
   },
+  "by_author_comments": {
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 9,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 0,
+      "comment_count": 47,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 15,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 8,
+      "comment_count": 93,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 11,
+      "comment_count": 78,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 7,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 10,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 17,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 7,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 12,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 19,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 10,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 13,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 3,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 6,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 11,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 15,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 11,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 19,
+      "comment_count": 96,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 8,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 7,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 1,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 17,
+      "comment_count": 125,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 0,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 14,
+      "comment_count": 104,
+      "coverage_partial": true,
+      "thread_count": 36
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 26,
+      "comment_count": 204,
+      "coverage_partial": false,
+      "thread_count": 58
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W30.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W30.json
@@ -1516,6 +1516,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 12,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 15,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 2,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 2,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 3,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 39,
+      "comment_count": 161,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 19,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 3,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 8,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 9,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 6,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 0,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 4,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 11,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 13,
+      "comment_count": 152,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 10,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 8,
+      "comment_count": 89,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 26,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 7,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 5,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 5,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 10,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 6,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 10,
+      "comment_count": 183,
+      "coverage_partial": false,
+      "thread_count": 51
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 0,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 17,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 3,
+      "comment_count": 61,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 25,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 5,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 17,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 25
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W31.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W31.json
@@ -1243,6 +1243,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 15,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 10,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 18,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 9,
+      "comment_count": 86,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 6,
+      "comment_count": 110,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 15,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 20,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 15,
+      "comment_count": 76,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 14,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 12,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 3,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 3,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 33,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 20,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 3,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 3,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 5,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 9,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 6,
+      "comment_count": 57,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 5,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 15,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 3,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 1,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 2,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 11
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W32.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W32.json
@@ -1330,6 +1330,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 12,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 26,
+      "comment_count": 199,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 19,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 11,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 25,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 10,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 10,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 1,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 3,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 5,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 8,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 3,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 12,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 11,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 12,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 13,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 19,
+      "comment_count": 191,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 12,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 34,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 10,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 9,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 0,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 1,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 28,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 11,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 11,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 21,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 25
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W33.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W33.json
@@ -1281,6 +1281,296 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 18,
+      "comment_count": 109,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 25,
+      "comment_count": 108,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 10,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 9,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 2,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 9,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 8,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 4,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 3,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 3,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 15,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 21,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 13,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 23,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 14,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 11,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 22,
+      "comment_count": 141,
+      "coverage_partial": true,
+      "thread_count": 37
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 10,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 1,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 9,
+      "comment_count": 110,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 11,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 1,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 0,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 6
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W34.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W34.json
@@ -1405,6 +1405,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 24,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 15,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 4,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 5,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 6,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 4,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 10,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 15,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 6,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 12,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 13,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 7,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 17,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 16,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 11,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 20,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 13,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 12,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 17,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 3,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 12,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 19,
+      "comment_count": 170,
+      "coverage_partial": false,
+      "thread_count": 52
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 17,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 18,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 7,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 8,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 14,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 2,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 13,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 10,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 26
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W35.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W35.json
@@ -1332,6 +1332,314 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 9,
+      "comment_count": 78,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 7,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 10,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 12,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 6,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 4,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 6,
+      "comment_count": 61,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 10,
+      "comment_count": 149,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 7,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 4,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 14,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 6,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 11,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 8,
+      "comment_count": 97,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 15,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 31,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 11,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 14,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 14,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 8,
+      "comment_count": 81,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 17,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 20,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 10,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 4,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 9,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 7,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 11
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W36.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W36.json
@@ -1385,6 +1385,320 @@
       }
     }
   },
+  "by_author_comments": {
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 24,
+      "comment_count": 129,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 3,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 14,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 7,
+      "comment_count": 143,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 12,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 12,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 10,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 6,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 7,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 7,
+      "comment_count": 31,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 13,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 9,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 19,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 11,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 6,
+      "comment_count": 19,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 21,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 1,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 22,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 16,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 3,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 1,
+      "comment_count": 7,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 15,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 12,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 13,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 12,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 18
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W37.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W37.json
@@ -1312,6 +1312,308 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 10,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 10,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 6,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 22,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 2,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 15,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 2,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 9,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 16,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 7,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 5,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 7,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 1,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 10,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 3,
+      "comment_count": 156,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 29,
+      "comment_count": 141,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 6,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 15,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 25,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 6,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 5,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 6,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 3,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 10,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 2
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2023-W38.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W38.json
@@ -1223,6 +1223,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 9,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 0,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 4,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 9,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 10,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 8,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 9,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 4,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 7,
+      "comment_count": 104,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 14,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 6,
+      "comment_count": 80,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 11,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 14,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 7,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 6,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 3,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 10,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 10,
+      "comment_count": 79,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 36,
+      "comment_count": 245,
+      "coverage_partial": false,
+      "thread_count": 64
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 26,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 4,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 19
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2023-W39.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W39.json
@@ -1223,6 +1223,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 1,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 33,
+      "comment_count": 128,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 1,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 11,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 13,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 9,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 18,
+      "comment_count": 118,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 7,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 9,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 10,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 10,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 0,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 13,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 11,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 1,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 12,
+      "comment_count": 143,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 10,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 10,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 1,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 7,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 10,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 4,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 7,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 17,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 2,
+      "comment_count": 49,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 13,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 18,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 12,
+      "comment_count": 161,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 7,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 17,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 12,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 20,
+      "comment_count": 140,
+      "coverage_partial": false,
+      "thread_count": 33
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W40.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W40.json
@@ -1299,6 +1299,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 13,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 11,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 18,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 19,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 2,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 14,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 21,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 11,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 20,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 15,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 15,
+      "comment_count": 107,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 15,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 20,
+      "comment_count": 154,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 4,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 5,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 15,
+      "comment_count": 81,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 0,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 9,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 5,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 18,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 10,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2023-W41.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W41.json
@@ -1130,6 +1130,242 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 10,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 10,
+      "comment_count": 63,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 12,
+      "comment_count": 106,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 11,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 11,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 10,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 0,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 3,
+      "comment_count": 85,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 4,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 14,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 3,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 5,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 13,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 18,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 15,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 3,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2023-W42.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W42.json
@@ -1198,6 +1198,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 6,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 3,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 14,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 10,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 8,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 6,
+      "comment_count": 106,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 11,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 8,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 10,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 13,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 11,
+      "comment_count": 80,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 7,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 16,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 11,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 13,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 1,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 6,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 17,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 13,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 4,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 11,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 4,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W43.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W43.json
@@ -1201,6 +1201,296 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 10,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 8,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 16,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 14,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 6,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 19,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 2,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 9,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 15,
+      "comment_count": 127,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 9,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 6,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 16,
+      "comment_count": 108,
+      "coverage_partial": true,
+      "thread_count": 41
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 1,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 8,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 18,
+      "comment_count": 117,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 12,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 5,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 18,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 10,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 11,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 10,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 19,
+      "comment_count": 124,
+      "coverage_partial": false,
+      "thread_count": 31
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W44.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W44.json
@@ -1140,6 +1140,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 2,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 17,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 22,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 0,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 7,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 10,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 10,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 12,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 5,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 8,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 9,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 2,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 0,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 10,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 5,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 28,
+      "comment_count": 140,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 2,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 13,
+      "comment_count": 90,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 12,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 2,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 17
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W45.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W45.json
@@ -1238,6 +1238,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 8,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 18,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 13,
+      "comment_count": 108,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 15,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 2,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 10,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 17,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 7,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 27,
+      "comment_count": 188,
+      "coverage_partial": false,
+      "thread_count": 45
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 15,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 22,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 12,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 17,
+      "comment_count": 90,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 2,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 5,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 15,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 3,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 2,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 38,
+      "comment_count": 144,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 10,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 17,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 10,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2023-W46.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W46.json
@@ -1065,6 +1065,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 26,
+      "comment_count": 158,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 18,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 20,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 11,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 31,
+      "comment_count": 132,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 13,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 11,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 21,
+      "comment_count": 112,
+      "coverage_partial": true,
+      "thread_count": 46
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 8,
+      "comment_count": 82,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 5,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 18,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 6,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 12,
+      "comment_count": 193,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 14,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 1,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 3,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 9,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 0,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 6,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W47.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W47.json
@@ -992,6 +992,242 @@
       }
     }
   },
+  "by_author_comments": {
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 17,
+      "comment_count": 87,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 4,
+      "comment_count": 41,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 5,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 7,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 17,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 20,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 6,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 8,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 3,
+      "comment_count": 17,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 16,
+      "comment_count": 117,
+      "coverage_partial": true,
+      "thread_count": 36
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 12,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 6,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 4,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 7,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 26,
+      "comment_count": 101,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 11,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 7,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 12,
+      "comment_count": 89,
+      "coverage_partial": true,
+      "thread_count": 19
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W48.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W48.json
@@ -1109,6 +1109,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 13,
+      "comment_count": 62,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 12,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 14,
+      "comment_count": 117,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 5,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 16,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 13,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 6,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 0,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 2,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 6,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 10,
+      "comment_count": 84,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 18,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 13,
+      "comment_count": 59,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 0,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 16,
+      "comment_count": 89,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 5,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 4,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W49.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W49.json
@@ -1178,6 +1178,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 11,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 0,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 6,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 1,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 6,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 29,
+      "comment_count": 221,
+      "coverage_partial": false,
+      "thread_count": 61
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 5,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 4,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 8,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 8,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 28,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 5,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 63,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 33,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 11,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 15,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 0,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 3,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 22
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W50.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W50.json
@@ -1222,6 +1222,284 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 8,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 5,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 8,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 14,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 20,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 11,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 19,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 7,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 1,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 12,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 10,
+      "comment_count": 122,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 10,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 8,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 3,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 9,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 11,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 22,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 12,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 19,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 6,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 2,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W51.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W51.json
@@ -1053,6 +1053,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 22,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 5,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 14,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 6,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 15,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 19,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 10,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 7,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 5,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 1,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 5,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 0,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 11,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 13,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 10,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 8,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 10,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 8,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 0,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 16
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2023-W52.json
+++ b/docs/data/aggregates/weekly_rollups/2023-W52.json
@@ -544,6 +544,122 @@
       }
     }
   },
+  "by_author_comments": {
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 12,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 8,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 9,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 8,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 7,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 6,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 8,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 0,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 26,
+      "comment_count": 131,
+      "coverage_partial": true,
+      "thread_count": 35
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 20,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    }
+  },
   "by_repository": {
     "auth-service": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W01.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W01.json
@@ -1071,6 +1071,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 13,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 11,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 10,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 1,
+      "comment_count": 13,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 5,
+      "comment_count": 19,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 15,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 2,
+      "comment_count": 31,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 5,
+      "comment_count": 23,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 0,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 6,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 13,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 3,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 13,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 12,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 16,
+      "comment_count": 129,
+      "coverage_partial": true,
+      "thread_count": 37
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 10,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 23,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 12,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 13,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W02.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W02.json
@@ -1145,6 +1145,296 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 13,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 10,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 15,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 5,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 23,
+      "comment_count": 146,
+      "coverage_partial": false,
+      "thread_count": 44
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 8,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 6,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 16,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 34,
+      "comment_count": 170,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 6,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 6,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 1,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 4,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 4,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 6,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 23,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 8,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 10,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W03.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W03.json
@@ -1116,6 +1116,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 2,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 7,
+      "comment_count": 51,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 20,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 8,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 4,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 6,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 11,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 13,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 13,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 4,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 5,
+      "comment_count": 83,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 6,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 2,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 17,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 5,
+      "comment_count": 96,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 23,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 11,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 8,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 1,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 10,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 10,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 14,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W04.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W04.json
@@ -1177,6 +1177,254 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 28,
+      "comment_count": 121,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 14,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 13,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 5,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 7,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 1,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 6,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 5,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 6,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 22,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 3,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 3,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 19,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 7,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 1,
+      "comment_count": 69,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 5,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 22,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 16,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 14,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 8,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 13,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 10,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W05.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W05.json
@@ -1107,6 +1107,242 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 12,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 0,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 20,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 16,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 23,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 14,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 20,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 5,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 0,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 5,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 8,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 15,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 10,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 7,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 15,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 11,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 15,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 19,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 13,
+      "comment_count": 135,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 21,
+      "comment_count": 99,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 12,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 14,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 0,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 6
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W06.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W06.json
@@ -1236,6 +1236,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 20,
+      "comment_count": 101,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 1,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 3,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 16,
+      "comment_count": 98,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 3,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 9,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 9,
+      "comment_count": 49,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 7,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 16,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 8,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 24,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 13,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 4,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 19,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 16,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 9,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 10,
+      "comment_count": 110,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 12,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 20,
+      "comment_count": 155,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 8,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W07.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W07.json
@@ -1236,6 +1236,254 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 0,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 16,
+      "comment_count": 128,
+      "coverage_partial": false,
+      "thread_count": 45
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 22,
+      "comment_count": 132,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 12,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 6,
+      "comment_count": 61,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 9,
+      "comment_count": 161,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 12,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 6,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 6,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 22,
+      "comment_count": 189,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 11,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 3,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 8,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 9,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 10,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 10,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 27,
+      "comment_count": 104,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 24,
+      "comment_count": 173,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 1,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 10,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 29,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 25,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 5,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 13,
+      "comment_count": 151,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 10,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 16
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W08.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W08.json
@@ -1276,6 +1276,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 11,
+      "comment_count": 101,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 2,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 10,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 5,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 12,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 7,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 16,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 13,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 3,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 8,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 14,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 8,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 10,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 2,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 6,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 18,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 24,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 6,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 9,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 7,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 10,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 14,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 9,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 19,
+      "comment_count": 69,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 22,
+      "comment_count": 134,
+      "coverage_partial": true,
+      "thread_count": 36
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W09.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W09.json
@@ -1205,6 +1205,284 @@
       }
     }
   },
+  "by_author_comments": {
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 6,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 18,
+      "comment_count": 122,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 10,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 0,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 6,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 31,
+      "comment_count": 174,
+      "coverage_partial": false,
+      "thread_count": 45
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 9,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 17,
+      "comment_count": 85,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 4,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 21,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 10,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 3,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 12,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 25,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 6,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 17,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 4,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 9,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 5,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 16,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 3,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 17,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 9,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W10.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W10.json
@@ -1167,6 +1167,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 6,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 10,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 4,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 6,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 10,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 4,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 2,
+      "comment_count": 11,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 16,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 2,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 14,
+      "comment_count": 136,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 9,
+      "comment_count": 87,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 4,
+      "comment_count": 13,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 14,
+      "comment_count": 141,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 9,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 10,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 17,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 9,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 12,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 0,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 0,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 12
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W11.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W11.json
@@ -1405,6 +1405,320 @@
       }
     }
   },
+  "by_author_comments": {
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 10,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 13,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 16,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 6,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 14,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 2,
+      "comment_count": 53,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 17,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 19,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 6,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 14,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 15,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 11,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 11,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 5,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 17,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 14,
+      "comment_count": 132,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 7,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 7,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 9,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 0,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 1,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 15,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 4,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 12,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 2,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 12,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 2,
+      "comment_count": 29,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W12.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W12.json
@@ -1390,6 +1390,320 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 8,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 10,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 7,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 8,
+      "comment_count": 120,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 10,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 15,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 6,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 2,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 13,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 2,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 12,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 19,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 12,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 6,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 16,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 13,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 14,
+      "comment_count": 175,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 4,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 1,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 13,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 9,
+      "comment_count": 121,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 4,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 20,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 9,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 16,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 19,
+      "comment_count": 122,
+      "coverage_partial": true,
+      "thread_count": 40
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 12,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 15,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 1,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 5
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W13.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W13.json
@@ -1228,6 +1228,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 20,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 21,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 7,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 7,
+      "comment_count": 84,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 4,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 16,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 8,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 13,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 20,
+      "comment_count": 137,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 18,
+      "comment_count": 146,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 9,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 11,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 10,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 15,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 9,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 4,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 8,
+      "comment_count": 157,
+      "coverage_partial": true,
+      "thread_count": 41
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 9,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 17,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 36
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W14.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W14.json
@@ -1385,6 +1385,284 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 11,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 14,
+      "comment_count": 120,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 3,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 6,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 19,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 17,
+      "comment_count": 88,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 8,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 25,
+      "comment_count": 90,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 19,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 11,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 12,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 10,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 1,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 6,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 37,
+      "comment_count": 171,
+      "coverage_partial": false,
+      "thread_count": 52
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 15,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 2,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 16,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 13,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 17,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 14,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 19,
+      "comment_count": 151,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 8
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W15.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W15.json
@@ -1483,6 +1483,332 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 10,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 9,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 5,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 14,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 8,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 17,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 6,
+      "comment_count": 95,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 24,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 12,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 0,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 0,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 19,
+      "comment_count": 103,
+      "coverage_partial": true,
+      "thread_count": 39
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 14,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 8,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 23,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 17,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 8,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 20,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 2,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 12,
+      "comment_count": 133,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 25,
+      "comment_count": 192,
+      "coverage_partial": false,
+      "thread_count": 51
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 1,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 7,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 13,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 25,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 9,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 14,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 9,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 26,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 10,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W16.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W16.json
@@ -1444,6 +1444,344 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 8,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 16,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 12,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 20,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 23,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 23,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 7,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 11,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 9,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 5,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 2,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 12,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 2,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 3,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 28,
+      "comment_count": 137,
+      "coverage_partial": false,
+      "thread_count": 49
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 7,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 6,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 33,
+      "comment_count": 176,
+      "coverage_partial": false,
+      "thread_count": 51
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 6,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 11,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 11,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 10,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 2,
+      "comment_count": 11,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 10,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 9,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 6,
+      "comment_count": 153,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 24,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 11,
+      "comment_count": 108,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 8,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 15,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 6,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 4,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W17.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W17.json
@@ -1407,6 +1407,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 9,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 9,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 14,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 7,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 14,
+      "comment_count": 131,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 9,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 7,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 5,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 6,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 1,
+      "comment_count": 80,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 3,
+      "comment_count": 41,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 10,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 15,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 19,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 12,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 16,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 9,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 8,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 13,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 11,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 0,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 2,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 4,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 7,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 9,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 4,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 3,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 7,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 8,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 9,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 8,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W18.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W18.json
@@ -1437,6 +1437,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 11,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 28,
+      "comment_count": 253,
+      "coverage_partial": false,
+      "thread_count": 56
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 10,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 2,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 8,
+      "comment_count": 114,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 22,
+      "comment_count": 241,
+      "coverage_partial": false,
+      "thread_count": 59
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 16,
+      "comment_count": 57,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 12,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 8,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 11,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 11,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 13,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 12,
+      "comment_count": 144,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 17,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 10,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 11,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 4,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 27,
+      "comment_count": 171,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 18,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 12,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 0,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 13,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 11,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 13,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 0,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 5,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 2,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W19.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W19.json
@@ -1398,6 +1398,314 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 17,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 0,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 15,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 7,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 4,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 1,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 12,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 20,
+      "comment_count": 78,
+      "coverage_partial": true,
+      "thread_count": 39
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 13,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 19,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 13,
+      "comment_count": 143,
+      "coverage_partial": false,
+      "thread_count": 48
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 6,
+      "comment_count": 59,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 3,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 1,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 7,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 12,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 10,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 14,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 2,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 3,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 9,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 7,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 2,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 10,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 21
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W20.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W20.json
@@ -1439,6 +1439,338 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 16,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 16,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 14,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 3,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 6,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 16,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 6,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 19,
+      "comment_count": 137,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 13,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 9,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 23,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 21,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 10,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 18,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 13,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 11,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 5,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 31,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 3,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 5,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 3,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 17,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 11,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 10,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 9,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 6,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 11,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 4,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 7,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 4,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 7,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 13,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 16,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 16,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 21,
+      "comment_count": 118,
+      "coverage_partial": true,
+      "thread_count": 41
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 9,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W21.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W21.json
@@ -1583,6 +1583,362 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 6,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 4,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 16,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 12,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 12,
+      "comment_count": 57,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 9,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 3,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 5,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 10,
+      "comment_count": 139,
+      "coverage_partial": true,
+      "thread_count": 39
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 5,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 19,
+      "comment_count": 151,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 29,
+      "comment_count": 193,
+      "coverage_partial": false,
+      "thread_count": 52
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 0,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 0,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 9,
+      "comment_count": 140,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 1,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 15,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 9,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 5,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 14,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 0,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 13,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 17,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 13,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 4,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 1,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 4,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 17,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 11,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 1,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 9,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 12,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 11,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 9,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 3,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 21,
+      "comment_count": 77,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 7,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 21
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W22.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W22.json
@@ -1564,6 +1564,362 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 20,
+      "comment_count": 155,
+      "coverage_partial": true,
+      "thread_count": 53
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 10,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 13,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 10,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 10,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 15,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 16,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 11,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 3,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 11,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 19,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 6,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 1,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 3,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 11,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 21,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 18,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 6,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 6,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 5,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 2,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 23,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 1,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 11,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 17,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 17,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 21,
+      "comment_count": 102,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 8,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 21,
+      "comment_count": 80,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 19,
+      "comment_count": 169,
+      "coverage_partial": true,
+      "thread_count": 44
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 0,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 9,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 7,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 8,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 5,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 9,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 28,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 6,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W23.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W23.json
@@ -1587,6 +1587,386 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 12,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 0,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 13,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 20,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 17,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 9,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 7,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 11,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 16,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 8,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 13,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 10,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 10,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 12,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 12,
+      "comment_count": 104,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 9,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 13,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 8,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 9,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 18,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 6,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 6,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 8,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 4,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 11,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 19,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 11,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 13,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 6,
+      "comment_count": 41,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 7,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 8,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 20,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 2,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W24.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W24.json
@@ -1515,6 +1515,344 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 8,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 12,
+      "comment_count": 100,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 14,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 14,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 15,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 12,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 10,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 19,
+      "comment_count": 148,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 7,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 7,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 4,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 6,
+      "comment_count": 109,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 7,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 10,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 13,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 6,
+      "comment_count": 76,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 0,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 10,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 14,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 15,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 8,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 12,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 13,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 11,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 13,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 12,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 8,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 1,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 32,
+      "comment_count": 144,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 26,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 11,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 8,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 13,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 13,
+      "comment_count": 115,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 19,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 20,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 0,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 10,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W25.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W25.json
@@ -1603,6 +1603,368 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 13,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 13,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 10,
+      "comment_count": 89,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 2,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 14,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 15,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 15,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 12,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 7,
+      "comment_count": 69,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 5,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 12,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 0,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 17,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 11,
+      "comment_count": 68,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 7,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 11,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 0,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 14,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 7,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 14,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 27,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 7,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 8,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 11,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 1,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 8,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 3,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 10,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 15,
+      "comment_count": 170,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 7,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 15,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 3,
+      "comment_count": 47,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 6,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 8,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 7,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 6,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 14,
+      "comment_count": 178,
+      "coverage_partial": false,
+      "thread_count": 41
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W26.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W26.json
@@ -1539,6 +1539,356 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 3,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 16,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 2,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 16,
+      "comment_count": 102,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 29,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 16,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 27,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 14,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 10,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 7,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 10,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 17,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 16,
+      "comment_count": 114,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 23,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 3,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 12,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 19,
+      "comment_count": 110,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 17,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 8,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 11,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 16,
+      "comment_count": 144,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 17,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 21,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 13,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 13,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 6,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 18,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 4,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 1,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 13,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W27.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W27.json
@@ -1537,6 +1537,374 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 9,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 13,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 18,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 19,
+      "comment_count": 171,
+      "coverage_partial": false,
+      "thread_count": 52
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 15,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 14,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 11,
+      "comment_count": 80,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 6,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 13,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 5,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 22,
+      "comment_count": 189,
+      "coverage_partial": false,
+      "thread_count": 49
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 5,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 13,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 7,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 0,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 13,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 37,
+      "comment_count": 180,
+      "coverage_partial": true,
+      "thread_count": 53
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 4,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 16,
+      "comment_count": 135,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 10,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 8,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 9,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 15,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 10,
+      "comment_count": 114,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 11,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 9,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 9,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 16,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 4,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 14
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W28.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W28.json
@@ -1475,6 +1475,308 @@
       }
     }
   },
+  "by_author_comments": {
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 13,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 6,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 7,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 47,
+      "comment_count": 213,
+      "coverage_partial": true,
+      "thread_count": 69
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 7,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 30,
+      "comment_count": 163,
+      "coverage_partial": false,
+      "thread_count": 53
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 10,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 13,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 5,
+      "comment_count": 86,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 18,
+      "comment_count": 185,
+      "coverage_partial": true,
+      "thread_count": 49
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 6,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 14,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 8,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 16,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 5,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 13,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 13,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 17,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 3,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 11,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 10,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 6,
+      "comment_count": 63,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 8,
+      "comment_count": 115,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 4,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 21,
+      "comment_count": 137,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 4,
+      "comment_count": 71,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 17,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 8,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 16,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 14,
+      "comment_count": 86,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W29.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W29.json
@@ -1574,6 +1574,368 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 17,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 8,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 10,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 13,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 13,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 19,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 6,
+      "comment_count": 57,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 20,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 5,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 7,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 13,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 11,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 0,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 6,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 22,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 12,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 9,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 6,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 6,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 7,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 34,
+      "comment_count": 153,
+      "coverage_partial": false,
+      "thread_count": 55
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 17,
+      "comment_count": 118,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 0,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 1,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 6,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 11,
+      "comment_count": 150,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 9,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 15,
+      "comment_count": 137,
+      "coverage_partial": true,
+      "thread_count": 45
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 1,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 13,
+      "comment_count": 124,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 17,
+      "comment_count": 255,
+      "coverage_partial": false,
+      "thread_count": 69
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 27,
+      "comment_count": 157,
+      "coverage_partial": false,
+      "thread_count": 51
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W30.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W30.json
@@ -1441,6 +1441,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 1,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 6,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 6,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 18,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 9,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 12,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 10,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 28,
+      "comment_count": 140,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 0,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 17,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 1,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 14,
+      "comment_count": 167,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 2,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 6,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 8,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 10,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 19,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 12,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 5,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 22,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 17,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 13,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 15,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 0,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 14,
+      "comment_count": 149,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 13,
+      "comment_count": 107,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 6,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 7,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 2,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 6,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W31.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W31.json
@@ -1454,6 +1454,338 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 7,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 15,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 7,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 6,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 7,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 9,
+      "comment_count": 104,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 10,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 0,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 12,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 15,
+      "comment_count": 142,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 0,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 2,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 4,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 24,
+      "comment_count": 124,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 13,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 24,
+      "comment_count": 124,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 27,
+      "comment_count": 124,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 7,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 5,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 1,
+      "comment_count": 11,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 1,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 12,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 7,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 14,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 17,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 9,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 19,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 14,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 2,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 11,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W32.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W32.json
@@ -1552,6 +1552,368 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 9,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 11,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 10,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 12,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 9,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 17,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 20,
+      "comment_count": 120,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 10,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 8,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 16,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 30,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 6,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 26,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 10,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 8,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 23,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 6,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 12,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 11,
+      "comment_count": 150,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 6,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 9,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 4,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 3,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 13,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 6,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 4,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 9,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 11,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 9,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 15,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W33.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W33.json
@@ -1497,6 +1497,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 25,
+      "comment_count": 106,
+      "coverage_partial": true,
+      "thread_count": 36
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 12,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 11,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 6,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 1,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 6,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 12,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 12,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 11,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 14,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 7,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 7,
+      "comment_count": 29,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 35,
+      "comment_count": 143,
+      "coverage_partial": false,
+      "thread_count": 52
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 21,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 10,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 17,
+      "comment_count": 141,
+      "coverage_partial": true,
+      "thread_count": 40
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 17,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 2,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 21,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 25,
+      "comment_count": 165,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 7,
+      "comment_count": 120,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 8,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 7,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 6,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 1,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 10,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 1,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 1,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 32,
+      "comment_count": 116,
+      "coverage_partial": true,
+      "thread_count": 41
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 10,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 1,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 8,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W34.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W34.json
@@ -1488,6 +1488,314 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 5,
+      "comment_count": 63,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 6,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 5,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 6,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 19,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 18,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 21,
+      "comment_count": 176,
+      "coverage_partial": true,
+      "thread_count": 56
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 20,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 4,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 3,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 27,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 7,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 4,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 32,
+      "comment_count": 140,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 13,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 8,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 9,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 7,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 20,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 15,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 18,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 17,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 11,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 13,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 33,
+      "comment_count": 240,
+      "coverage_partial": false,
+      "thread_count": 56
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 2,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 12,
+      "comment_count": 49,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 10,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 13,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W35.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W35.json
@@ -1605,6 +1605,374 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 1,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 3,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 7,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 9,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 7,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 11,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 14,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 6,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 21,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 7,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 8,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 26,
+      "comment_count": 149,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 8,
+      "comment_count": 34,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 10,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 8,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 12,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 13,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 12,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 5,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 13,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 13,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 12,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 7,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 15,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 6,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 12,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 9,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 1,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 18,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 20,
+      "comment_count": 104,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 6,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 1,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 3,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 8,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W36.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W36.json
@@ -1403,6 +1403,314 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 23,
+      "comment_count": 194,
+      "coverage_partial": true,
+      "thread_count": 51
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 10,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 8,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 3,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 0,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 10,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 5,
+      "comment_count": 61,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 1,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 1,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 10,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 11,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 11,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 9,
+      "comment_count": 88,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 24,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 5,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 17,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 7,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 21,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 2,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 19,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 17,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 10,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 16,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 6,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W37.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W37.json
@@ -1427,6 +1427,326 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 8,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 17,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 9,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 16,
+      "comment_count": 93,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 12,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 3,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 1,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 8,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 17,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 10,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 4,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 7,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 5,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 24,
+      "comment_count": 141,
+      "coverage_partial": false,
+      "thread_count": 48
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 13,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 18,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 10,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 8,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 8,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 4,
+      "comment_count": 49,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 13,
+      "comment_count": 100,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 16,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 13,
+      "comment_count": 150,
+      "coverage_partial": true,
+      "thread_count": 37
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 7,
+      "comment_count": 103,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 6,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 12,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 5,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 15,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 7,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W38.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W38.json
@@ -1352,6 +1352,308 @@
       }
     }
   },
+  "by_author_comments": {
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 12,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 19,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 14,
+      "comment_count": 121,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 4,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 11,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 14,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 13,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 4,
+      "comment_count": 101,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 2,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 6,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 25,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 10,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 3,
+      "comment_count": 23,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 9,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 7,
+      "comment_count": 111,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 1,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 7,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 17,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 11,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 9,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 11,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 14,
+      "comment_count": 151,
+      "coverage_partial": true,
+      "thread_count": 41
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 18,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 4,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 21,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 6,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 4,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W39.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W39.json
@@ -1396,6 +1396,338 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 5,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 13,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 7,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 6,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 15,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 20,
+      "comment_count": 109,
+      "coverage_partial": true,
+      "thread_count": 37
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 5,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 4,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 9,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 16,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 6,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 11,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 17,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 5,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 7,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 12,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 9,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 20,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 15,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 12,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 15,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 7,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 7,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 8,
+      "comment_count": 84,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 8,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 7,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 9,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 4,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 13,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 13,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W40.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W40.json
@@ -1321,6 +1321,314 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 17,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 5,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 13,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 10,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 3,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 8,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 21,
+      "comment_count": 103,
+      "coverage_partial": true,
+      "thread_count": 42
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 21,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 8,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 10,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 14,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 8,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 14,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 15,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 19,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 13,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 16,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 25,
+      "comment_count": 104,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 16,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 18,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 2,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 11,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 8,
+      "comment_count": 62,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 9,
+      "comment_count": 122,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 1,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 13,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 11,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 4,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 19,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W41.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W41.json
@@ -1232,6 +1232,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 6,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 6,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 3,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 8,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 19,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 13,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 1,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 3,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 11,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 14,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 12,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 24,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 9,
+      "comment_count": 80,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 18,
+      "comment_count": 170,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 8,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 9,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 13,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 11,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 12,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 13,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 5,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 5,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 5,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 10,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 12,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 13,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 19
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W42.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W42.json
@@ -1187,6 +1187,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 16,
+      "comment_count": 150,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 5,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 4,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 7,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 24,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 16,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 19,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 13,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 11,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 7,
+      "comment_count": 105,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 3,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 18,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 3,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 6,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 11,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 7,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 7,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 6,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 16,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 14,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 5,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 6,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W43.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W43.json
@@ -1227,6 +1227,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 13,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 4,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 2,
+      "comment_count": 51,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 6,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 8,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 1,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 6,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 8,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 27,
+      "comment_count": 197,
+      "coverage_partial": false,
+      "thread_count": 56
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 25,
+      "comment_count": 122,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 10,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 1,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 2,
+      "comment_count": 77,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 16,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 11,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 14,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 6,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 14,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 2,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 14,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 20,
+      "comment_count": 95,
+      "coverage_partial": true,
+      "thread_count": 23
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W44.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W44.json
@@ -1189,6 +1189,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 8,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 9,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 22,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 11,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 10,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 23,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 21,
+      "comment_count": 200,
+      "coverage_partial": true,
+      "thread_count": 56
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 11,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 10,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 1,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 1,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 9,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 2,
+      "comment_count": 13,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 1,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 11,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 11,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 15,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W45.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W45.json
@@ -1178,6 +1178,272 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 0,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 8,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 13,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 13,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 6,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 5,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 9,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 11,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 10,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 8,
+      "comment_count": 100,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 17,
+      "comment_count": 149,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 7,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 17,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 15,
+      "comment_count": 114,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 9,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 7,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 0,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 17,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 10,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 3,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 7,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 5,
+      "comment_count": 120,
+      "coverage_partial": true,
+      "thread_count": 30
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W46.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W46.json
@@ -1340,6 +1340,296 @@
       }
     }
   },
+  "by_author_comments": {
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 20,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 3,
+      "comment_count": 109,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 18,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 13,
+      "comment_count": 80,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 6,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 8,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 1,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 13,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 18,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 8,
+      "comment_count": 165,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 4,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 15,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 2,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 5,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 3,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 11,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 5,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 8,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 14,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 4,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 24,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 6,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 13,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 5,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 11,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 16
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W47.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W47.json
@@ -1225,6 +1225,296 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 4,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 6,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 18,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 23,
+      "comment_count": 144,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 3,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 5,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 2,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 13,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 10,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 5,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 14,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 8,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 15,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 15,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 8,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 0,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 8,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 1,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 0,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 15,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 13,
+      "comment_count": 91,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 10,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 17,
+      "comment_count": 84,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 13,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 19,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 9,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 2,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 10,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 9,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 19
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2024-W48.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W48.json
@@ -1114,6 +1114,266 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 21,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 17,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 12,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 2,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 17,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 15,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 10,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 25,
+      "comment_count": 128,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 5,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 2,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 22,
+      "comment_count": 124,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 14,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 13,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 15,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 24,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 9,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 19,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 4,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 19,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 11,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 33,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W49.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W49.json
@@ -1145,6 +1145,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 8,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 22,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 16,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 19,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 11,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 16,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 8,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 7,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 16,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 3,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 14,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 10,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 15,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 1,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 14,
+      "comment_count": 156,
+      "coverage_partial": false,
+      "thread_count": 45
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 15,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 16,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 30,
+      "comment_count": 156,
+      "coverage_partial": true,
+      "thread_count": 49
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 12,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 7,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 3,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 11,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 24
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W50.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W50.json
@@ -1205,6 +1205,278 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 10,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 19,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 12,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 16,
+      "comment_count": 98,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 3,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 4,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 4,
+      "comment_count": 57,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 7,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 5,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 16,
+      "comment_count": 111,
+      "coverage_partial": true,
+      "thread_count": 36
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 5,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 8,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 12,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 24,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 15,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 11,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 13,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 1,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 18,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 1,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 10,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 7,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 10,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 13,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 20,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W51.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W51.json
@@ -1242,6 +1242,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 6,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 15,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 11,
+      "comment_count": 67,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 21,
+      "comment_count": 166,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 23,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 7,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 8,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 8,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 16,
+      "comment_count": 122,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 2,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 10,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 5,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 16,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 5,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 15,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 5,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 5,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 12,
+      "comment_count": 97,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 13,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 17,
+      "comment_count": 148,
+      "coverage_partial": true,
+      "thread_count": 30
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2024-W52.json
+++ b/docs/data/aggregates/weekly_rollups/2024-W52.json
@@ -633,6 +633,134 @@
       }
     }
   },
+  "by_author_comments": {
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 7,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 13,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 11,
+      "comment_count": 47,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 3,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 13,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 15,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 3,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 23,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 4,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 1,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 14,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 21
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W01.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W01.json
@@ -1210,6 +1210,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 11,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 5,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 21,
+      "comment_count": 154,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 18,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 11,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 9,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 9,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 11,
+      "comment_count": 142,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 10,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 10,
+      "comment_count": 108,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 14,
+      "comment_count": 171,
+      "coverage_partial": false,
+      "thread_count": 45
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 13,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 9,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 10,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 6,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 10,
+      "comment_count": 82,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 11,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 24,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 9,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 20,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 10,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 18,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 12,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 8,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W02.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W02.json
@@ -1294,6 +1294,296 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 11,
+      "comment_count": 160,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 10,
+      "comment_count": 76,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 22,
+      "comment_count": 124,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 5,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 10,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 10,
+      "comment_count": 79,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 0,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 3,
+      "comment_count": 83,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 1,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 6,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 22,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 8,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 1,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 12,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 5,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 11,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 12,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 2,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 15,
+      "comment_count": 110,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 9,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 12,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 44
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 8,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 19,
+      "comment_count": 162,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 15,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W03.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W03.json
@@ -1227,6 +1227,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 7,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 0,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 15,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 15,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 5,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 29,
+      "comment_count": 147,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 9,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 10,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 14,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 8,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 6,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 27,
+      "comment_count": 158,
+      "coverage_partial": false,
+      "thread_count": 45
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 3,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 7,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 6,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 20,
+      "comment_count": 86,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 3,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 12,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 17,
+      "comment_count": 155,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 7,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 15,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W04.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W04.json
@@ -1116,6 +1116,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 0,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 11,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 14,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 17,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 17,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 5,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 7,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 17,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 25,
+      "comment_count": 119,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 18,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 7,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 19,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 12,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 5,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 1,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 3,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 2,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 16,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 9,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 21,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 14,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 14,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 13,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 1,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 5,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 5,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 9,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 11,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W05.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W05.json
@@ -1309,6 +1309,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 14,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 8,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 7,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 6,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 3,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 13,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 9,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 20,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 13,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 16,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 18,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 7,
+      "comment_count": 107,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 8,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 9,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 11,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 0,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 16,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 16,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 2,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 18,
+      "comment_count": 59,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 5,
+      "comment_count": 17,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 14,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W06.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W06.json
@@ -1417,6 +1417,320 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 3,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 5,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 12,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 1,
+      "comment_count": 100,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 5,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 10,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 6,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 13,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 5,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 8,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 3,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 14,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 4,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 5,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 9,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 5,
+      "comment_count": 57,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 13,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 16,
+      "comment_count": 111,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 10,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 11,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 16,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 15,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 12,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 5,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 5,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 8,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 25,
+      "comment_count": 179,
+      "coverage_partial": true,
+      "thread_count": 42
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 20,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 9,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 9,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 15,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W07.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W07.json
@@ -1341,6 +1341,320 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 15,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 8,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 13,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 24,
+      "comment_count": 148,
+      "coverage_partial": true,
+      "thread_count": 42
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 13,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 8,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 12,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 17,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 16,
+      "comment_count": 142,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 5,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 4,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 16,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 2,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 0,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 4,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 24,
+      "comment_count": 231,
+      "coverage_partial": false,
+      "thread_count": 54
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 8,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 1,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 6,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 14,
+      "comment_count": 59,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 6,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 10,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 12,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 3,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 9,
+      "comment_count": 53,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 14,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 4,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W08.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W08.json
@@ -1310,6 +1310,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 2,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 26,
+      "comment_count": 190,
+      "coverage_partial": false,
+      "thread_count": 48
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 21,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 15,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 0,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 0,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 2,
+      "comment_count": 29,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 4,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 0,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 9,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 16,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 7,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 21,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 2,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 19,
+      "comment_count": 159,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 7,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 18,
+      "comment_count": 118,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 13,
+      "comment_count": 96,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 20,
+      "comment_count": 122,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 9,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 0,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 7,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 11,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W09.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W09.json
@@ -1408,6 +1408,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 18,
+      "comment_count": 199,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 4,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 11,
+      "comment_count": 176,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 12,
+      "comment_count": 47,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 15,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 16,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 5,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 16,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 12,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 9,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 16,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 13,
+      "comment_count": 106,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 5,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 13,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 7,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 1,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 9,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 4,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 10,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 16,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 18,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 27,
+      "comment_count": 130,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 5,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 2,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 17,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 15,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 6,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 16
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W10.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W10.json
@@ -1445,6 +1445,344 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 9,
+      "comment_count": 87,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 4,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 6,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 0,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 1,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 2,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 3,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 3,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 10,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 1,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 10,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 31,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 7,
+      "comment_count": 120,
+      "coverage_partial": true,
+      "thread_count": 36
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 3,
+      "comment_count": 118,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 3,
+      "comment_count": 79,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 0,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 29,
+      "comment_count": 128,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 8,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 2,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 18,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 0,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 2,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 8,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 18,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 0,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 2,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 7,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 9,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 4,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W11.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W11.json
@@ -1375,6 +1375,308 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 14,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 17,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 6,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 6,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 6,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 3,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 9,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 15,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 13,
+      "comment_count": 67,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 2,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 9,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 3,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 23,
+      "comment_count": 138,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 13,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 12,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 16,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 20,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 10,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 4,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 4,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 2,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 2,
+      "comment_count": 71,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 14,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 6,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 6,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 11,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 17,
+      "comment_count": 102,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 13,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 10,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 30,
+      "comment_count": 187,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 27,
+      "comment_count": 140,
+      "coverage_partial": true,
+      "thread_count": 35
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 11,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 16
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W12.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W12.json
@@ -1430,6 +1430,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 6,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 7,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 6,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 11,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 5,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 9,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 8,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 1,
+      "comment_count": 17,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 6,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 20,
+      "comment_count": 157,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 10,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 12,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 0,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 7,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 5,
+      "comment_count": 51,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 14,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 2,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 14,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 21,
+      "comment_count": 141,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 16,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 8,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 5,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 8,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 5,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 13,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 6,
+      "comment_count": 51,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 17,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 19,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 19,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 12,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 22,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 0,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 13,
+      "comment_count": 107,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 12,
+      "comment_count": 117,
+      "coverage_partial": true,
+      "thread_count": 35
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 2,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 7,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 19
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W13.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W13.json
@@ -1337,6 +1337,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 13,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 13,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 9,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 17,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 4,
+      "comment_count": 47,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 18,
+      "comment_count": 131,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 5,
+      "comment_count": 90,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 16,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 19,
+      "comment_count": 84,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 7,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 8,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 7,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 22,
+      "comment_count": 118,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 2,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 8,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 13,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 8,
+      "comment_count": 57,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 23,
+      "comment_count": 154,
+      "coverage_partial": false,
+      "thread_count": 44
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 17,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 10,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 10,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 18,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 15,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 2,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 11,
+      "comment_count": 71,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 29,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 8,
+      "comment_count": 122,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 16,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 9,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 9,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W14.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W14.json
@@ -1590,6 +1590,380 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 10,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 10,
+      "comment_count": 79,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 4,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 9,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 21,
+      "comment_count": 147,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 13,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 2,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 10,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 20,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 5,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 12,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 27,
+      "comment_count": 219,
+      "coverage_partial": true,
+      "thread_count": 51
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 2,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 11,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 14,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 5,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 4,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 6,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 1,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 23,
+      "comment_count": 102,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 9,
+      "comment_count": 76,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 6,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 11,
+      "comment_count": 76,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 14,
+      "comment_count": 87,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 9,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 4,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 21,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 9,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 11,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 5,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 11,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 7,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 8,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 1,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W15.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W15.json
@@ -1401,6 +1401,326 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 6,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 10,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 10,
+      "comment_count": 108,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 13,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 11,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 22,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 7,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 13,
+      "comment_count": 113,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 12,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 6,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 1,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 5,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 14,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 15,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 9,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 14,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 2,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 8,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 7,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 23,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 9,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 14,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 7,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 9,
+      "comment_count": 29,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 13,
+      "comment_count": 110,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 12,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 12,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 11,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 10,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 0,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 20,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 32
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W16.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W16.json
@@ -1271,6 +1271,278 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 11,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 20,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 20,
+      "comment_count": 157,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 11,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 16,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 15,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 19,
+      "comment_count": 189,
+      "coverage_partial": false,
+      "thread_count": 50
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 19,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 3,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 2,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 15,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 3,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 16,
+      "comment_count": 115,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 18,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 14,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 8,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 38,
+      "comment_count": 195,
+      "coverage_partial": false,
+      "thread_count": 57
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 35,
+      "comment_count": 168,
+      "coverage_partial": false,
+      "thread_count": 49
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 10,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 18,
+      "comment_count": 121,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 13,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 13,
+      "comment_count": 87,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 5,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 8,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 15,
+      "comment_count": 153,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 31,
+      "comment_count": 169,
+      "coverage_partial": false,
+      "thread_count": 53
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 10,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 3,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 8,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 9,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 2,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 7
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W17.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W17.json
@@ -1701,6 +1701,404 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 19,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 0,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 18,
+      "comment_count": 100,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 8,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 8,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 10,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 9,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 8,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 10,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 12,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 8,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 18,
+      "comment_count": 101,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 3,
+      "comment_count": 81,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 18,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 13,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 12,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 10,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 10,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 18,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 8,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 5,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 4,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 9,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 11,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 13,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 16,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 2,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 26,
+      "comment_count": 155,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 13,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 5,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 11,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 6,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 9,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 23,
+      "comment_count": 67,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 8,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 11,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 15,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 21,
+      "comment_count": 168,
+      "coverage_partial": true,
+      "thread_count": 40
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 14,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 18,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 32
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W18.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W18.json
@@ -1643,6 +1643,404 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 21,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 24,
+      "comment_count": 121,
+      "coverage_partial": true,
+      "thread_count": 36
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 35,
+      "comment_count": 168,
+      "coverage_partial": false,
+      "thread_count": 48
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 15,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 2,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 11,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 20,
+      "comment_count": 154,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 13,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 12,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 16,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 8,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 10,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 9,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 6,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 12,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 0,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 9,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 8,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 5,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 10,
+      "comment_count": 67,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 15,
+      "comment_count": 146,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 15,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 5,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 7,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 6,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 6,
+      "comment_count": 132,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 15,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 22,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 6,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 33,
+      "comment_count": 118,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 13,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 25
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W19.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W19.json
@@ -1351,6 +1351,332 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 18,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 27,
+      "comment_count": 107,
+      "coverage_partial": true,
+      "thread_count": 45
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 13,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 7,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 25,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 10,
+      "comment_count": 126,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 2,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 6,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 16,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 3,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 4,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 7,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 7,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 2,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 18,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 9,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 0,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 11,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 10,
+      "comment_count": 51,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 16,
+      "comment_count": 113,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 3,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 24,
+      "comment_count": 209,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 4,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 2,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 14,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 9,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 10,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 83,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 19,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 7,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 13,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 0,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 13,
+      "comment_count": 139,
+      "coverage_partial": true,
+      "thread_count": 46
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W20.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W20.json
@@ -1557,6 +1557,362 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 9,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 2,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 8,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 3,
+      "comment_count": 31,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 11,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 20,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 9,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 14,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 15,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 3,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 1,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 5,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 22,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 1,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 5,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 7,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 4,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 4,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 10,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 10,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 6,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 8,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 24,
+      "comment_count": 199,
+      "coverage_partial": false,
+      "thread_count": 53
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 11,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 18,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 21,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 5,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 20,
+      "comment_count": 168,
+      "coverage_partial": false,
+      "thread_count": 44
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 18,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 5,
+      "comment_count": 59,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 6,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 0,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 13,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 16,
+      "comment_count": 165,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 10,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 15,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 27
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W21.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W21.json
@@ -1583,6 +1583,368 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 26,
+      "comment_count": 162,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 6,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 4,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 23,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 6,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 15,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 17,
+      "comment_count": 169,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 18,
+      "comment_count": 151,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 9,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 9,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 3,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 1,
+      "comment_count": 37,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 21,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 25,
+      "comment_count": 143,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 7,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 9,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 8,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 13,
+      "comment_count": 57,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 17,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 0,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 18,
+      "comment_count": 148,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 18,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 7,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 21,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 0,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 18,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 6,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 5,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 23,
+      "comment_count": 182,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 13,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 20,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 7,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W22.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W22.json
@@ -1657,6 +1657,368 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 4,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 5,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 2,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 2,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 19,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 11,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 12,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 15,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 9,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 7,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 23,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 21,
+      "comment_count": 150,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 27,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 48
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 11,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 6,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 1,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 6,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 11,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 6,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 9,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 5,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 15,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 19,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 6,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 13,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 5,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 7,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 17,
+      "comment_count": 187,
+      "coverage_partial": true,
+      "thread_count": 40
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 16,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 7,
+      "comment_count": 122,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 15,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 7,
+      "comment_count": 153,
+      "coverage_partial": false,
+      "thread_count": 44
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 4,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 13,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 6,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 1,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 12,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 1,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W23.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W23.json
@@ -1648,6 +1648,392 @@
       }
     }
   },
+  "by_author_comments": {
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 1,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 27,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 4,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 11,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 6,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 15,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 1,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 0,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 4,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 20,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 9,
+      "comment_count": 37,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 5,
+      "comment_count": 53,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 26,
+      "comment_count": 105,
+      "coverage_partial": true,
+      "thread_count": 40
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 6,
+      "comment_count": 120,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 13,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 9,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 3,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 6,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 6,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 6,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 4,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 4,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 5,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 9,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 11,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 3,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 26,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 4,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 9,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 23,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 0,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 3,
+      "comment_count": 7,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 9,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 12,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 9,
+      "comment_count": 185,
+      "coverage_partial": true,
+      "thread_count": 40
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 33,
+      "comment_count": 182,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 34,
+      "comment_count": 157,
+      "coverage_partial": false,
+      "thread_count": 50
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 18,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 19
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W24.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W24.json
@@ -1675,6 +1675,386 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 10,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 4,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 14,
+      "comment_count": 74,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 8,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 6,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 19,
+      "comment_count": 89,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 11,
+      "comment_count": 140,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 16,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 2,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 9,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 16,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 2,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 7,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 14,
+      "comment_count": 103,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 5,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 19,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 22,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 17,
+      "comment_count": 155,
+      "coverage_partial": true,
+      "thread_count": 37
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 7,
+      "comment_count": 43,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 4,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 24,
+      "comment_count": 176,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 10,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 4,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 9,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 25,
+      "comment_count": 231,
+      "coverage_partial": false,
+      "thread_count": 59
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 3,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 7,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 8,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 8,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 16,
+      "comment_count": 76,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 18,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 9,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 7,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 6,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 4,
+      "comment_count": 143,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 5,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 1,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 0,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 0,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 7,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 19,
+      "comment_count": 118,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W25.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W25.json
@@ -1588,6 +1588,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 18,
+      "comment_count": 112,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 15,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 21,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 14,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 8,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 13,
+      "comment_count": 122,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 7,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 8,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 13,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 9,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 12,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 6,
+      "comment_count": 69,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 9,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 4,
+      "comment_count": 81,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 16,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 8,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 15,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 11,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 7,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 14,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 13,
+      "comment_count": 84,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 19,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 1,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 19,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 8,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 25,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 44
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 10,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 24,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 10,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W26.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W26.json
@@ -2816,10 +2816,10 @@
     }
   },
   "comments": {
-    "active_thread_count": 1595,
-    "comment_count": 11388,
+    "active_thread_count": 1653,
+    "comment_count": 11903,
     "coverage_partial": true,
-    "thread_count": 3259
+    "thread_count": 3395
   },
   "cycle_time_p50": 404.445,
   "cycle_time_p90": 2342.982,

--- a/docs/data/aggregates/weekly_rollups/2025-W26.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W26.json
@@ -1475,6 +1475,392 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 42,
+      "comment_count": 322,
+      "coverage_partial": false,
+      "thread_count": 78
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 12,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 17,
+      "comment_count": 91,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 12,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 11,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 26,
+      "comment_count": 147,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 34,
+      "comment_count": 204,
+      "coverage_partial": false,
+      "thread_count": 53
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 51,
+      "comment_count": 320,
+      "coverage_partial": false,
+      "thread_count": 88
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 26,
+      "comment_count": 134,
+      "coverage_partial": true,
+      "thread_count": 45
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 30,
+      "comment_count": 169,
+      "coverage_partial": true,
+      "thread_count": 59
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 21,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 47,
+      "comment_count": 264,
+      "coverage_partial": true,
+      "thread_count": 77
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 36,
+      "comment_count": 315,
+      "coverage_partial": true,
+      "thread_count": 79
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 1,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 28,
+      "comment_count": 272,
+      "coverage_partial": true,
+      "thread_count": 69
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 18,
+      "comment_count": 156,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 18,
+      "comment_count": 199,
+      "coverage_partial": false,
+      "thread_count": 63
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 31,
+      "comment_count": 200,
+      "coverage_partial": true,
+      "thread_count": 61
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 41,
+      "comment_count": 239,
+      "coverage_partial": true,
+      "thread_count": 64
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 25,
+      "comment_count": 314,
+      "coverage_partial": true,
+      "thread_count": 90
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 29,
+      "comment_count": 164,
+      "coverage_partial": false,
+      "thread_count": 54
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 39,
+      "comment_count": 236,
+      "coverage_partial": true,
+      "thread_count": 70
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 1,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 19,
+      "comment_count": 130,
+      "coverage_partial": true,
+      "thread_count": 39
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 18,
+      "comment_count": 206,
+      "coverage_partial": true,
+      "thread_count": 64
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 17,
+      "comment_count": 100,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 10,
+      "comment_count": 164,
+      "coverage_partial": true,
+      "thread_count": 46
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 33,
+      "comment_count": 175,
+      "coverage_partial": true,
+      "thread_count": 57
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 27,
+      "comment_count": 243,
+      "coverage_partial": true,
+      "thread_count": 78
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 25,
+      "comment_count": 176,
+      "coverage_partial": false,
+      "thread_count": 63
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 26,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 50
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 17,
+      "comment_count": 187,
+      "coverage_partial": true,
+      "thread_count": 54
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 31,
+      "comment_count": 254,
+      "coverage_partial": true,
+      "thread_count": 69
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 40,
+      "comment_count": 301,
+      "coverage_partial": true,
+      "thread_count": 65
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 24,
+      "comment_count": 229,
+      "coverage_partial": false,
+      "thread_count": 66
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 38,
+      "comment_count": 194,
+      "coverage_partial": false,
+      "thread_count": 61
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 32,
+      "comment_count": 165,
+      "coverage_partial": true,
+      "thread_count": 56
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 7,
+      "comment_count": 51,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 67,
+      "comment_count": 400,
+      "coverage_partial": false,
+      "thread_count": 109
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 23,
+      "comment_count": 231,
+      "coverage_partial": true,
+      "thread_count": 54
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 19,
+      "comment_count": 196,
+      "coverage_partial": true,
+      "thread_count": 56
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 16,
+      "comment_count": 122,
+      "coverage_partial": true,
+      "thread_count": 32
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 35,
+      "comment_count": 249,
+      "coverage_partial": false,
+      "thread_count": 73
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 6,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 32,
+      "comment_count": 239,
+      "coverage_partial": true,
+      "thread_count": 61
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 24,
+      "comment_count": 231,
+      "coverage_partial": false,
+      "thread_count": 65
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 11,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 33,
+      "comment_count": 186,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 17,
+      "comment_count": 191,
+      "coverage_partial": true,
+      "thread_count": 41
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 21,
+      "comment_count": 121,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 46,
+      "comment_count": 297,
+      "coverage_partial": true,
+      "thread_count": 79
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 21,
+      "comment_count": 111,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 29,
+      "comment_count": 242,
+      "coverage_partial": false,
+      "thread_count": 79
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 22,
+      "comment_count": 78,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 21,
+      "comment_count": 181,
+      "coverage_partial": true,
+      "thread_count": 45
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 19,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 29,
+      "comment_count": 228,
+      "coverage_partial": true,
+      "thread_count": 68
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 27,
+      "comment_count": 181,
+      "coverage_partial": true,
+      "thread_count": 57
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 15,
+      "comment_count": 90,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 16,
+      "comment_count": 89,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 27,
+      "comment_count": 211,
+      "coverage_partial": false,
+      "thread_count": 74
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 51,
+      "comment_count": 481,
+      "coverage_partial": true,
+      "thread_count": 126
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 34,
+      "comment_count": 208,
+      "coverage_partial": true,
+      "thread_count": 60
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 32,
+      "comment_count": 185,
+      "coverage_partial": true,
+      "thread_count": 68
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W27.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W27.json
@@ -1754,6 +1754,422 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 14,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 22,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 14,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 10,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 11,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 10,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 3,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 10,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 7,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 10,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 5,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 11,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 7,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 12,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 5,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 14,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 20,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 10,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 9,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 19,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 2,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 8,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 6,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 14,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 2,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 2,
+      "comment_count": 72,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 9,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 8,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 0,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 11,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 23,
+      "comment_count": 153,
+      "coverage_partial": false,
+      "thread_count": 54
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 18,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 15,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 14,
+      "comment_count": 107,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 32,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 9,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W28.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W28.json
@@ -1704,6 +1704,416 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 6,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 11,
+      "comment_count": 131,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 11,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 15,
+      "comment_count": 59,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 2,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 7,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 6,
+      "comment_count": 79,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 5,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 17,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 4,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 17,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 16,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 4,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 1,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 16,
+      "comment_count": 82,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 12,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 4,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 5,
+      "comment_count": 79,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 11,
+      "comment_count": 105,
+      "coverage_partial": true,
+      "thread_count": 35
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 6,
+      "comment_count": 63,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 2,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 17,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 15,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 11,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 10,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 7,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 12,
+      "comment_count": 128,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 17,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 1,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 11,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 22,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 7,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 7,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 6,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 5,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 16,
+      "comment_count": 132,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 2,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W29.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W29.json
@@ -1706,6 +1706,422 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 5,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 3,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 3,
+      "comment_count": 23,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 12,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 2,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 0,
+      "comment_count": 7,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 20,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 27,
+      "comment_count": 180,
+      "coverage_partial": false,
+      "thread_count": 45
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 9,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 4,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 23,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 16,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 0,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 2,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 21,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 16,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 17,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 6,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 33,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 48
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 3,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 7,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 6,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 9,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 4,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 13,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 14,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 14,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 22,
+      "comment_count": 159,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 18,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 5,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 7,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 7,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 7,
+      "comment_count": 81,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 5,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 6,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 12,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 23,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 7,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 17,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 9,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 45
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 4,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 9,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 7,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 10,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 33
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W30.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W30.json
@@ -1515,6 +1515,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 12,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 8,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 11,
+      "comment_count": 49,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 9,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 15,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 1,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 3,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 6,
+      "comment_count": 66,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 16,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 15,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 10,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 16,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "6034a2d9-3c8b-5547-b146-9f9638260536": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 11,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 12,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 1,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 14,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 2,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 8,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 7,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 13,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 6,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 2,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 3,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 10,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 14,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 23,
+      "comment_count": 234,
+      "coverage_partial": false,
+      "thread_count": 60
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 8,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 20,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 18,
+      "comment_count": 155,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 6,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 12,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 9,
+      "comment_count": 84,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 17,
+      "comment_count": 132,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 7,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 15,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 1,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 24,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 39
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W31.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W31.json
@@ -1586,6 +1586,386 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 10,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 2,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 11,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 9,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 10,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 10,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 7,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 24,
+      "comment_count": 129,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 15,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 20,
+      "comment_count": 162,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 8,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 19,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 15,
+      "comment_count": 95,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 0,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 3,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 10,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 3,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 9,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 13,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 9,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 3,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 10,
+      "comment_count": 98,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 3,
+      "comment_count": 79,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 8,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 19,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 24,
+      "comment_count": 121,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 7,
+      "comment_count": 63,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 8,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 20,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 8,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 21,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 4,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 26,
+      "comment_count": 165,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 8,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 10,
+      "comment_count": 89,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 21,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 3,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 2,
+      "comment_count": 34,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 8,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 30
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W32.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W32.json
@@ -1561,6 +1561,368 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 7,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 10,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 9,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 6,
+      "comment_count": 19,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 0,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 11,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 4,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 5,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 19,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 24,
+      "comment_count": 174,
+      "coverage_partial": false,
+      "thread_count": 48
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 1,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 1,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 26,
+      "comment_count": 136,
+      "coverage_partial": false,
+      "thread_count": 55
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 17,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 6,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 13,
+      "comment_count": 136,
+      "coverage_partial": true,
+      "thread_count": 34
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 14,
+      "comment_count": 140,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 2,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 7,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 13,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 5,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 11,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 7,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 12,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 6,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 14,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 19,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 11,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 3,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 3,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 10,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 7,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 5,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W33.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W33.json
@@ -1464,6 +1464,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 6,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 4,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 11,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 12,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 30,
+      "comment_count": 142,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 11,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 9,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 6,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 27,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 17,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 17,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 10,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 10,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 6,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 20,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 29,
+      "comment_count": 192,
+      "coverage_partial": false,
+      "thread_count": 42
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 8,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 12,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 20,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 26,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 17,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 9,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 9,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "b49c78dd-667a-5b08-b69e-3f70d3ad2f93": {
+      "active_thread_count": 0,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 5,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 16,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 8,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 4,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 11,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 12,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 21,
+      "comment_count": 130,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 7,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 1,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 11,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 3,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 4
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W34.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W34.json
@@ -1601,6 +1601,386 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 11,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 8,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 0,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 9,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 14,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 9,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 11,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 18,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 26,
+      "comment_count": 160,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 10,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 2,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 11,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 9,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 3,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 22,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 15,
+      "comment_count": 119,
+      "coverage_partial": true,
+      "thread_count": 31
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 7,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 2,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 2,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 1,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 20,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 20,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 13,
+      "comment_count": 170,
+      "coverage_partial": false,
+      "thread_count": 47
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 5,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a2d87e8b-8f92-57cf-95a3-f51fb3603d15": {
+      "active_thread_count": 4,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 8,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 16,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 13,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 3,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 2,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 1,
+      "comment_count": 68,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 7,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 9,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 28,
+      "comment_count": 94,
+      "coverage_partial": true,
+      "thread_count": 38
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 13,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 1,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 20,
+      "comment_count": 126,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W35.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W35.json
@@ -1506,6 +1506,344 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 10,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1aadf0a6-8404-5f19-88f6-f9a4b5bb87c1": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 7,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 34,
+      "comment_count": 129,
+      "coverage_partial": true,
+      "thread_count": 44
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 4,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 7,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 5,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 7,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 10,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 3,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 18,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 15,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 14,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 3,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 5,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 16,
+      "comment_count": 162,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 7,
+      "comment_count": 137,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 1,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 7,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 5,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 15,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 4,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 10,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 4,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 14,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 25,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 22,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 13,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 6,
+      "comment_count": 82,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 23,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 13,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 1,
+      "comment_count": 71,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 4,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 11,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 14,
+      "comment_count": 82,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 8,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 15,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 19,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 1,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W36.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W36.json
@@ -1624,6 +1624,386 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 7,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 10,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 1,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 8,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 10,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 15,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 5,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 3,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 11,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 4,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 14,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 0,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 13,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 4,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 12,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 6,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 3,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 4,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "70d0c1db-abc3-54ae-94ad-44ffb9f54fbd": {
+      "active_thread_count": 2,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 4,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 5,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 8,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 18,
+      "comment_count": 49,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 19,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 10,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 13,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 11,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 11,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 21,
+      "comment_count": 86,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 9,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 14,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 9,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 7,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 13,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 10,
+      "comment_count": 61,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 14,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 12,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 16,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 9,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "e249be08-ddb3-5d5c-8c82-1482b06f8038": {
+      "active_thread_count": 3,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 7,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 8,
+      "comment_count": 105,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 11,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 9,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W37.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W37.json
@@ -1434,6 +1434,350 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 9,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 5,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 3,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 7,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 20,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 6,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 8,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 3,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 6,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 15,
+      "comment_count": 159,
+      "coverage_partial": true,
+      "thread_count": 36
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 6,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 2,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 7,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 0,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 13,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 10,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 18,
+      "comment_count": 140,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 10,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 12,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "90194b13-4cbd-5a6d-b6f4-b380c8480276": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 4,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 8,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 10,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 14,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 10,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 8,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 11,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 18,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 17,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 21,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 10,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f5205e29-ac6d-5873-be14-1bee920f94b0": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 12,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 17,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 35
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W38.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W38.json
@@ -1314,6 +1314,296 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 5,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 14,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 6,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 11,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 14,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 14,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 3,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 4,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 19,
+      "comment_count": 172,
+      "coverage_partial": true,
+      "thread_count": 46
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 21,
+      "comment_count": 147,
+      "coverage_partial": false,
+      "thread_count": 43
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 12,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 6,
+      "comment_count": 50,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 5,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 20,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 3,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 36,
+      "comment_count": 211,
+      "coverage_partial": false,
+      "thread_count": 57
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 6,
+      "comment_count": 38,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 19,
+      "comment_count": 81,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 1,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 13,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 9,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 0,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 5,
+      "comment_count": 46,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 14,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 6,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 17,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 14,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 9,
+      "comment_count": 162,
+      "coverage_partial": false,
+      "thread_count": 44
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 7,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 19,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 8,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 15,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 4,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 11,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 11,
+      "comment_count": 135,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 11,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 6
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W39.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W39.json
@@ -1186,6 +1186,260 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 4,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 3,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 16,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 13,
+      "comment_count": 117,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 16,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 2,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 14,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 4,
+      "comment_count": 127,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 2,
+      "comment_count": 29,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 1,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 1,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 6,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 25,
+      "comment_count": 167,
+      "coverage_partial": false,
+      "thread_count": 60
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 8,
+      "comment_count": 132,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 1,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 28,
+      "comment_count": 128,
+      "coverage_partial": false,
+      "thread_count": 52
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 11,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 5,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 13,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 6,
+      "comment_count": 39,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 8,
+      "comment_count": 99,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 28,
+      "comment_count": 103,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 3,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 0,
+      "comment_count": 37,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 1,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 26,
+      "comment_count": 152,
+      "coverage_partial": true,
+      "thread_count": 41
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 27,
+      "comment_count": 131,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 21,
+      "comment_count": 88,
+      "coverage_partial": true,
+      "thread_count": 29
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 7,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 1,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 2,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 2,
+      "comment_count": 23,
+      "coverage_partial": false,
+      "thread_count": 7
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W40.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W40.json
@@ -1352,6 +1352,338 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 11,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 0,
+      "comment_count": 24,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 14,
+      "comment_count": 59,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 6,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 13,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 9,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "2a7ff968-31b8-5d98-8f0b-9cb3b386e3bb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2f87858d-1877-58bd-a052-afe1cfcb5b8d": {
+      "active_thread_count": 13,
+      "comment_count": 109,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 6,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 9,
+      "comment_count": 127,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 2,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 13,
+      "comment_count": 53,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 1,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 10,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 4,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "4783efe7-14c3-55f0-be33-cb55d332c9c2": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 5,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 0,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 10,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 1,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 3,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 3,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 9,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 15,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 0,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 3,
+      "comment_count": 33,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 7,
+      "comment_count": 55,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 23,
+      "comment_count": 142,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 12,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 14,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 5,
+      "comment_count": 78,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 13,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 4,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 5,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 16,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 15,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e5041028-ca35-5c7e-ace9-71fce373f9ba": {
+      "active_thread_count": 2,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e72fb699-499f-5db2-845b-bc719b31717e": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 6,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W41.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W41.json
@@ -1385,6 +1385,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "03400ec3-30a2-5538-930e-749eb3e819bf": {
+      "active_thread_count": 4,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 8,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 24,
+      "comment_count": 202,
+      "coverage_partial": true,
+      "thread_count": 52
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 17,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 14,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 1,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 12,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 9,
+      "comment_count": 67,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 15,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 13,
+      "comment_count": 90,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 22,
+      "comment_count": 108,
+      "coverage_partial": true,
+      "thread_count": 40
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 10,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 10,
+      "comment_count": 41,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 15,
+      "comment_count": 77,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 10,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 11,
+      "comment_count": 59,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 15,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 3,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 5,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 3,
+      "comment_count": 31,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 8,
+      "comment_count": 80,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "9c653f8c-83a0-58b2-9832-4bacbfb73690": {
+      "active_thread_count": 20,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 2,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 9,
+      "comment_count": 75,
+      "coverage_partial": true,
+      "thread_count": 23
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 24,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 7,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c9877d6d-c3c4-5aef-bb4d-2a8511e2fb77": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 13,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "d1db96a0-2eb3-5731-bd79-701dfce367ed": {
+      "active_thread_count": 4,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 3,
+      "comment_count": 90,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 3,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 1,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W42.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W42.json
@@ -1541,6 +1541,344 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 5,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 5,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 7,
+      "comment_count": 73,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 20,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 13,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 15,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 6,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 2,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 8,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "3e5c2481-0c41-538c-b31f-bb5f8e10fc7c": {
+      "active_thread_count": 23,
+      "comment_count": 170,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 6,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 10,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 18,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 11,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 1,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 16,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 7,
+      "comment_count": 51,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 23,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 2,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 4,
+      "comment_count": 106,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 2,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 4,
+      "comment_count": 79,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 15,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 3,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 18,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 7,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 3,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 5,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 10,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 5,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 2,
+      "comment_count": 34,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 17,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 12,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 12,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "e1ed9361-dd1e-54e5-8795-0b68baf8512f": {
+      "active_thread_count": 4,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "e66599fd-1084-5ced-8b69-3aae3897238a": {
+      "active_thread_count": 27,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 6,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "f11cbecb-16bd-5696-a7a6-0078d1559742": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 20,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "fa599eb4-03b8-5d2d-aeee-5cfc436e496d": {
+      "active_thread_count": 3,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "fea4a98a-8269-59fa-96bb-3b7fad5cd3f1": {
+      "active_thread_count": 4,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 11
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W43.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W43.json
@@ -1385,6 +1385,344 @@
       }
     }
   },
+  "by_author_comments": {
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 0,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 22,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 1,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 12,
+      "comment_count": 93,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 0,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 13,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "530d9e42-833f-51c7-8daa-03395d8f573c": {
+      "active_thread_count": 13,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 0,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 2,
+      "comment_count": 107,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 11,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 16,
+      "comment_count": 84,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 1,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 23,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 38
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 0,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 4,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 2,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 12,
+      "comment_count": 58,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 8,
+      "comment_count": 68,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 14,
+      "comment_count": 121,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 7,
+      "comment_count": 61,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 2,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 10,
+      "comment_count": 47,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 3,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 15,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 7,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 9,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 6,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 15,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "d448bc60-8fe8-5fde-9da8-eeb195c80b72": {
+      "active_thread_count": 9,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 7,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 0,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 15,
+      "comment_count": 77,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 22,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 9,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W44.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W44.json
@@ -1232,6 +1232,290 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 18,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 12,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 10,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 22,
+      "comment_count": 101,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 13,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 29,
+      "comment_count": 130,
+      "coverage_partial": false,
+      "thread_count": 36
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 9,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 9,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 10,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 13,
+      "comment_count": 54,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 5,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 17,
+      "comment_count": 92,
+      "coverage_partial": true,
+      "thread_count": 26
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 1,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 2,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 11,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 28,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 30
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 16,
+      "comment_count": 95,
+      "coverage_partial": true,
+      "thread_count": 33
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "89b7bbb3-2f4c-5de8-b4cd-335a04f55adb": {
+      "active_thread_count": 20,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 2,
+      "comment_count": 57,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 4,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9dd16093-4cd4-5588-95a4-024ef402adf1": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 0,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 11,
+      "comment_count": 132,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 5,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 10,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 5,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 2,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 10,
+      "comment_count": 102,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 7,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 12,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 2,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 19,
+      "comment_count": 112,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 7,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 8,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 5,
+      "comment_count": 12,
+      "coverage_partial": true,
+      "thread_count": 6
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W45.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W45.json
@@ -1265,6 +1265,296 @@
       }
     }
   },
+  "by_author_comments": {
+    "0139879c-ac5b-5d79-8a7b-499784002eb8": {
+      "active_thread_count": 5,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 6,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 9,
+      "comment_count": 32,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 4,
+      "comment_count": 22,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 1,
+      "comment_count": 16,
+      "coverage_partial": true,
+      "thread_count": 4
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 8,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 8,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 24,
+      "comment_count": 116,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 5,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 3,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 10,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 10,
+      "comment_count": 59,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "5c990c39-5a5a-5c67-b190-ce41431b0e0e": {
+      "active_thread_count": 4,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 14,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 15,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 3,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 0,
+      "comment_count": 57,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 1,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "7857d219-29d0-5f5e-a9bf-6fce154b062c": {
+      "active_thread_count": 0,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 11,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 4,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 3,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 7,
+      "comment_count": 108,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 2,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 4,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a2bcc6dc-41a3-50d2-86cf-8dcb98701597": {
+      "active_thread_count": 8,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 6,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 13,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 18,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 17,
+      "comment_count": 174,
+      "coverage_partial": false,
+      "thread_count": 46
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 5,
+      "comment_count": 53,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 10,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 0,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 3,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "cfe9685a-dc3e-5407-b9f6-08be45ca6529": {
+      "active_thread_count": 11,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 3,
+      "comment_count": 11,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 5,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 14,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 6,
+      "comment_count": 91,
+      "coverage_partial": false,
+      "thread_count": 20
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W46.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W46.json
@@ -1290,6 +1290,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 7,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "06575f71-2e05-5966-8d9f-db7328edcd43": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 3,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 4,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "20c3cd5f-fd32-591a-91fe-8fb395a703cc": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 14,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "2b44dd0c-c10e-562c-88e1-f34149fa431d": {
+      "active_thread_count": 4,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 1,
+      "comment_count": 7,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 9,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 1,
+      "comment_count": 21,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 2,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "429ef4f5-6373-525c-82df-27c55e1cd9d9": {
+      "active_thread_count": 11,
+      "comment_count": 92,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 2,
+      "comment_count": 99,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 3,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 2,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 8,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 7,
+      "comment_count": 103,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 3,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 13,
+      "comment_count": 84,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 6,
+      "comment_count": 37,
+      "coverage_partial": true,
+      "thread_count": 10
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 6,
+      "comment_count": 48,
+      "coverage_partial": true,
+      "thread_count": 16
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 4,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 18,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 5,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 14,
+      "comment_count": 75,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 10,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 0,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a079455f-a8ff-5c3e-ab28-d33a1da4b532": {
+      "active_thread_count": 12,
+      "comment_count": 49,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 9,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 24,
+      "comment_count": 149,
+      "coverage_partial": false,
+      "thread_count": 41
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 12,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 18,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 1,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 9,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 10,
+      "comment_count": 66,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "c05ea2fd-75f3-58c3-a3f5-97af92f23e8b": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 15,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 6,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 4,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 6,
+      "comment_count": 114,
+      "coverage_partial": false,
+      "thread_count": 26
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "e8985549-5280-5da4-9c6f-6c70b09821dc": {
+      "active_thread_count": 0,
+      "comment_count": 7,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 4,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f53c8daa-8a1c-5b4a-83ed-57fc8d270479": {
+      "active_thread_count": 13,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 15
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W47.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W47.json
@@ -1261,6 +1261,278 @@
       }
     }
   },
+  "by_author_comments": {
+    "08cf57e7-c6eb-568f-a9ef-8baa194946b6": {
+      "active_thread_count": 21,
+      "comment_count": 88,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 1,
+      "comment_count": 13,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 6,
+      "comment_count": 22,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 12,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "3d8e7b17-0b01-544c-bc57-b9e524a363a5": {
+      "active_thread_count": 18,
+      "comment_count": 67,
+      "coverage_partial": true,
+      "thread_count": 27
+    },
+    "40d81568-152f-54d0-98c8-ef321164926e": {
+      "active_thread_count": 15,
+      "comment_count": 96,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 12,
+      "comment_count": 64,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "5690cecf-177b-5c80-b64b-3fbce2c5f7a5": {
+      "active_thread_count": 12,
+      "comment_count": 109,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 1,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 9,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "5e8051b8-312f-5897-b10a-7137ec37d442": {
+      "active_thread_count": 1,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6169694a-d7cf-57cb-a94a-15b2f02e99cc": {
+      "active_thread_count": 9,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "639dc735-977c-5375-9ad9-61de9de9b186": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 11,
+      "comment_count": 82,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 3,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "677bb7bd-0214-5e76-ae56-bbda25b1e871": {
+      "active_thread_count": 5,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 4,
+      "comment_count": 70,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 22,
+      "comment_count": 133,
+      "coverage_partial": true,
+      "thread_count": 30
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 8,
+      "comment_count": 95,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "91ae6e14-cfd3-5c68-81ce-cd71961a30d4": {
+      "active_thread_count": 21,
+      "comment_count": 134,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "93f4b724-5be5-56fb-93b7-f5aae249ab52": {
+      "active_thread_count": 23,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "a778cba4-5127-5c45-85de-1da27ad6b478": {
+      "active_thread_count": 6,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 1,
+      "comment_count": 9,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "b5bbf539-5403-5bdb-b3ac-48bae2e0f805": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 0,
+      "comment_count": 14,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 9,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 6,
+      "comment_count": 54,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 9,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "da14f23a-2c9e-50f9-a43f-52ff358506a7": {
+      "active_thread_count": 11,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 13,
+      "comment_count": 152,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 14,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 8,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f1897bc8-d2c0-56fc-90dd-0a0ae8e6d59c": {
+      "active_thread_count": 7,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "f1b2196c-ebcc-5f68-9297-4e069b0a5f7f": {
+      "active_thread_count": 15,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 31
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "fa3bbf9d-fc6d-5b10-b54d-37fc21741913": {
+      "active_thread_count": 15,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "fde7a229-7aa3-5d95-bc33-fdfa7b802aa5": {
+      "active_thread_count": 4,
+      "comment_count": 46,
+      "coverage_partial": false,
+      "thread_count": 11
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W48.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W48.json
@@ -1161,6 +1161,296 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 14,
+      "comment_count": 98,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "04080230-eb2a-5a89-80a9-921bd67a5f12": {
+      "active_thread_count": 14,
+      "comment_count": 64,
+      "coverage_partial": true,
+      "thread_count": 20
+    },
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "1f512ed5-c075-547f-b192-d85f6eab15e4": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "28dafc05-3b3a-5355-a7b0-f93b3539979b": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "2a03e81e-b520-533a-bc0a-3a20ba263993": {
+      "active_thread_count": 6,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 3,
+      "comment_count": 19,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "3c2c389a-f6c8-5a9e-a63c-a024efc0cae0": {
+      "active_thread_count": 2,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 7,
+      "comment_count": 73,
+      "coverage_partial": true,
+      "thread_count": 17
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 7,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 16,
+      "comment_count": 90,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "46ac88e2-4abc-5661-ab77-f98efc3fd1d7": {
+      "active_thread_count": 8,
+      "comment_count": 110,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 4,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "527ae27c-497f-5a3f-8373-6c58b732fa08": {
+      "active_thread_count": 10,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "5a237dc9-ee8c-5764-aab4-4a8c520366fe": {
+      "active_thread_count": 17,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 4,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 4,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "7c31d024-0e3b-571e-815a-917ba333ba62": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "81fd281e-1585-58ab-ba51-80b5890145af": {
+      "active_thread_count": 12,
+      "comment_count": 100,
+      "coverage_partial": true,
+      "thread_count": 28
+    },
+    "96515d60-2f47-57fd-9caf-ab557b4a4267": {
+      "active_thread_count": 17,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "9ac1c4ec-36b0-58da-99f4-5832c021d3bb": {
+      "active_thread_count": 8,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 2,
+      "comment_count": 58,
+      "coverage_partial": true,
+      "thread_count": 18
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 5,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 12,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 5,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 0,
+      "comment_count": 39,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "b7b6ebbc-1829-5d25-8ccb-08fa6839cd2a": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 4,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "c2f4aa88-a439-52b4-acab-aec101374d25": {
+      "active_thread_count": 5,
+      "comment_count": 29,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "c85a8665-b462-5165-98fe-10ee9e61f539": {
+      "active_thread_count": 6,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "c93de2d5-2252-58e3-9fca-48b7108631e0": {
+      "active_thread_count": 28,
+      "comment_count": 183,
+      "coverage_partial": false,
+      "thread_count": 39
+    },
+    "ca1fbba8-960c-5feb-994a-5ff0d85b6064": {
+      "active_thread_count": 5,
+      "comment_count": 42,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 16,
+      "comment_count": 156,
+      "coverage_partial": false,
+      "thread_count": 33
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "ce701784-66e1-5265-bb39-3bafacb0d515": {
+      "active_thread_count": 9,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 8,
+      "comment_count": 59,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 10,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 20
+    },
+    "d848df3b-5df7-5f9d-89dc-a735fefa3447": {
+      "active_thread_count": 10,
+      "comment_count": 68,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "da2833a3-7f2f-5de9-9d38-7a36c7e0c2dc": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 20,
+      "comment_count": 99,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 6,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "dddf98ff-15e4-589c-a533-e853864dd614": {
+      "active_thread_count": 2,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 20,
+      "comment_count": 139,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W49.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W49.json
@@ -1389,6 +1389,338 @@
       }
     }
   },
+  "by_author_comments": {
+    "06b47a0c-bb14-5611-911d-a35367b4a343": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "0d020a1d-c429-5645-8677-5486ba08f044": {
+      "active_thread_count": 0,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "192a25de-2d1b-5e10-a0eb-dcc2b5e7ac1e": {
+      "active_thread_count": 8,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "1eeff2f2-5d8c-566b-ae72-61ccfba07ea7": {
+      "active_thread_count": 6,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 1,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 4,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "321f42a1-e6c8-5a9f-a514-989fefce50a2": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 3,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "382a1fe7-038d-5b3b-9c87-8a65d0376b8b": {
+      "active_thread_count": 3,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 8,
+      "comment_count": 52,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 7,
+      "comment_count": 67,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "4237b7e6-65bf-5f6f-831e-efba9e5e326b": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "4507291f-28b5-5f92-b624-4262b17e2c4e": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 9,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "4eadb007-7f46-56b1-8740-4a0af48b25d9": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 12,
+      "comment_count": 122,
+      "coverage_partial": false,
+      "thread_count": 32
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 0,
+      "comment_count": 17,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "6138fda9-22d1-528f-ae49-9dbe817ea747": {
+      "active_thread_count": 11,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 17,
+      "comment_count": 68,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "64546a0f-3835-5db3-9a4a-64dbf4e824d9": {
+      "active_thread_count": 1,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "655c7e03-2cc4-5976-84fb-c22130b784b3": {
+      "active_thread_count": 10,
+      "comment_count": 65,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 5,
+      "comment_count": 60,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "702b8ab3-7cb6-5f42-a622-872ccb101552": {
+      "active_thread_count": 29,
+      "comment_count": 154,
+      "coverage_partial": false,
+      "thread_count": 54
+    },
+    "7a2ba1f3-9e8b-5fbd-beaf-1f115c6dd2e3": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 20,
+      "comment_count": 133,
+      "coverage_partial": false,
+      "thread_count": 44
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 1,
+      "comment_count": 7,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "7eae5e76-3be3-5341-8e00-3e3c8b208202": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": true,
+      "thread_count": 5
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 0,
+      "comment_count": 9,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "85bdd61e-de82-500a-b3bd-2a71d1c06a8a": {
+      "active_thread_count": 0,
+      "comment_count": 1,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 6,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "938fe6da-bd5f-56d2-9c06-9b4fb1139ed3": {
+      "active_thread_count": 8,
+      "comment_count": 42,
+      "coverage_partial": true,
+      "thread_count": 21
+    },
+    "a87e4ad3-5fe4-5e75-951d-1abd77ebf161": {
+      "active_thread_count": 0,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "aa526dc1-3820-5712-8e50-ddac8478705f": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "b068b72e-177c-57d1-a77e-d84ada9e0990": {
+      "active_thread_count": 6,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 1,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "bc38140d-a62f-5b00-829c-7e251ddd9ef9": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "c00ae966-ee3c-535a-8ee6-672cd76da36c": {
+      "active_thread_count": 2,
+      "comment_count": 30,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "c14ebd6a-33d7-5119-84a8-fbf6fa8114b5": {
+      "active_thread_count": 10,
+      "comment_count": 88,
+      "coverage_partial": true,
+      "thread_count": 19
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 3,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "cbbe09b8-1513-5614-bd03-554f8a7718ff": {
+      "active_thread_count": 3,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": true,
+      "thread_count": 3
+    },
+    "cbef9c82-665d-56bf-a0ff-b94a0f0eb1b3": {
+      "active_thread_count": 10,
+      "comment_count": 56,
+      "coverage_partial": true,
+      "thread_count": 14
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 3,
+      "comment_count": 15,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 9,
+      "comment_count": 80,
+      "coverage_partial": true,
+      "thread_count": 22
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "dde0af13-4241-559b-9791-6efd249a207e": {
+      "active_thread_count": 1,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 13,
+      "comment_count": 52,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 2
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 2,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "f04e5f18-a655-5fb2-9899-cfb66dfbdd40": {
+      "active_thread_count": 16,
+      "comment_count": 137,
+      "coverage_partial": false,
+      "thread_count": 37
+    },
+    "fae290f1-a24a-56db-8d42-01b4acdd6cb9": {
+      "active_thread_count": 10,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 14
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W50.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W50.json
@@ -1259,6 +1259,302 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 11,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "0b249c6f-ede6-5846-b400-d4e2ab3fdc92": {
+      "active_thread_count": 10,
+      "comment_count": 34,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "12da521a-b144-5479-b2cc-f32c01d31acd": {
+      "active_thread_count": 1,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 18,
+      "comment_count": 92,
+      "coverage_partial": true,
+      "thread_count": 24
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 10,
+      "comment_count": 41,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "1fbcf577-0afe-5393-8090-5fd25137a8e8": {
+      "active_thread_count": 7,
+      "comment_count": 158,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 20,
+      "comment_count": 100,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 1,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "2daa926c-4827-599c-800c-78ceba1e2558": {
+      "active_thread_count": 2,
+      "comment_count": 62,
+      "coverage_partial": true,
+      "thread_count": 15
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 0,
+      "comment_count": 3,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "3281ab9d-1db0-551b-9810-33c4a8d872c4": {
+      "active_thread_count": 1,
+      "comment_count": 13,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "36f40327-12d8-5b26-a15f-313debe03843": {
+      "active_thread_count": 21,
+      "comment_count": 94,
+      "coverage_partial": false,
+      "thread_count": 25
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 16,
+      "comment_count": 113,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "3d8f75f7-ac9c-5402-929a-a63bce3a8897": {
+      "active_thread_count": 19,
+      "comment_count": 87,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "3f9c13e9-a095-528f-8162-06d3ecbb33d9": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 3,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "45454a1f-599b-5b19-81c8-c01c423442c3": {
+      "active_thread_count": 4,
+      "comment_count": 40,
+      "coverage_partial": true,
+      "thread_count": 8
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "513b4803-0e3a-5217-b377-5bd8ed10011f": {
+      "active_thread_count": 7,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "53e3621f-9b19-5bbc-a9e7-eb316343f98e": {
+      "active_thread_count": 5,
+      "comment_count": 35,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "577689a9-035b-5053-9d85-eb8c695edda5": {
+      "active_thread_count": 3,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 2,
+      "comment_count": 8,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 7,
+      "comment_count": 120,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "5e64877f-9bf3-5333-98a9-b4e2476d5273": {
+      "active_thread_count": 6,
+      "comment_count": 45,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 16,
+      "comment_count": 86,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "65d44a2c-47b6-58bb-95e3-9452d553c007": {
+      "active_thread_count": 5,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "698ff602-383e-5e11-b00c-6a74b22f2238": {
+      "active_thread_count": 8,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 5,
+      "comment_count": 97,
+      "coverage_partial": false,
+      "thread_count": 35
+    },
+    "79bf5913-b79e-536d-b3fa-c7bc950a244b": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7efc5962-2947-5546-9c25-cd2a3c1bcf51": {
+      "active_thread_count": 6,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "84434e77-3995-5517-aa30-e9724a4307ed": {
+      "active_thread_count": 7,
+      "comment_count": 44,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "864bbd27-2179-5171-a2fb-b9cb7d3f88db": {
+      "active_thread_count": 5,
+      "comment_count": 32,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "8673d9b1-1769-5602-97ed-135c806c2b4e": {
+      "active_thread_count": 7,
+      "comment_count": 43,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "8a5b2406-9f57-5e4a-bea2-a06ec7602c34": {
+      "active_thread_count": 1,
+      "comment_count": 20,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9434ad44-21e0-5d3c-a09c-3c33640cb086": {
+      "active_thread_count": 0,
+      "comment_count": 40,
+      "coverage_partial": false,
+      "thread_count": 8
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 4,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "a791accb-541c-5010-9202-d3d286437286": {
+      "active_thread_count": 5,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "a7aaa70f-ed59-5ab8-bd5c-d3bf956e7c6b": {
+      "active_thread_count": 10,
+      "comment_count": 74,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "b1238244-1dff-5232-aae6-73ad452a75a0": {
+      "active_thread_count": 3,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c52a8434-8e4b-51ae-89db-010dc937ade2": {
+      "active_thread_count": 19,
+      "comment_count": 104,
+      "coverage_partial": false,
+      "thread_count": 23
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 20,
+      "comment_count": 83,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "cdc00a5c-993a-56ab-aa8a-9739fbb4d3a3": {
+      "active_thread_count": 1,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 6
+    },
+    "ce04fbd4-c08b-55f3-9585-5a76c04dc485": {
+      "active_thread_count": 11,
+      "comment_count": 62,
+      "coverage_partial": false,
+      "thread_count": 16
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 5,
+      "comment_count": 44,
+      "coverage_partial": true,
+      "thread_count": 11
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 1,
+      "comment_count": 25,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 2,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "e7df4671-04e7-5ad1-8d32-4e1923c91065": {
+      "active_thread_count": 2,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 4,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 14
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 2,

--- a/docs/data/aggregates/weekly_rollups/2025-W51.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W51.json
@@ -1198,6 +1198,278 @@
       }
     }
   },
+  "by_author_comments": {
+    "04c36b2c-5096-58df-b775-0672dd0ac715": {
+      "active_thread_count": 15,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "11126187-6289-5bd8-a60b-c358e2ce21e4": {
+      "active_thread_count": 6,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "1c626ab4-1226-53f4-9eba-2f2f2cd78466": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "1d6fcb02-a878-50f0-9221-ca058b41701f": {
+      "active_thread_count": 5,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "1e6a1278-fa30-5862-ae60-0bd2208dbb3d": {
+      "active_thread_count": 17,
+      "comment_count": 157,
+      "coverage_partial": false,
+      "thread_count": 34
+    },
+    "226d1176-ffc5-542e-9f0d-8e5dd565f48c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "27033abe-8d6c-5612-88b9-296ea8b603be": {
+      "active_thread_count": 4,
+      "comment_count": 123,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "30598a16-77c5-5b20-b803-819d14be3441": {
+      "active_thread_count": 6,
+      "comment_count": 38,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "348c4b05-b659-5f84-9203-a2092a5071ef": {
+      "active_thread_count": 2,
+      "comment_count": 21,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "374916a5-a518-588b-9a1f-005e9f3b47dd": {
+      "active_thread_count": 11,
+      "comment_count": 140,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "3eded2f7-48a3-5b2f-8448-3b2ff8a1b216": {
+      "active_thread_count": 14,
+      "comment_count": 28,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "429e1343-3733-55c1-af54-d9a82f37935c": {
+      "active_thread_count": 7,
+      "comment_count": 72,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "46341819-09c7-5f56-af79-05d9be8b22af": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "4990918a-5676-50c3-9598-5f23646ffc7c": {
+      "active_thread_count": 3,
+      "comment_count": 27,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "5b589f79-7cc3-5639-9824-ddc9500772f7": {
+      "active_thread_count": 46,
+      "comment_count": 244,
+      "coverage_partial": true,
+      "thread_count": 58
+    },
+    "612fbb5d-1bbc-58bc-af66-928e26768f59": {
+      "active_thread_count": 7,
+      "comment_count": 18,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "63230cdd-2ed3-5537-91ed-174558c1224b": {
+      "active_thread_count": 1,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "644c22e5-97b7-588e-9bb9-302635067952": {
+      "active_thread_count": 6,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "665dea45-ae71-589f-8f3c-bcb0c2e41a11": {
+      "active_thread_count": 4,
+      "comment_count": 33,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 8,
+      "comment_count": 50,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 17,
+      "comment_count": 84,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "9db53b28-1eff-5152-b583-0a83a16b67b6": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "a6e51ae7-2e66-5dfd-bb20-87c8071f9729": {
+      "active_thread_count": 3,
+      "comment_count": 24,
+      "coverage_partial": false,
+      "thread_count": 7
+    },
+    "aff0d50d-7ee8-5387-ad34-bedc8312970d": {
+      "active_thread_count": 12,
+      "comment_count": 69,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "b5084d1b-1d46-5f04-9abc-6f33ca3583b2": {
+      "active_thread_count": 12,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 21
+    },
+    "b7ad1ee1-902d-532c-9b80-0eda227e722c": {
+      "active_thread_count": 5,
+      "comment_count": 18,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "bd9e17b1-0b06-5284-9bf5-2300a7ec5778": {
+      "active_thread_count": 9,
+      "comment_count": 85,
+      "coverage_partial": false,
+      "thread_count": 18
+    },
+    "c44b04ad-873c-5f16-87c5-6c3c350dc296": {
+      "active_thread_count": 3,
+      "comment_count": 145,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "c513be1c-8837-5c31-b5c5-fb2853442175": {
+      "active_thread_count": 34,
+      "comment_count": 230,
+      "coverage_partial": false,
+      "thread_count": 57
+    },
+    "c6564adf-871f-57e3-aaf3-b5d1cff626d6": {
+      "active_thread_count": 9,
+      "comment_count": 114,
+      "coverage_partial": true,
+      "thread_count": 25
+    },
+    "cb1f2a5d-f3f5-5bcf-bcd3-fe013b150194": {
+      "active_thread_count": 0,
+      "comment_count": 4,
+      "coverage_partial": true,
+      "thread_count": 1
+    },
+    "cbd5bf5c-4c72-513e-8f8b-7e4629d47b2a": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "cc294c6d-7d4c-510f-a891-95b1820f4239": {
+      "active_thread_count": 5,
+      "comment_count": 14,
+      "coverage_partial": true,
+      "thread_count": 6
+    },
+    "cce90b10-5bcc-5193-b670-10c27fc27b0e": {
+      "active_thread_count": 11,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "d093c274-679c-53ff-b1ca-73932f1f4434": {
+      "active_thread_count": 10,
+      "comment_count": 57,
+      "coverage_partial": false,
+      "thread_count": 12
+    },
+    "d3225da6-88d8-50bf-80c3-f547b9c530b7": {
+      "active_thread_count": 0,
+      "comment_count": 5,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d4bf62a8-2330-5afd-a841-ce8cca5ecf71": {
+      "active_thread_count": 2,
+      "comment_count": 16,
+      "coverage_partial": false,
+      "thread_count": 4
+    },
+    "d62a08f1-da5c-55b2-a473-9fd58a52ca91": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "d8529cbf-a17e-56be-89e6-72effbf69841": {
+      "active_thread_count": 9,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 24
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 15,
+      "comment_count": 103,
+      "coverage_partial": false,
+      "thread_count": 29
+    },
+    "dd90d4ae-b703-5f35-9687-f6b1d3cbebd6": {
+      "active_thread_count": 1,
+      "comment_count": 6,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "e240a9d8-6a7a-5fd1-bce3-4cd050c0946e": {
+      "active_thread_count": 1,
+      "comment_count": 4,
+      "coverage_partial": false,
+      "thread_count": 1
+    },
+    "ed15254c-8741-5f52-a86a-763e430d271e": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "edd8ead8-cc32-5e8a-9f64-d88206710636": {
+      "active_thread_count": 20,
+      "comment_count": 125,
+      "coverage_partial": false,
+      "thread_count": 40
+    },
+    "fa2210af-6bf9-5f40-b530-17574196e576": {
+      "active_thread_count": 8,
+      "comment_count": 60,
+      "coverage_partial": false,
+      "thread_count": 12
+    }
+  },
   "by_repository": {
     "android-app": {
       "authors_count": 1,

--- a/docs/data/aggregates/weekly_rollups/2025-W52.json
+++ b/docs/data/aggregates/weekly_rollups/2025-W52.json
@@ -644,6 +644,146 @@
       }
     }
   },
+  "by_author_comments": {
+    "03943000-b3aa-55b3-8033-bd4e5bab83fb": {
+      "active_thread_count": 3,
+      "comment_count": 76,
+      "coverage_partial": false,
+      "thread_count": 19
+    },
+    "30f9f653-d7f5-52a2-a7c4-578f1e1d241f": {
+      "active_thread_count": 7,
+      "comment_count": 63,
+      "coverage_partial": false,
+      "thread_count": 17
+    },
+    "3a27b729-1c55-5383-a129-770ee1d44029": {
+      "active_thread_count": 8,
+      "comment_count": 26,
+      "coverage_partial": true,
+      "thread_count": 13
+    },
+    "43f64846-3ad1-579b-98e9-f3a08e718f75": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 3
+    },
+    "47d485b1-d1c2-5601-810b-8f3bc63119e2": {
+      "active_thread_count": 12,
+      "comment_count": 56,
+      "coverage_partial": false,
+      "thread_count": 28
+    },
+    "53faba57-1084-584c-8873-637b1c8e9fa5": {
+      "active_thread_count": 2,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 9
+    },
+    "54c6fbbc-70c1-5d67-bb5f-8a4685113aa0": {
+      "active_thread_count": 6,
+      "comment_count": 37,
+      "coverage_partial": false,
+      "thread_count": 14
+    },
+    "59cb7d66-58a2-59e7-942f-4da2b915d6c9": {
+      "active_thread_count": 2,
+      "comment_count": 28,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "5b99e00c-ab32-5315-9404-232bade14bdf": {
+      "active_thread_count": 6,
+      "comment_count": 35,
+      "coverage_partial": true,
+      "thread_count": 7
+    },
+    "6b0e129f-e628-5593-8a58-899c481f4d5c": {
+      "active_thread_count": 0,
+      "comment_count": 0,
+      "coverage_partial": true,
+      "thread_count": 0
+    },
+    "6d720789-90aa-5ce3-b7fb-02533fcbcf70": {
+      "active_thread_count": 1,
+      "comment_count": 30,
+      "coverage_partial": false,
+      "thread_count": 10
+    },
+    "736796b8-e955-5a92-9658-2dcf16b75f26": {
+      "active_thread_count": 9,
+      "comment_count": 70,
+      "coverage_partial": false,
+      "thread_count": 27
+    },
+    "76b80c19-5714-524e-b656-41176d684adb": {
+      "active_thread_count": 7,
+      "comment_count": 89,
+      "coverage_partial": false,
+      "thread_count": 22
+    },
+    "7a983fd7-ee82-530f-851a-70785c8fe4a5": {
+      "active_thread_count": 8,
+      "comment_count": 55,
+      "coverage_partial": false,
+      "thread_count": 11
+    },
+    "7bfae255-fb96-5f69-8d1b-f086c2b3f494": {
+      "active_thread_count": 3,
+      "comment_count": 26,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "8e2a8c54-f6c3-5b6f-a945-92d2f3298e28": {
+      "active_thread_count": 10,
+      "comment_count": 36,
+      "coverage_partial": false,
+      "thread_count": 15
+    },
+    "9b064573-dab2-5837-b361-f50b8235b324": {
+      "active_thread_count": 0,
+      "comment_count": 12,
+      "coverage_partial": false,
+      "thread_count": 5
+    },
+    "9cc11263-ee7a-5cf3-8cf0-984b7e573dff": {
+      "active_thread_count": 1,
+      "comment_count": 10,
+      "coverage_partial": false,
+      "thread_count": 2
+    },
+    "b83a510a-1a2f-564d-8eb7-37d406c889cc": {
+      "active_thread_count": 2,
+      "comment_count": 27,
+      "coverage_partial": true,
+      "thread_count": 9
+    },
+    "c0623aee-9084-5059-b49b-95a39425acb9": {
+      "active_thread_count": 0,
+      "comment_count": 2,
+      "coverage_partial": false,
+      "thread_count": 0
+    },
+    "db58c77c-2999-5071-a857-37ed2deae874": {
+      "active_thread_count": 8,
+      "comment_count": 36,
+      "coverage_partial": true,
+      "thread_count": 12
+    },
+    "f6a6d51a-6648-578d-9582-e5420d036157": {
+      "active_thread_count": 12,
+      "comment_count": 65,
+      "coverage_partial": false,
+      "thread_count": 13
+    },
+    "f8de20c9-af06-518c-8697-881b5334bd67": {
+      "active_thread_count": 12,
+      "comment_count": 48,
+      "coverage_partial": false,
+      "thread_count": 12
+    }
+  },
   "by_repository": {
     "auth-service": {
       "authors_count": 1,

--- a/docs/dataset-loader.js
+++ b/docs/dataset-loader.js
@@ -1337,7 +1337,11 @@ var PRInsightsDatasetLoader = (() => {
     "_prs_cap",
     // Feature 333 weekly comments-aggregate (gated on capabilities.comments_metrics).
     // Atomic when present per INV-1-08; absent entirely when capability-off (FR-3-03).
-    "comments"
+    "comments",
+    // Feature 334 per-author comments-density (gated on capabilities.comments_metrics).
+    // Outer dict at rollup root; per-entry atomic per INV-2-08; absent entirely
+    // when capability-off (FR-3-03 + INV-2-09).
+    "by_author_comments"
   ]);
   var PR_RECORD_REQUIRED_FIELDS = [
     "id",
@@ -1749,6 +1753,126 @@ var PRInsightsDatasetLoader = (() => {
     }
     return { errors };
   }
+  function validateAuthorCommentsDensity(data, path) {
+    const errors = [];
+    if (!isObject(data)) {
+      errors.push(createError(path, "object", getTypeName(data)));
+      return { errors };
+    }
+    const entries = Object.entries(
+      data
+    );
+    if (entries.length === 0) {
+      errors.push(
+        createError(
+          path,
+          "non-empty Record<string, AuthorCommentsDensityEntry>",
+          "{}",
+          `by_author_comments MUST be omitted entirely when no per-author buckets exist (FR-3-03 + INV-2-09); empty object is a contract violation`
+        )
+      );
+      return { errors };
+    }
+    const requiredFields = [
+      "thread_count",
+      "comment_count",
+      "active_thread_count",
+      "coverage_partial"
+    ];
+    for (const [key, entry] of entries) {
+      const entryPath = buildPath(path, key);
+      if (!isObject(entry)) {
+        errors.push(createError(entryPath, "object", getTypeName(entry)));
+        continue;
+      }
+      const missing = requiredFields.filter(
+        (field) => !Object.prototype.hasOwnProperty.call(entry, field)
+      );
+      if (missing.length > 0) {
+        errors.push(
+          createError(
+            entryPath,
+            "all four of thread_count / comment_count / active_thread_count / coverage_partial",
+            `missing: ${missing.join(", ")}`,
+            `by_author_comments[${key}] atomicity violated (INV-2-08): expected all four of thread_count / comment_count / active_thread_count / coverage_partial; missing: ${missing.join(", ")}`
+          )
+        );
+      }
+      const numericFieldChecks = [
+        { name: "thread_count", value: entry.thread_count },
+        { name: "comment_count", value: entry.comment_count },
+        { name: "active_thread_count", value: entry.active_thread_count }
+      ];
+      for (const { name, value } of numericFieldChecks) {
+        if (!Object.prototype.hasOwnProperty.call(entry, name)) {
+          continue;
+        }
+        if (value === null) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number (non-null per INV-2-08; zero is the valid sum over an empty extracted-subset)",
+              "null",
+              `by_author_comments[${key}].${name} MUST be a non-null number (INV-2-08); null is not a valid sentinel \u2014 use 0 for an empty extracted-subset`
+            )
+          );
+        } else if (!isNumber(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number",
+              getTypeName(value),
+              `expected number at 'by_author_comments[${key}].${name}', got ${getTypeName(value)}`
+            )
+          );
+        } else if (value < 0) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "non-negative number (counts cannot be negative)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be non-negative; got ${value}`
+            )
+          );
+        } else if (!Number.isInteger(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "integer (counts must be whole numbers)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be an integer; got ${value}`
+            )
+          );
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, "coverage_partial")) {
+        const coveragePartial = entry.coverage_partial;
+        if (!isBoolean(coveragePartial)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, "coverage_partial"),
+              "boolean",
+              getTypeName(coveragePartial),
+              `expected boolean at 'by_author_comments[${key}].coverage_partial', got ${getTypeName(coveragePartial)}`
+            )
+          );
+        }
+      }
+      const entryThread = entry.thread_count;
+      const entryActive = entry.active_thread_count;
+      if (isNumber(entryThread) && isNumber(entryActive) && Number.isInteger(entryThread) && Number.isInteger(entryActive) && entryThread >= 0 && entryActive >= 0 && entryActive > entryThread) {
+        errors.push(
+          createError(
+            buildPath(entryPath, "active_thread_count"),
+            "<= thread_count (INV-2-07; active is a subset of total)",
+            `${entryActive} > ${entryThread}`,
+            `by_author_comments[${key}] ordering violated (INV-2-07): active_thread_count (${entryActive}) MUST NOT exceed thread_count (${entryThread})`
+          )
+        );
+      }
+    }
+    return { errors };
+  }
   function validateRollup(data, strict) {
     const errors = [];
     const warnings = [];
@@ -1899,6 +2023,13 @@ var PRInsightsDatasetLoader = (() => {
     if (Object.prototype.hasOwnProperty.call(data, "comments") && data.comments !== void 0) {
       const commentsResult = validateCommentsAggregate(data.comments, "comments");
       errors.push(...commentsResult.errors);
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "by_author_comments") && data.by_author_comments !== void 0) {
+      const byAuthorCommentsResult = validateAuthorCommentsDensity(
+        data.by_author_comments,
+        "by_author_comments"
+      );
+      errors.push(...byAuthorCommentsResult.errors);
     }
     const unknown = findUnknownFields(data, KNOWN_ROOT_FIELDS2, "", strict);
     errors.push(...unknown.errors);

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -3839,3 +3839,91 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
         transparent 5px
     );
 }
+
+/* =====================================================================
+ * Feature 334: per-author comments-density chart
+ * Row-table layout (one row per author) with a 3-button radio-group
+ * sort selector, top-50 cap, and a per-row partial-coverage qualifier
+ * mirroring the 333 .coverage-partial CSS class hook.
+ * ===================================================================*/
+.comments-author-density-sort {
+    display: flex;
+    gap: 0.5rem;
+    margin: 0.5rem 0 0.75rem 0;
+    flex-wrap: wrap;
+}
+
+.comments-author-density-sort-btn {
+    border: 1px solid var(--border-color, #d0d7de);
+    background: var(--bg-secondary, #f6f8fa);
+    color: var(--text-primary, inherit);
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    line-height: 1.4;
+}
+
+.comments-author-density-sort-btn:focus-visible {
+    outline: 2px solid var(--primary, #0969da);
+    outline-offset: 2px;
+}
+
+.comments-author-density-sort-btn.is-active {
+    background: var(--primary, #0969da);
+    color: var(--bg-primary, #ffffff);
+    border-color: var(--primary, #0969da);
+}
+
+.comments-author-density-table {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
+    column-gap: 1rem;
+    row-gap: 0.125rem;
+    align-items: center;
+}
+
+.comments-author-density-thead,
+.comments-author-density-row {
+    display: contents;
+}
+
+.comments-author-density-thead > [role="columnheader"] {
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary, #57606a);
+    padding: 0.25rem 0;
+    border-bottom: 1px solid var(--border-color, #d0d7de);
+}
+
+.comments-author-density-row > [role="cell"] {
+    padding: 0.25rem 0;
+    font-size: 0.9375rem;
+}
+
+.comments-author-density-row .comments-author-density-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.comments-author-density-numeric {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
+/* Partial-coverage qualifier on rows whose reduced coverage_partial=true
+ * (FR-4-03).  Shares the .coverage-partial class hook with 333 so the
+ * convention stays visually consistent across the two surfaces. */
+.comments-author-density-row.coverage-partial > [role="cell"] {
+    color: var(--text-tertiary, #6e7781);
+    background-image: repeating-linear-gradient(
+        45deg,
+        rgba(110, 119, 129, 0.08) 0,
+        rgba(110, 119, 129, 0.08) 4px,
+        transparent 4px,
+        transparent 8px
+    );
+}

--- a/extension/tests/artifact-client.test.ts
+++ b/extension/tests/artifact-client.test.ts
@@ -8,6 +8,16 @@
  * - AuthenticatedDatasetLoader manifest validation and caching
  */
 
+import * as _fsOriginal from "fs";
+
+function _loadFs(): typeof _fsOriginal {
+  return _fsOriginal;
+}
+
+const _fs = _loadFs();
+
+import { resolve as resolvePath } from "path";
+
 import {
   ArtifactClient,
   AuthenticatedDatasetLoader,
@@ -1257,6 +1267,69 @@ describe("AuthenticatedDatasetLoader", () => {
       expect(loader.getCapabilityState().commentsMetricsAvailable).toBe(false);
       expect(loader.getCapabilityState().commentsCoverageStatus).toBe(
         "disabled",
+      );
+    });
+
+    it("gates the Feature 334 per-author chart via the same loader path that the 333 chart uses (live-extension regression)", async () => {
+      // F3 reinforcement (Feature 334): the per-author comments-density
+      // chart row introduced by US1 is gated on
+      // ``loader.getCapabilityState()?.commentsMetricsAvailable === true``
+      // — the SAME expression the 333 comments-trend chart uses.  PR
+      // #347 fixed the live-extension regression where that gate
+      // short-circuited to ``false`` on AuthenticatedDatasetLoader
+      // because the method was missing; this test re-exercises the
+      // capability path against the per-author chart's call site so a
+      // future loader refactor cannot silently re-introduce the same
+      // failure mode for the new chart.
+      const loader = buildLoader({
+        ...baseManifest,
+        capabilities: {
+          author_filters: true,
+          author_repo_exact: true,
+          comments_metrics: true,
+          reviewer_repository_mode: "constrained",
+          reviewer_team_mode: "disallowed",
+          cross_dimensional_available: true,
+        },
+      });
+
+      await loader.loadManifest();
+
+      // Live-loader capability state is the load-bearing gate for the
+      // per-author chart.  Confirm via the same chained access the
+      // dashboard uses at the per-author chart's call site.
+      const gateValue =
+        loader.getCapabilityState?.()?.commentsMetricsAvailable === true;
+      expect(gateValue).toBe(true);
+    });
+
+    it("source-parse: the per-author chart's dashboard gate uses the SAME getCapabilityState chain as the 333 chart", () => {
+      // Lock the dashboard call sites so a refactor cannot drop the
+      // per-author gate or pivot it to a different loader method
+      // without surfacing here.
+      const dashboardSrcLocal = _fs.readFileSync(
+        resolvePath(__dirname, "../ui/dashboard.ts"),
+        "utf-8",
+      );
+
+      // Both the 333 and 334 chart blocks must reference the canonical
+      // ``commentsMetricsAvailable`` field via the optional-chained
+      // ``getCapabilityState`` call.
+      const occurrences = dashboardSrcLocal.match(
+        /loader\?\.getCapabilityState\?\.\(\)\?\.commentsMetricsAvailable === true/g,
+      );
+      expect(occurrences).not.toBeNull();
+      // At least two: one for the 333 chart, one for the 334 chart.
+      expect(occurrences!.length).toBeGreaterThanOrEqual(2);
+
+      // The 334 ``ensureCommentsAuthorDensityContainer()`` call sits
+      // inside the capability-on branch.
+      expect(dashboardSrcLocal).toContain(
+        "ensureCommentsAuthorDensityContainer()",
+      );
+      // The capability-off branch calls the remove helper.
+      expect(dashboardSrcLocal).toContain(
+        "removeCommentsAuthorDensityContainer()",
       );
     });
   });

--- a/extension/tests/dashboard/comments-author-density-dashboard-lifecycle.test.ts
+++ b/extension/tests/dashboard/comments-author-density-dashboard-lifecycle.test.ts
@@ -1,0 +1,540 @@
+/**
+ * Comments-Author-Density Dashboard Lifecycle Tests (Feature 334, T027).
+ *
+ * Verifies the dashboard-layer container helpers
+ * (``ensureCommentsAuthorDensityContainer`` /
+ * ``removeCommentsAuthorDensityContainer``) and the on→on re-render
+ * idempotency invariant under the four lifecycle paths called out by
+ * FR-3-01 + FR-3-02 + SC-1-03:
+ *
+ *   (a) Initial capability-off — no chart row mounted; Metrics tab DOM
+ *       byte-identical to the pre-feature baseline.
+ *   (b) On→off transition — ``removeCommentsAuthorDensityContainer``
+ *       cleans up the previously inserted row; DOM returns to the
+ *       pre-feature baseline (FR-3-02).
+ *   (c) Off→on transition — ``ensureCommentsAuthorDensityContainer``
+ *       inserts the row exactly once (FR-3-02).
+ *   (d) On→on re-render idempotency — calling the dashboard's
+ *       per-refresh sequence (``ensureCommentsAuthorDensityContainer()`` +
+ *       ``renderCommentsAuthorDensityChart()``) twice consecutively
+ *       yields exactly ONE row, ONE chart leaf, and non-duplicated row /
+ *       sort-toolbar content.
+ *
+ * Same source-parse contract pattern as the 333 lifecycle test
+ * (``comments-trend-dashboard-lifecycle.test.ts``): test-side mirrors
+ * of the dashboard helpers are locked to the production source via
+ * ``dashboardSrc.indexOf`` assertions so the mirrors cannot silently
+ * drift from the real ``dashboard.ts`` helpers.  Reading order: scroll
+ * to the four-scenario describe block first; the source-parse contract
+ * is the safety net.
+ *
+ * Why this file does not import dashboard.ts directly: ``init()`` runs
+ * at module load (jsdom's ``DOMContentLoaded`` fires immediately) so
+ * the entire dashboard bootstrap chain triggers — established pattern
+ * is the test-side mirror with a source-parse lock (per 333 lifecycle
+ * test header).
+ */
+
+import * as _fsOriginal from "fs";
+
+function _loadFs(): typeof _fsOriginal {
+  return _fsOriginal;
+}
+
+const _fs = _loadFs();
+
+import { resolve } from "path";
+
+import { renderCommentsAuthorDensityChart } from "../../ui/modules/charts/comments-author-density";
+import type { Rollup } from "../../ui/dataset-loader";
+import type { FilterState } from "../../ui/modules/filters";
+
+// ---------------------------------------------------------------------------
+// Source under test (read once for the contract-lock describe block).
+// ---------------------------------------------------------------------------
+
+const dashboardSrcPath = resolve(__dirname, "../../ui/dashboard.ts");
+const dashboardSrc = _fs.readFileSync(dashboardSrcPath, "utf-8");
+
+// ---------------------------------------------------------------------------
+// Test-side mirrors of the dashboard helpers in dashboard.ts.
+//
+// Mirrors ``ensureCommentsAuthorDensityContainer`` /
+// ``removeCommentsAuthorDensityContainer``.  The source-parse contract
+// describe block locks each mirror to its production counterpart so they
+// cannot silently drift.
+// ---------------------------------------------------------------------------
+
+function ensureCommentsAuthorDensityContainerContract(): HTMLElement | null {
+  const existing = document.getElementById("comments-author-density");
+  if (existing) return existing;
+
+  const commentsTrendRow = document.querySelector(
+    '[data-comments-trend-row="true"]',
+  );
+  let anchorRow: Element | null = commentsTrendRow;
+  if (!anchorRow) {
+    const cycleDist = document.getElementById("cycle-distribution");
+    anchorRow = cycleDist?.closest(".charts-row") ?? null;
+  }
+  if (!anchorRow || !anchorRow.parentElement) return null;
+
+  const row = document.createElement("div");
+  row.className = "charts-row";
+  row.setAttribute("data-comments-author-density-row", "true");
+
+  const containerCell = document.createElement("div");
+  containerCell.className = "chart-container";
+
+  const heading = document.createElement("h3");
+  heading.textContent = "Comment Density by Author";
+  containerCell.appendChild(heading);
+
+  const chart = document.createElement("div");
+  chart.id = "comments-author-density";
+  chart.className = "chart";
+
+  containerCell.appendChild(chart);
+  row.appendChild(containerCell);
+
+  anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+
+  return chart;
+}
+
+function removeCommentsAuthorDensityContainerContract(): void {
+  const row = document.querySelector(
+    '[data-comments-author-density-row="true"]',
+  );
+  if (!row) return;
+  row.parentElement?.removeChild(row);
+}
+
+// ---------------------------------------------------------------------------
+// Pre-feature Metrics-tab baseline.
+//
+// Mirrors the pre-Feature-334 static markup: the four pre-existing charts
+// (throughput, cycle-time-trend, reviewer-activity, cycle-distribution)
+// plus the 333 ``comments-trend`` row that ships ahead of the per-author
+// chart in any capability-on render order.  FR-3-01 / SC-1-03 byte-identity
+// is verified against the no-comments-row baseline (i.e., the DOM state
+// when ``capabilities.comments_metrics`` is off — the per-author row AND
+// the 333 row are both absent).
+// ---------------------------------------------------------------------------
+
+const PRE_FEATURE_METRICS_HTML = `
+  <section id="tab-metrics">
+    <div class="charts-row" data-pre-feature-row="row-1">
+      <div class="chart-container">
+        <h3>PR Throughput Over Time</h3>
+        <div id="throughput-chart" class="chart"></div>
+      </div>
+      <div class="chart-container">
+        <h3>Cycle Time Trend</h3>
+        <div id="cycle-time-trend" class="chart"></div>
+      </div>
+    </div>
+    <div class="charts-row" data-pre-feature-row="row-2">
+      <div class="chart-container">
+        <h3 id="reviewer-activity-label">Reviewer Activity</h3>
+        <div id="reviewer-activity" class="chart"></div>
+      </div>
+      <div class="chart-container">
+        <h3>Cycle Time Distribution</h3>
+        <div id="cycle-distribution" class="chart"></div>
+      </div>
+    </div>
+  </section>
+`;
+
+function mountPreFeatureBaseline(): void {
+  document.body.innerHTML = PRE_FEATURE_METRICS_HTML;
+}
+
+function metricsTabHtml(): string {
+  return document.getElementById("tab-metrics")?.outerHTML ?? "";
+}
+
+// Insert a synthetic 333 comments-trend row mirroring the dashboard's
+// capability-on render order (333 row mounted first, 334 row mounted
+// below it).  Tests that exercise scenarios (b)/(c)/(d) need this so
+// the 334 row anchors on the 333 row exactly as it does in production.
+function mount333Row(): HTMLElement {
+  const cycleDist = document.getElementById("cycle-distribution");
+  const anchorRow = cycleDist?.closest(".charts-row");
+  if (!anchorRow || !anchorRow.parentElement) {
+    throw new Error("baseline missing cycle-distribution anchor");
+  }
+  const row = document.createElement("div");
+  row.className = "charts-row";
+  row.setAttribute("data-comments-trend-row", "true");
+  const containerCell = document.createElement("div");
+  containerCell.className = "chart-container";
+  const heading = document.createElement("h3");
+  heading.textContent = "Comments Trend";
+  containerCell.appendChild(heading);
+  const chart = document.createElement("div");
+  chart.id = "comments-trend";
+  chart.className = "chart";
+  containerCell.appendChild(chart);
+  row.appendChild(containerCell);
+  anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+  return chart;
+}
+
+// ---------------------------------------------------------------------------
+// Per-author rollup builder (used by scenarios (b)-(d)).
+// ---------------------------------------------------------------------------
+
+interface AuthorBucket {
+  thread_count: number;
+  comment_count: number;
+  active_thread_count: number;
+  coverage_partial: boolean;
+}
+
+function makeAuthorRollup(index: number, authorCount: number): Rollup {
+  const buckets: Record<string, AuthorBucket> = {};
+  for (let i = 0; i < authorCount; i++) {
+    buckets[`author-${String(i).padStart(3, "0")}`] = {
+      thread_count: 5 + index,
+      comment_count: (5 + index) * 4,
+      active_thread_count: Math.min(2, 5 + index),
+      coverage_partial: false,
+    };
+  }
+  return {
+    week: `2025-W${String(index + 1).padStart(2, "0")}`,
+    pr_count: 10 + index * 2,
+    cycle_time_p50: 60 + index * 5,
+    cycle_time_p90: 120 + index * 10,
+    authors_count: authorCount,
+    reviewers_count: 3 + index,
+    by_repository: null,
+    by_team: null,
+    by_author_comments: buckets,
+  };
+}
+
+function makeAuthorRollups(weekCount: number, authorCount: number): Rollup[] {
+  return Array.from({ length: weekCount }, (_, i) =>
+    makeAuthorRollup(i, authorCount),
+  );
+}
+
+const NO_FILTERS: FilterState = {
+  repos: [],
+  teams: [],
+  reviewers: [],
+  authors: [],
+};
+
+// ===========================================================================
+// Source-parse contract — locks the test-side mirrors to dashboard.ts.
+// ===========================================================================
+
+describe("comments-author-density dashboard lifecycle — source-parse contract", () => {
+  it("ensureCommentsAuthorDensityContainer in dashboard.ts implements check-first idempotency + 333 anchor preference", () => {
+    const helperStart = dashboardSrc.indexOf(
+      "function ensureCommentsAuthorDensityContainer(",
+    );
+    expect(helperStart).toBeGreaterThan(-1);
+
+    const helperBody = dashboardSrc.slice(helperStart, helperStart + 2000);
+
+    // Check-first idempotency: the helper queries the existing leaf BEFORE
+    // building any new DOM. Without this, scenario (d) would fail (a
+    // second render would insert a duplicate row).
+    expect(helperBody).toContain(
+      'document.getElementById("comments-author-density")',
+    );
+    expect(helperBody).toMatch(/if \(existing\) return existing;/);
+
+    // 333 anchor preference + cycle-distribution fallback. The
+    // production anchor logic is what places the 334 row BELOW the 333
+    // chart per FR-4-01 in the typical capability-on render order.
+    expect(helperBody).toContain('[data-comments-trend-row="true"]');
+    expect(helperBody).toContain(
+      'document.getElementById("cycle-distribution")',
+    );
+    expect(helperBody).toContain('.closest(".charts-row")');
+
+    // Row markers used by the cleanup helper and by scenarios (a)-(d).
+    expect(helperBody).toContain('row.className = "charts-row"');
+    expect(helperBody).toContain(
+      'row.setAttribute("data-comments-author-density-row", "true")',
+    );
+    expect(helperBody).toContain('chart.id = "comments-author-density"');
+
+    // Insertion ordering: the new row sits immediately after the anchor
+    // row's next sibling so it lands BELOW the 333 chart (or below
+    // cycle-distribution when 333 is not mounted).
+    expect(helperBody).toContain(
+      "anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling)",
+    );
+  });
+
+  it("ensureCommentsAuthorDensityContainer mounts the heading", () => {
+    const helperStart = dashboardSrc.indexOf(
+      "function ensureCommentsAuthorDensityContainer(",
+    );
+    expect(helperStart).toBeGreaterThan(-1);
+
+    const helperBody = dashboardSrc.slice(helperStart, helperStart + 2000);
+
+    // Peer-pattern parity with the 333 row: every chart container has
+    // an <h3> title. The locked text is asserted here so a future
+    // refactor that drops or renames it fails this contract.
+    expect(helperBody).toContain('document.createElement("h3")');
+    expect(helperBody).toContain(
+      'heading.textContent = "Comment Density by Author"',
+    );
+  });
+
+  it("removeCommentsAuthorDensityContainer in dashboard.ts targets the data-attribute selector", () => {
+    const helperStart = dashboardSrc.indexOf(
+      "function removeCommentsAuthorDensityContainer(",
+    );
+    expect(helperStart).toBeGreaterThan(-1);
+
+    const helperBody = dashboardSrc.slice(helperStart, helperStart + 800);
+    expect(helperBody).toContain('[data-comments-author-density-row="true"]');
+    expect(helperBody).toMatch(/if \(!row\) return;/);
+    expect(helperBody).toContain("row.parentElement?.removeChild(row)");
+  });
+
+  it("dashboard refresh path calls both helpers behind the capability gate", () => {
+    // The capability gate at dashboard.ts is the entry point all four
+    // lifecycle scenarios verify. If the gate or call sites move, this
+    // assertion fails so scenario (d)'s "two consecutive refreshes"
+    // simulation can be re-validated.
+    expect(dashboardSrc).toContain("ensureCommentsAuthorDensityContainer()");
+    expect(dashboardSrc).toContain(
+      "renderCommentsAuthorDensityChartModule(cadContainer",
+    );
+    expect(dashboardSrc).toContain("removeCommentsAuthorDensityContainer()");
+  });
+});
+
+// ===========================================================================
+// Lifecycle scenarios (a)-(d).
+// ===========================================================================
+
+describe("comments-author-density dashboard lifecycle — four scenarios (T027)", () => {
+  let baselineHtml: string;
+
+  beforeEach(() => {
+    mountPreFeatureBaseline();
+    baselineHtml = metricsTabHtml();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario (a) — initial capability-off (FR-3-01 + SC-1-03).
+  // -------------------------------------------------------------------------
+
+  it("(a) initial capability-off renders Metrics tab byte-identical to pre-feature baseline", () => {
+    // The dashboard's capability-off branch calls the remove helper only
+    // (no insertion). Initial capability-off is a pure no-op because the
+    // row was never inserted.
+    removeCommentsAuthorDensityContainerContract();
+
+    // No chart leaf, no row marker.
+    expect(document.getElementById("comments-author-density")).toBeNull();
+    expect(
+      document.querySelector('[data-comments-author-density-row="true"]'),
+    ).toBeNull();
+
+    // Heading absent under initial capability-off — the chart row was
+    // never inserted, so its child <h3> is not mounted either.
+    expect(
+      document.querySelectorAll('[data-comments-author-density-row="true"] h3'),
+    ).toHaveLength(0);
+
+    // Four pre-existing charts still occupy their original layout positions.
+    expect(document.getElementById("throughput-chart")).not.toBeNull();
+    expect(document.getElementById("cycle-time-trend")).not.toBeNull();
+    expect(document.getElementById("reviewer-activity")).not.toBeNull();
+    expect(document.getElementById("cycle-distribution")).not.toBeNull();
+
+    // Two pre-feature `.charts-row` elements only — no new row inserted.
+    expect(document.querySelectorAll(".charts-row").length).toBe(2);
+
+    // Strict byte-identity: capability-off must produce the same DOM
+    // string as the pre-feature baseline.
+    expect(metricsTabHtml()).toBe(baselineHtml);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario (b) — on→off transition (FR-3-02).
+  // -------------------------------------------------------------------------
+
+  it("(b) on→off transition cleans up the chart row and restores byte-identity", () => {
+    // In production the 333 row mounts first under capability-on.  Mirror
+    // that anchoring environment so the 334 row is inserted below it.
+    mount333Row();
+    const baselineWith333 = metricsTabHtml();
+
+    // Step 1: capability-on render inserts the per-author row + content.
+    const chart = ensureCommentsAuthorDensityContainerContract();
+    expect(chart).not.toBeNull();
+    renderCommentsAuthorDensityChart(chart!, makeAuthorRollups(8, 5), {
+      filters: NO_FILTERS,
+    });
+
+    // Sanity: per-author row + chart leaf + rendered rows present.
+    expect(document.getElementById("comments-author-density")).not.toBeNull();
+    expect(
+      document.querySelector('[data-comments-author-density-row="true"]'),
+    ).not.toBeNull();
+    expect(
+      document.querySelectorAll('[data-comments-author-density-row="true"] h3'),
+    ).toHaveLength(1);
+    expect(
+      document.querySelectorAll(".comments-author-density-row").length,
+    ).toBe(5);
+    // 2 pre-feature rows + 333 row + 334 row = 4
+    expect(document.querySelectorAll(".charts-row").length).toBe(4);
+
+    // Step 2: capability-off reload runs only the remove helper.
+    removeCommentsAuthorDensityContainerContract();
+
+    // Cleanup: per-author row gone, but the 333 row stays (it's owned
+    // by removeCommentsTrendContainer, not this helper).
+    expect(document.getElementById("comments-author-density")).toBeNull();
+    expect(
+      document.querySelector('[data-comments-author-density-row="true"]'),
+    ).toBeNull();
+    expect(
+      document.querySelectorAll('[data-comments-author-density-row="true"] h3'),
+    ).toHaveLength(0);
+    // 333 row still present.
+    expect(
+      document.querySelectorAll('[data-comments-trend-row="true"]').length,
+    ).toBe(1);
+    // 2 pre-feature rows + 333 row = 3
+    expect(document.querySelectorAll(".charts-row").length).toBe(3);
+    expect(metricsTabHtml()).toBe(baselineWith333);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario (c) — off→on transition (FR-3-02).
+  // -------------------------------------------------------------------------
+
+  it("(c) off→on transition inserts the chart row exactly once", () => {
+    mount333Row();
+
+    // Step 1: capability-off render is a no-op on a fresh DOM.
+    removeCommentsAuthorDensityContainerContract();
+    expect(document.getElementById("comments-author-density")).toBeNull();
+
+    // Step 2: capability-on reload calls the ensure helper and renders.
+    const chart = ensureCommentsAuthorDensityContainerContract();
+    expect(chart).not.toBeNull();
+    renderCommentsAuthorDensityChart(chart!, makeAuthorRollups(8, 5), {
+      filters: NO_FILTERS,
+    });
+
+    // Exactly one row marker and one chart leaf.
+    expect(
+      document.querySelectorAll('[data-comments-author-density-row="true"]')
+        .length,
+    ).toBe(1);
+    expect(document.querySelectorAll("#comments-author-density").length).toBe(
+      1,
+    );
+    expect(
+      document.querySelectorAll('[data-comments-author-density-row="true"] h3'),
+    ).toHaveLength(1);
+
+    // Total `.charts-row` count is now 4 (row-1 + row-2 + 333 row + 334 row).
+    expect(document.querySelectorAll(".charts-row").length).toBe(4);
+
+    // The 334 row sits IMMEDIATELY AFTER the 333 row (FR-4-01: per-author
+    // breakdown sits below the weekly trend chart).
+    const trendRow = document.querySelector('[data-comments-trend-row="true"]');
+    expect(trendRow).not.toBeNull();
+    expect(trendRow!.nextElementSibling).not.toBeNull();
+    expect(
+      trendRow!.nextElementSibling?.getAttribute(
+        "data-comments-author-density-row",
+      ),
+    ).toBe("true");
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario (d) — on→on re-render idempotency.
+  // -------------------------------------------------------------------------
+
+  it("(d) on→on re-render is idempotent at the dashboard AND chart layers", () => {
+    mount333Row();
+    const rollups = makeAuthorRollups(8, 5);
+
+    // First "refresh" — capability-on path.
+    const chart1 = ensureCommentsAuthorDensityContainerContract();
+    expect(chart1).not.toBeNull();
+    renderCommentsAuthorDensityChart(chart1!, rollups, {
+      filters: NO_FILTERS,
+    });
+
+    const rowCountAfterFirst = document.querySelectorAll(
+      '[data-comments-author-density-row="true"]',
+    ).length;
+    const chartCountAfterFirst = document.querySelectorAll(
+      "#comments-author-density",
+    ).length;
+    const dataRowCountAfterFirst = document.querySelectorAll(
+      ".comments-author-density-row",
+    ).length;
+    const sortToolbarCountAfterFirst = document.querySelectorAll(
+      '.comments-author-density-sort[role="toolbar"]',
+    ).length;
+    const headingCountAfterFirst = document.querySelectorAll(
+      '[data-comments-author-density-row="true"] h3',
+    ).length;
+
+    expect(rowCountAfterFirst).toBe(1);
+    expect(chartCountAfterFirst).toBe(1);
+    expect(dataRowCountAfterFirst).toBe(5);
+    expect(sortToolbarCountAfterFirst).toBe(1);
+    expect(headingCountAfterFirst).toBe(1);
+
+    // Second "refresh" — same capability state, same data.
+    const chart2 = ensureCommentsAuthorDensityContainerContract();
+    expect(chart2).not.toBeNull();
+    renderCommentsAuthorDensityChart(chart2!, rollups, {
+      filters: NO_FILTERS,
+    });
+
+    // DASHBOARD-LAYER IDEMPOTENCY: the second ensure call MUST reuse
+    // the existing chart leaf instead of inserting a duplicate row.
+    expect(chart2).toBe(chart1);
+    expect(
+      document.querySelectorAll('[data-comments-author-density-row="true"]')
+        .length,
+    ).toBe(1);
+    expect(document.querySelectorAll("#comments-author-density").length).toBe(
+      1,
+    );
+
+    // CHART-LAYER IDEMPOTENCY: renderTrustedHtml replaces content, so
+    // row + sort-toolbar counts stay stable instead of doubling.
+    expect(
+      document.querySelectorAll(".comments-author-density-row").length,
+    ).toBe(dataRowCountAfterFirst);
+    expect(
+      document.querySelectorAll('.comments-author-density-sort[role="toolbar"]')
+        .length,
+    ).toBe(sortToolbarCountAfterFirst);
+
+    // Heading + total `.charts-row` count stable.
+    expect(
+      document.querySelectorAll('[data-comments-author-density-row="true"] h3')
+        .length,
+    ).toBe(1);
+    expect(document.querySelectorAll(".charts-row").length).toBe(4);
+  });
+});

--- a/extension/tests/fixtures/broken-docs/artifact-client.js
+++ b/extension/tests/fixtures/broken-docs/artifact-client.js
@@ -1330,7 +1330,11 @@ var PRInsightsArtifactClient = (() => {
     "_prs_cap",
     // Feature 333 weekly comments-aggregate (gated on capabilities.comments_metrics).
     // Atomic when present per INV-1-08; absent entirely when capability-off (FR-3-03).
-    "comments"
+    "comments",
+    // Feature 334 per-author comments-density (gated on capabilities.comments_metrics).
+    // Outer dict at rollup root; per-entry atomic per INV-2-08; absent entirely
+    // when capability-off (FR-3-03 + INV-2-09).
+    "by_author_comments"
   ]);
   var PR_RECORD_REQUIRED_FIELDS = [
     "id",
@@ -1742,6 +1746,126 @@ var PRInsightsArtifactClient = (() => {
     }
     return { errors };
   }
+  function validateAuthorCommentsDensity(data, path) {
+    const errors = [];
+    if (!isObject(data)) {
+      errors.push(createError(path, "object", getTypeName(data)));
+      return { errors };
+    }
+    const entries = Object.entries(
+      data
+    );
+    if (entries.length === 0) {
+      errors.push(
+        createError(
+          path,
+          "non-empty Record<string, AuthorCommentsDensityEntry>",
+          "{}",
+          `by_author_comments MUST be omitted entirely when no per-author buckets exist (FR-3-03 + INV-2-09); empty object is a contract violation`
+        )
+      );
+      return { errors };
+    }
+    const requiredFields = [
+      "thread_count",
+      "comment_count",
+      "active_thread_count",
+      "coverage_partial"
+    ];
+    for (const [key, entry] of entries) {
+      const entryPath = buildPath(path, key);
+      if (!isObject(entry)) {
+        errors.push(createError(entryPath, "object", getTypeName(entry)));
+        continue;
+      }
+      const missing = requiredFields.filter(
+        (field) => !Object.prototype.hasOwnProperty.call(entry, field)
+      );
+      if (missing.length > 0) {
+        errors.push(
+          createError(
+            entryPath,
+            "all four of thread_count / comment_count / active_thread_count / coverage_partial",
+            `missing: ${missing.join(", ")}`,
+            `by_author_comments[${key}] atomicity violated (INV-2-08): expected all four of thread_count / comment_count / active_thread_count / coverage_partial; missing: ${missing.join(", ")}`
+          )
+        );
+      }
+      const numericFieldChecks = [
+        { name: "thread_count", value: entry.thread_count },
+        { name: "comment_count", value: entry.comment_count },
+        { name: "active_thread_count", value: entry.active_thread_count }
+      ];
+      for (const { name, value } of numericFieldChecks) {
+        if (!Object.prototype.hasOwnProperty.call(entry, name)) {
+          continue;
+        }
+        if (value === null) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number (non-null per INV-2-08; zero is the valid sum over an empty extracted-subset)",
+              "null",
+              `by_author_comments[${key}].${name} MUST be a non-null number (INV-2-08); null is not a valid sentinel \u2014 use 0 for an empty extracted-subset`
+            )
+          );
+        } else if (!isNumber(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number",
+              getTypeName(value),
+              `expected number at 'by_author_comments[${key}].${name}', got ${getTypeName(value)}`
+            )
+          );
+        } else if (value < 0) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "non-negative number (counts cannot be negative)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be non-negative; got ${value}`
+            )
+          );
+        } else if (!Number.isInteger(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "integer (counts must be whole numbers)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be an integer; got ${value}`
+            )
+          );
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, "coverage_partial")) {
+        const coveragePartial = entry.coverage_partial;
+        if (!isBoolean(coveragePartial)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, "coverage_partial"),
+              "boolean",
+              getTypeName(coveragePartial),
+              `expected boolean at 'by_author_comments[${key}].coverage_partial', got ${getTypeName(coveragePartial)}`
+            )
+          );
+        }
+      }
+      const entryThread = entry.thread_count;
+      const entryActive = entry.active_thread_count;
+      if (isNumber(entryThread) && isNumber(entryActive) && Number.isInteger(entryThread) && Number.isInteger(entryActive) && entryThread >= 0 && entryActive >= 0 && entryActive > entryThread) {
+        errors.push(
+          createError(
+            buildPath(entryPath, "active_thread_count"),
+            "<= thread_count (INV-2-07; active is a subset of total)",
+            `${entryActive} > ${entryThread}`,
+            `by_author_comments[${key}] ordering violated (INV-2-07): active_thread_count (${entryActive}) MUST NOT exceed thread_count (${entryThread})`
+          )
+        );
+      }
+    }
+    return { errors };
+  }
   function validateRollup(data, strict) {
     const errors = [];
     const warnings = [];
@@ -1892,6 +2016,13 @@ var PRInsightsArtifactClient = (() => {
     if (Object.prototype.hasOwnProperty.call(data, "comments") && data.comments !== void 0) {
       const commentsResult = validateCommentsAggregate(data.comments, "comments");
       errors.push(...commentsResult.errors);
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "by_author_comments") && data.by_author_comments !== void 0) {
+      const byAuthorCommentsResult = validateAuthorCommentsDensity(
+        data.by_author_comments,
+        "by_author_comments"
+      );
+      errors.push(...byAuthorCommentsResult.errors);
     }
     const unknown = findUnknownFields(data, KNOWN_ROOT_FIELDS2, "", strict);
     errors.push(...unknown.errors);

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -8782,12 +8782,11 @@ var PRInsightsDashboard = (() => {
   function renderSortControls(activeMetric) {
     const buttons = COMMENTS_AUTHOR_DENSITY_SORT_METRICS.map((metric) => {
       const checked = metric === activeMetric;
-      const ariaChecked = checked ? "true" : "false";
-      const tabIndex = checked ? "0" : "-1";
+      const ariaPressed = checked ? "true" : "false";
       const label = metricLabel(metric);
-      return `<button type="button" class="comments-author-density-sort-btn${checked ? " is-active" : ""}" role="radio" aria-checked="${ariaChecked}" tabindex="${tabIndex}" data-sort-metric="${escapeHtml(metric)}">${escapeHtml(label)}</button>`;
+      return `<button type="button" class="comments-author-density-sort-btn${checked ? " is-active" : ""}" aria-pressed="${ariaPressed}" data-sort-metric="${escapeHtml(metric)}">${escapeHtml(label)}</button>`;
     }).join("");
-    return `<div class="comments-author-density-sort" role="radiogroup" aria-label="Sort author rows by metric">${buttons}</div>`;
+    return `<div class="comments-author-density-sort" role="toolbar" aria-label="Sort author rows by metric">${buttons}</div>`;
   }
   function renderTable(rows) {
     const rowsHtml = rows.map((row) => renderRow(row)).join("");

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -8665,6 +8665,53 @@ var PRInsightsDashboard = (() => {
     if (displayCmp !== 0) return displayCmp;
     return a2.authorKey < b2.authorKey ? -1 : 1;
   }
+  var sortMetricByContainer = /* @__PURE__ */ new WeakMap();
+  var sortListenerControllers = /* @__PURE__ */ new WeakMap();
+  function attachSortToggleListeners(container, rollups, options) {
+    sortListenerControllers.get(container)?.abort();
+    const controller = new AbortController();
+    sortListenerControllers.set(container, controller);
+    const { signal } = controller;
+    const resolveMetric = (raw) => {
+      return COMMENTS_AUTHOR_DENSITY_SORT_METRICS.find((m2) => m2 === raw);
+    };
+    const activate = (metric) => {
+      sortMetricByContainer.set(container, metric);
+      renderCommentsAuthorDensityChart(container, rollups, {
+        ...options,
+        sortMetric: metric
+      });
+    };
+    const findSortButton = (event) => {
+      const target = event.target;
+      return target.closest(".comments-author-density-sort-btn");
+    };
+    container.addEventListener(
+      "click",
+      (event) => {
+        const button = findSortButton(event);
+        if (!button) return;
+        const metric = resolveMetric(button.dataset.sortMetric);
+        if (!metric) return;
+        activate(metric);
+      },
+      { signal }
+    );
+    container.addEventListener(
+      "keydown",
+      (event) => {
+        const button = findSortButton(event);
+        if (!button) return;
+        const key = event.key;
+        if (key !== "Enter" && key !== " ") return;
+        const metric = resolveMetric(button.dataset.sortMetric);
+        if (!metric) return;
+        event.preventDefault();
+        activate(metric);
+      },
+      { signal }
+    );
+  }
   function renderCommentsAuthorDensityChart(container, rollups, options) {
     if (!container) return;
     if (options?.filters && hasActiveFilters2(options.filters)) {
@@ -8697,7 +8744,13 @@ var PRInsightsDashboard = (() => {
         coverage_partial: bucket.coverage_partial
       });
     }
-    const activeMetric = options?.sortMetric ?? "comment_count";
+    let activeMetric;
+    if (options?.sortMetric) {
+      activeMetric = options.sortMetric;
+      sortMetricByContainer.set(container, activeMetric);
+    } else {
+      activeMetric = sortMetricByContainer.get(container) ?? "comment_count";
+    }
     rows.sort((a2, b2) => compareRows(a2, b2, activeMetric));
     const truncated = rows.length > MAX_COMMENTS_AUTHOR_DENSITY_ROWS;
     const display = truncated ? rows.slice(0, MAX_COMMENTS_AUTHOR_DENSITY_ROWS) : rows;
@@ -8714,6 +8767,7 @@ var PRInsightsDashboard = (() => {
       container,
       `${truncationHtml}${sortControlsHtml}${tableHtml}${partialLegendHtml}`
     );
+    attachSortToggleListeners(container, rollups, options);
   }
   function metricLabel(metric) {
     switch (metric) {

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -8596,6 +8596,8 @@ var PRInsightsDashboard = (() => {
 
   // ../ui/modules/charts/comments-author-density.ts
   var MAX_COMMENTS_AUTHOR_DENSITY_ROWS = 50;
+  var FORMER_OR_UNAVAILABLE_AUTHOR_KEY = "__former_or_unavailable_author__";
+  var FORMER_OR_UNAVAILABLE_AUTHOR_LABEL = "Former / unavailable author";
   var COMMENTS_AUTHOR_DENSITY_SORT_METRICS = [
     "comment_count",
     "thread_count",
@@ -8640,6 +8642,9 @@ var PRInsightsDashboard = (() => {
     return map;
   }
   function resolveDisplayName(authorKey, directory) {
+    if (authorKey === FORMER_OR_UNAVAILABLE_AUTHOR_KEY) {
+      return FORMER_OR_UNAVAILABLE_AUTHOR_LABEL;
+    }
     if (directory) {
       const found = directory.get(authorKey);
       if (typeof found === "string" && found.length > 0) {

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -1312,7 +1312,11 @@ var PRInsightsDashboard = (() => {
     "_prs_cap",
     // Feature 333 weekly comments-aggregate (gated on capabilities.comments_metrics).
     // Atomic when present per INV-1-08; absent entirely when capability-off (FR-3-03).
-    "comments"
+    "comments",
+    // Feature 334 per-author comments-density (gated on capabilities.comments_metrics).
+    // Outer dict at rollup root; per-entry atomic per INV-2-08; absent entirely
+    // when capability-off (FR-3-03 + INV-2-09).
+    "by_author_comments"
   ]);
   var PR_RECORD_REQUIRED_FIELDS = [
     "id",
@@ -1724,6 +1728,126 @@ var PRInsightsDashboard = (() => {
     }
     return { errors };
   }
+  function validateAuthorCommentsDensity(data, path) {
+    const errors = [];
+    if (!isObject(data)) {
+      errors.push(createError(path, "object", getTypeName(data)));
+      return { errors };
+    }
+    const entries = Object.entries(
+      data
+    );
+    if (entries.length === 0) {
+      errors.push(
+        createError(
+          path,
+          "non-empty Record<string, AuthorCommentsDensityEntry>",
+          "{}",
+          `by_author_comments MUST be omitted entirely when no per-author buckets exist (FR-3-03 + INV-2-09); empty object is a contract violation`
+        )
+      );
+      return { errors };
+    }
+    const requiredFields = [
+      "thread_count",
+      "comment_count",
+      "active_thread_count",
+      "coverage_partial"
+    ];
+    for (const [key, entry] of entries) {
+      const entryPath = buildPath(path, key);
+      if (!isObject(entry)) {
+        errors.push(createError(entryPath, "object", getTypeName(entry)));
+        continue;
+      }
+      const missing = requiredFields.filter(
+        (field) => !Object.prototype.hasOwnProperty.call(entry, field)
+      );
+      if (missing.length > 0) {
+        errors.push(
+          createError(
+            entryPath,
+            "all four of thread_count / comment_count / active_thread_count / coverage_partial",
+            `missing: ${missing.join(", ")}`,
+            `by_author_comments[${key}] atomicity violated (INV-2-08): expected all four of thread_count / comment_count / active_thread_count / coverage_partial; missing: ${missing.join(", ")}`
+          )
+        );
+      }
+      const numericFieldChecks = [
+        { name: "thread_count", value: entry.thread_count },
+        { name: "comment_count", value: entry.comment_count },
+        { name: "active_thread_count", value: entry.active_thread_count }
+      ];
+      for (const { name, value } of numericFieldChecks) {
+        if (!Object.prototype.hasOwnProperty.call(entry, name)) {
+          continue;
+        }
+        if (value === null) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number (non-null per INV-2-08; zero is the valid sum over an empty extracted-subset)",
+              "null",
+              `by_author_comments[${key}].${name} MUST be a non-null number (INV-2-08); null is not a valid sentinel \u2014 use 0 for an empty extracted-subset`
+            )
+          );
+        } else if (!isNumber(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number",
+              getTypeName(value),
+              `expected number at 'by_author_comments[${key}].${name}', got ${getTypeName(value)}`
+            )
+          );
+        } else if (value < 0) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "non-negative number (counts cannot be negative)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be non-negative; got ${value}`
+            )
+          );
+        } else if (!Number.isInteger(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "integer (counts must be whole numbers)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be an integer; got ${value}`
+            )
+          );
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, "coverage_partial")) {
+        const coveragePartial = entry.coverage_partial;
+        if (!isBoolean(coveragePartial)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, "coverage_partial"),
+              "boolean",
+              getTypeName(coveragePartial),
+              `expected boolean at 'by_author_comments[${key}].coverage_partial', got ${getTypeName(coveragePartial)}`
+            )
+          );
+        }
+      }
+      const entryThread = entry.thread_count;
+      const entryActive = entry.active_thread_count;
+      if (isNumber(entryThread) && isNumber(entryActive) && Number.isInteger(entryThread) && Number.isInteger(entryActive) && entryThread >= 0 && entryActive >= 0 && entryActive > entryThread) {
+        errors.push(
+          createError(
+            buildPath(entryPath, "active_thread_count"),
+            "<= thread_count (INV-2-07; active is a subset of total)",
+            `${entryActive} > ${entryThread}`,
+            `by_author_comments[${key}] ordering violated (INV-2-07): active_thread_count (${entryActive}) MUST NOT exceed thread_count (${entryThread})`
+          )
+        );
+      }
+    }
+    return { errors };
+  }
   function validateRollup(data, strict) {
     const errors = [];
     const warnings = [];
@@ -1874,6 +1998,13 @@ var PRInsightsDashboard = (() => {
     if (Object.prototype.hasOwnProperty.call(data, "comments") && data.comments !== void 0) {
       const commentsResult = validateCommentsAggregate(data.comments, "comments");
       errors.push(...commentsResult.errors);
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "by_author_comments") && data.by_author_comments !== void 0) {
+      const byAuthorCommentsResult = validateAuthorCommentsDensity(
+        data.by_author_comments,
+        "by_author_comments"
+      );
+      errors.push(...byAuthorCommentsResult.errors);
     }
     const unknown = findUnknownFields(data, KNOWN_ROOT_FIELDS2, "", strict);
     errors.push(...unknown.errors);

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -6365,7 +6365,7 @@ var PRInsightsDashboard = (() => {
     const historicalPath = calculateLinePath(historicalPoints);
     const forecastPath = calculateLinePath(forecastPoints);
     const bandPath = calculateBandPath(upperPoints, lowerPoints);
-    const metricLabel = forecast.metric.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+    const metricLabel2 = forecast.metric.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
     const allWeeks = [];
     if (historicalData) {
       historicalData.forEach((h2) => allWeeks.push(h2.week));
@@ -6379,12 +6379,12 @@ var PRInsightsDashboard = (() => {
     }).join("");
     const latestValue = values[values.length - 1];
     const rangeClause = latestValue.lower_bound != null && latestValue.upper_bound != null ? ` (range ${latestValue.lower_bound.toFixed(1)} to ${latestValue.upper_bound.toFixed(1)})` : "";
-    const accessibleSummary = `${metricLabel} forecast: ${latestValue.predicted.toFixed(1)} ${forecast.unit}${rangeClause}`;
+    const accessibleSummary = `${metricLabel2} forecast: ${latestValue.predicted.toFixed(1)} ${forecast.unit}${rangeClause}`;
     const safeMetricId = sanitizeForId(forecast.metric);
     return `
-    <div class="forecast-chart" role="region" aria-label="${escapeHtml(metricLabel)} forecast">
+    <div class="forecast-chart" role="region" aria-label="${escapeHtml(metricLabel2)} forecast">
       <div class="chart-header">
-        <h4 id="chart-${safeMetricId}">${escapeHtml(metricLabel)}</h4>
+        <h4 id="chart-${safeMetricId}">${escapeHtml(metricLabel2)}</h4>
         <span class="chart-unit">(${escapeHtml(forecast.unit)})</span>
         ${wasTruncated ? `<span class="truncation-badge" title="Showing last ${MAX_CHART_POINTS} data points">Partial history</span>` : ""}
       </div>
@@ -6920,14 +6920,14 @@ var PRInsightsDashboard = (() => {
   }
   function renderInsightDataSection(data) {
     if (!data) return "";
-    const metricLabel = data.metric.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+    const metricLabel2 = data.metric.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
     const trendIcon = TREND_ICONS[data.trend_direction] || "";
     const trendClass = `trend-${data.trend_direction}`;
     const changeDisplay = data.change_percent !== void 0 ? `${data.change_percent > 0 ? "+" : ""}${data.change_percent.toFixed(1)}%` : "";
     return `
     <div class="insight-data-section">
       <div class="insight-metric">
-        <span class="metric-label">${escapeHtml(metricLabel)}</span>
+        <span class="metric-label">${escapeHtml(metricLabel2)}</span>
         <span class="metric-value">${escapeHtml(String(data.current_value))}</span>
         ${changeDisplay ? `<span class="metric-change ${trendClass}">${trendIcon} ${escapeHtml(changeDisplay)}</span>` : ""}
       </div>
@@ -8594,6 +8594,159 @@ var PRInsightsDashboard = (() => {
           ${partialNote}`;
   }
 
+  // ../ui/modules/charts/comments-author-density.ts
+  var MAX_COMMENTS_AUTHOR_DENSITY_ROWS = 50;
+  var COMMENTS_AUTHOR_DENSITY_SORT_METRICS = [
+    "comment_count",
+    "thread_count",
+    "active_thread_count"
+  ];
+  function hasByAuthorComments(rollup) {
+    const value = rollup.by_author_comments;
+    return value !== void 0 && value !== null && typeof value === "object";
+  }
+  function reducePerAuthor(rollups) {
+    const reduced = /* @__PURE__ */ new Map();
+    for (const rollup of rollups) {
+      for (const entry of Object.entries(rollup.by_author_comments)) {
+        const key = entry[0];
+        const bucket = entry[1];
+        const existing = reduced.get(key);
+        if (existing) {
+          existing.thread_count += bucket.thread_count;
+          existing.comment_count += bucket.comment_count;
+          existing.active_thread_count += bucket.active_thread_count;
+          existing.coverage_partial = existing.coverage_partial || bucket.coverage_partial;
+        } else {
+          reduced.set(key, {
+            thread_count: bucket.thread_count,
+            comment_count: bucket.comment_count,
+            active_thread_count: bucket.active_thread_count,
+            coverage_partial: bucket.coverage_partial
+          });
+        }
+      }
+    }
+    return reduced;
+  }
+  function buildAuthorsDirectory(authorsDimension) {
+    if (!authorsDimension) return null;
+    const map = /* @__PURE__ */ new Map();
+    for (const entry of authorsDimension) {
+      if (typeof entry.author_id === "string" && typeof entry.author_name === "string") {
+        map.set(entry.author_id, entry.author_name);
+      }
+    }
+    return map;
+  }
+  function resolveDisplayName(authorKey, directory) {
+    if (directory) {
+      const found = directory.get(authorKey);
+      if (typeof found === "string" && found.length > 0) {
+        return found;
+      }
+    }
+    return authorKey;
+  }
+  function metricValue(row, metric) {
+    switch (metric) {
+      case "comment_count":
+        return row.comment_count;
+      case "thread_count":
+        return row.thread_count;
+      case "active_thread_count":
+        return row.active_thread_count;
+    }
+  }
+  function compareRows(a2, b2, metric) {
+    const primary = metricValue(b2, metric) - metricValue(a2, metric);
+    if (primary !== 0) return primary;
+    const displayCmp = a2.displayName.localeCompare(b2.displayName);
+    if (displayCmp !== 0) return displayCmp;
+    return a2.authorKey < b2.authorKey ? -1 : 1;
+  }
+  function renderCommentsAuthorDensityChart(container, rollups, options) {
+    if (!container) return;
+    if (options?.filters && hasActiveFilters2(options.filters)) {
+      renderNoData(
+        container,
+        "Comments density is not yet filterable",
+        "Clear repo / team / author / reviewer filters to view per-author review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+      );
+      return;
+    }
+    const withByAuthor = rollups.filter(hasByAuthorComments);
+    const reduced = reducePerAuthor(withByAuthor);
+    if (reduced.size === 0) {
+      renderNoData(
+        container,
+        "No comments data for selected range",
+        "Try widening the date range, or confirm comments extraction is enabled for this dataset."
+      );
+      return;
+    }
+    const directory = buildAuthorsDirectory(options?.authorsDimension);
+    const rows = [];
+    for (const [key, bucket] of reduced) {
+      rows.push({
+        authorKey: key,
+        displayName: resolveDisplayName(key, directory),
+        thread_count: bucket.thread_count,
+        comment_count: bucket.comment_count,
+        active_thread_count: bucket.active_thread_count,
+        coverage_partial: bucket.coverage_partial
+      });
+    }
+    const activeMetric = options?.sortMetric ?? "comment_count";
+    rows.sort((a2, b2) => compareRows(a2, b2, activeMetric));
+    const truncated = rows.length > MAX_COMMENTS_AUTHOR_DENSITY_ROWS;
+    const display = truncated ? rows.slice(0, MAX_COMMENTS_AUTHOR_DENSITY_ROWS) : rows;
+    const truncationHtml = renderTruncationIndicator(
+      truncated,
+      MAX_COMMENTS_AUTHOR_DENSITY_ROWS,
+      "authors"
+    );
+    const sortControlsHtml = renderSortControls(activeMetric);
+    const tableHtml = renderTable(display);
+    const anyPartial = display.some((r2) => r2.coverage_partial);
+    const partialLegendHtml = anyPartial ? `<div class="chart-legend"><div class="legend-item legend-coverage-partial-item"><span class="legend-bar legend-bar-coverage-partial"></span><span>Partial coverage</span></div></div>` : "";
+    renderTrustedHtml(
+      container,
+      `${truncationHtml}${sortControlsHtml}${tableHtml}${partialLegendHtml}`
+    );
+  }
+  function metricLabel(metric) {
+    switch (metric) {
+      case "comment_count":
+        return "Comments";
+      case "thread_count":
+        return "Threads";
+      case "active_thread_count":
+        return "Active threads";
+    }
+  }
+  function renderSortControls(activeMetric) {
+    const buttons = COMMENTS_AUTHOR_DENSITY_SORT_METRICS.map((metric) => {
+      const checked = metric === activeMetric;
+      const ariaChecked = checked ? "true" : "false";
+      const tabIndex = checked ? "0" : "-1";
+      const label = metricLabel(metric);
+      return `<button type="button" class="comments-author-density-sort-btn${checked ? " is-active" : ""}" role="radio" aria-checked="${ariaChecked}" tabindex="${tabIndex}" data-sort-metric="${escapeHtml(metric)}">${escapeHtml(label)}</button>`;
+    }).join("");
+    return `<div class="comments-author-density-sort" role="radiogroup" aria-label="Sort author rows by metric">${buttons}</div>`;
+  }
+  function renderTable(rows) {
+    const rowsHtml = rows.map((row) => renderRow(row)).join("");
+    return `<div class="comments-author-density-table" role="table" aria-label="Per-author comment density"><div class="comments-author-density-thead" role="row"><div role="columnheader">Author</div><div role="columnheader" class="comments-author-density-numeric">Threads</div><div role="columnheader" class="comments-author-density-numeric">Active threads</div><div role="columnheader" class="comments-author-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+  }
+  function renderRow(row) {
+    const partialClass = row.coverage_partial ? " coverage-partial" : "";
+    const partialAttr = row.coverage_partial ? ' data-coverage-partial="true"' : "";
+    const partialNote = row.coverage_partial ? " (partial coverage)" : "";
+    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
+    return `<div class="comments-author-density-row${partialClass}" role="row" data-author-key="${escapeHtml(row.authorKey)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-author-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+  }
+
   // ../ui/modules/filter-constraint-resolver.ts
   function resolveFilterConstraints(raw, lastChanged) {
     const notices = [];
@@ -9281,7 +9434,7 @@ var PRInsightsDashboard = (() => {
   window.addEventListener(COMPARISON_TOGGLED_EVENT, comparisonListener);
 
   // ../ui/modules/shared/identity-fallback.ts
-  function resolveDisplayName(id, map) {
+  function resolveDisplayName2(id, map) {
     const mapped = map.get(id);
     return mapped !== void 0 ? mapped : id;
   }
@@ -9320,7 +9473,7 @@ var PRInsightsDashboard = (() => {
       return makeEmptyState(title, emptyDetail);
     }
     const rows = Object.entries(entries).sort((a2, b2) => b2[1].pr_count - a2[1].pr_count).map(([key, entry]) => ({
-      label: nameByKey ? resolveDisplayName(key, nameByKey) : key,
+      label: nameByKey ? resolveDisplayName2(key, nameByKey) : key,
       values: [String(entry.pr_count)]
     }));
     return makeBreakdownTable(title, columns, rows);
@@ -9705,7 +9858,7 @@ var PRInsightsDashboard = (() => {
   function buildPanelContent3(rollups, reviewerId, reviewerNameByKey) {
     const stats = buildStatRow(rollups, reviewerId);
     const subtitle = `${stats.totalPrs} ${stats.totalPrs === 1 ? "PR" : "PRs"} reviewed`;
-    const displayName = resolveDisplayName(reviewerId, reviewerNameByKey);
+    const displayName = resolveDisplayName2(reviewerId, reviewerNameByKey);
     return makePanelContent(displayName, subtitle, [
       stats.section,
       buildWeeklyTable(rollups, reviewerId)
@@ -10493,6 +10646,17 @@ var PRInsightsDashboard = (() => {
       } else {
         removeCommentsTrendContainer();
       }
+      if (loader?.getCapabilityState?.()?.commentsMetricsAvailable === true) {
+        const cadContainer = ensureCommentsAuthorDensityContainer();
+        if (cadContainer) {
+          renderCommentsAuthorDensityChart(cadContainer, rollups, {
+            filters: currentFilters,
+            authorsDimension: currentDimensions?.authors
+          });
+        }
+      } else {
+        removeCommentsAuthorDensityContainer();
+      }
       const throughputContainer = document.getElementById("throughput-chart");
       if (throughputContainer) {
         activeDrilldownHandles.push(
@@ -10719,7 +10883,7 @@ var PRInsightsDashboard = (() => {
         r2.reviewer_name
       ])
     );
-    const filterReviewerName = filterReviewerId !== void 0 ? resolveDisplayName(filterReviewerId, reviewerNameByKey) : void 0;
+    const filterReviewerName = filterReviewerId !== void 0 ? resolveDisplayName2(filterReviewerId, reviewerNameByKey) : void 0;
     renderReviewerActivity(
       elements.get("reviewer-activity") ?? null,
       rollups,
@@ -10762,6 +10926,41 @@ var PRInsightsDashboard = (() => {
     if (heading instanceof HTMLElement) {
       detachCommentsTrendInfoIcon(heading);
     }
+    row.parentElement?.removeChild(row);
+  }
+  function ensureCommentsAuthorDensityContainer() {
+    const existing = document.getElementById("comments-author-density");
+    if (existing) return existing;
+    const commentsTrendRow = document.querySelector(
+      '[data-comments-trend-row="true"]'
+    );
+    let anchorRow = commentsTrendRow;
+    if (!anchorRow) {
+      const cycleDist = document.getElementById("cycle-distribution");
+      anchorRow = cycleDist?.closest(".charts-row") ?? null;
+    }
+    if (!anchorRow || !anchorRow.parentElement) return null;
+    const row = document.createElement("div");
+    row.className = "charts-row";
+    row.setAttribute("data-comments-author-density-row", "true");
+    const containerCell = document.createElement("div");
+    containerCell.className = "chart-container";
+    const heading = document.createElement("h3");
+    heading.textContent = "Comment Density by Author";
+    containerCell.appendChild(heading);
+    const chart = document.createElement("div");
+    chart.id = "comments-author-density";
+    chart.className = "chart";
+    containerCell.appendChild(chart);
+    row.appendChild(containerCell);
+    anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+    return chart;
+  }
+  function removeCommentsAuthorDensityContainer() {
+    const row = document.querySelector(
+      '[data-comments-author-density-row="true"]'
+    );
+    if (!row) return;
     row.parentElement?.removeChild(row);
   }
   function toArtifactLoadResult(loaderResult, artifactPath) {

--- a/extension/tests/fixtures/broken-docs/dataset-loader.js
+++ b/extension/tests/fixtures/broken-docs/dataset-loader.js
@@ -1337,7 +1337,11 @@ var PRInsightsDatasetLoader = (() => {
     "_prs_cap",
     // Feature 333 weekly comments-aggregate (gated on capabilities.comments_metrics).
     // Atomic when present per INV-1-08; absent entirely when capability-off (FR-3-03).
-    "comments"
+    "comments",
+    // Feature 334 per-author comments-density (gated on capabilities.comments_metrics).
+    // Outer dict at rollup root; per-entry atomic per INV-2-08; absent entirely
+    // when capability-off (FR-3-03 + INV-2-09).
+    "by_author_comments"
   ]);
   var PR_RECORD_REQUIRED_FIELDS = [
     "id",
@@ -1749,6 +1753,126 @@ var PRInsightsDatasetLoader = (() => {
     }
     return { errors };
   }
+  function validateAuthorCommentsDensity(data, path) {
+    const errors = [];
+    if (!isObject(data)) {
+      errors.push(createError(path, "object", getTypeName(data)));
+      return { errors };
+    }
+    const entries = Object.entries(
+      data
+    );
+    if (entries.length === 0) {
+      errors.push(
+        createError(
+          path,
+          "non-empty Record<string, AuthorCommentsDensityEntry>",
+          "{}",
+          `by_author_comments MUST be omitted entirely when no per-author buckets exist (FR-3-03 + INV-2-09); empty object is a contract violation`
+        )
+      );
+      return { errors };
+    }
+    const requiredFields = [
+      "thread_count",
+      "comment_count",
+      "active_thread_count",
+      "coverage_partial"
+    ];
+    for (const [key, entry] of entries) {
+      const entryPath = buildPath(path, key);
+      if (!isObject(entry)) {
+        errors.push(createError(entryPath, "object", getTypeName(entry)));
+        continue;
+      }
+      const missing = requiredFields.filter(
+        (field) => !Object.prototype.hasOwnProperty.call(entry, field)
+      );
+      if (missing.length > 0) {
+        errors.push(
+          createError(
+            entryPath,
+            "all four of thread_count / comment_count / active_thread_count / coverage_partial",
+            `missing: ${missing.join(", ")}`,
+            `by_author_comments[${key}] atomicity violated (INV-2-08): expected all four of thread_count / comment_count / active_thread_count / coverage_partial; missing: ${missing.join(", ")}`
+          )
+        );
+      }
+      const numericFieldChecks = [
+        { name: "thread_count", value: entry.thread_count },
+        { name: "comment_count", value: entry.comment_count },
+        { name: "active_thread_count", value: entry.active_thread_count }
+      ];
+      for (const { name, value } of numericFieldChecks) {
+        if (!Object.prototype.hasOwnProperty.call(entry, name)) {
+          continue;
+        }
+        if (value === null) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number (non-null per INV-2-08; zero is the valid sum over an empty extracted-subset)",
+              "null",
+              `by_author_comments[${key}].${name} MUST be a non-null number (INV-2-08); null is not a valid sentinel \u2014 use 0 for an empty extracted-subset`
+            )
+          );
+        } else if (!isNumber(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number",
+              getTypeName(value),
+              `expected number at 'by_author_comments[${key}].${name}', got ${getTypeName(value)}`
+            )
+          );
+        } else if (value < 0) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "non-negative number (counts cannot be negative)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be non-negative; got ${value}`
+            )
+          );
+        } else if (!Number.isInteger(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "integer (counts must be whole numbers)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be an integer; got ${value}`
+            )
+          );
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, "coverage_partial")) {
+        const coveragePartial = entry.coverage_partial;
+        if (!isBoolean(coveragePartial)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, "coverage_partial"),
+              "boolean",
+              getTypeName(coveragePartial),
+              `expected boolean at 'by_author_comments[${key}].coverage_partial', got ${getTypeName(coveragePartial)}`
+            )
+          );
+        }
+      }
+      const entryThread = entry.thread_count;
+      const entryActive = entry.active_thread_count;
+      if (isNumber(entryThread) && isNumber(entryActive) && Number.isInteger(entryThread) && Number.isInteger(entryActive) && entryThread >= 0 && entryActive >= 0 && entryActive > entryThread) {
+        errors.push(
+          createError(
+            buildPath(entryPath, "active_thread_count"),
+            "<= thread_count (INV-2-07; active is a subset of total)",
+            `${entryActive} > ${entryThread}`,
+            `by_author_comments[${key}] ordering violated (INV-2-07): active_thread_count (${entryActive}) MUST NOT exceed thread_count (${entryThread})`
+          )
+        );
+      }
+    }
+    return { errors };
+  }
   function validateRollup(data, strict) {
     const errors = [];
     const warnings = [];
@@ -1899,6 +2023,13 @@ var PRInsightsDatasetLoader = (() => {
     if (Object.prototype.hasOwnProperty.call(data, "comments") && data.comments !== void 0) {
       const commentsResult = validateCommentsAggregate(data.comments, "comments");
       errors.push(...commentsResult.errors);
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "by_author_comments") && data.by_author_comments !== void 0) {
+      const byAuthorCommentsResult = validateAuthorCommentsDensity(
+        data.by_author_comments,
+        "by_author_comments"
+      );
+      errors.push(...byAuthorCommentsResult.errors);
     }
     const unknown = findUnknownFields(data, KNOWN_ROOT_FIELDS2, "", strict);
     errors.push(...unknown.errors);

--- a/extension/tests/fixtures/broken-docs/styles.css
+++ b/extension/tests/fixtures/broken-docs/styles.css
@@ -3839,3 +3839,91 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
         transparent 5px
     );
 }
+
+/* =====================================================================
+ * Feature 334: per-author comments-density chart
+ * Row-table layout (one row per author) with a 3-button radio-group
+ * sort selector, top-50 cap, and a per-row partial-coverage qualifier
+ * mirroring the 333 .coverage-partial CSS class hook.
+ * ===================================================================*/
+.comments-author-density-sort {
+    display: flex;
+    gap: 0.5rem;
+    margin: 0.5rem 0 0.75rem 0;
+    flex-wrap: wrap;
+}
+
+.comments-author-density-sort-btn {
+    border: 1px solid var(--border-color, #d0d7de);
+    background: var(--bg-secondary, #f6f8fa);
+    color: var(--text-primary, inherit);
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    line-height: 1.4;
+}
+
+.comments-author-density-sort-btn:focus-visible {
+    outline: 2px solid var(--primary, #0969da);
+    outline-offset: 2px;
+}
+
+.comments-author-density-sort-btn.is-active {
+    background: var(--primary, #0969da);
+    color: var(--bg-primary, #ffffff);
+    border-color: var(--primary, #0969da);
+}
+
+.comments-author-density-table {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
+    column-gap: 1rem;
+    row-gap: 0.125rem;
+    align-items: center;
+}
+
+.comments-author-density-thead,
+.comments-author-density-row {
+    display: contents;
+}
+
+.comments-author-density-thead > [role="columnheader"] {
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary, #57606a);
+    padding: 0.25rem 0;
+    border-bottom: 1px solid var(--border-color, #d0d7de);
+}
+
+.comments-author-density-row > [role="cell"] {
+    padding: 0.25rem 0;
+    font-size: 0.9375rem;
+}
+
+.comments-author-density-row .comments-author-density-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.comments-author-density-numeric {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
+/* Partial-coverage qualifier on rows whose reduced coverage_partial=true
+ * (FR-4-03).  Shares the .coverage-partial class hook with 333 so the
+ * convention stays visually consistent across the two surfaces. */
+.comments-author-density-row.coverage-partial > [role="cell"] {
+    color: var(--text-tertiary, #6e7781);
+    background-image: repeating-linear-gradient(
+        45deg,
+        rgba(110, 119, 129, 0.08) 0,
+        rgba(110, 119, 129, 0.08) 4px,
+        transparent 4px,
+        transparent 8px
+    );
+}

--- a/extension/tests/modules/charts/comments-author-density.test.ts
+++ b/extension/tests/modules/charts/comments-author-density.test.ts
@@ -832,6 +832,126 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
     expect(orderedAfter[0]).toBe(SENTINEL_KEY);
   });
 
+  // ===========================================================================
+  // US5 (T031): filter-not-supported posture (FR-4-07).  When ANY of the
+  // dashboard's per-PR dimension filters (repos / teams / authors /
+  // reviewers) is active, the chart MUST render a self-explanatory
+  // empty state instead of rows AND the empty state MUST be visibly
+  // distinct from the no-data-in-range empty state (FR-4-08).
+  // The short-circuit logic ships in US1 (T021); these tests gate
+  // the contract surface that future renders must keep honoring.
+  // ===========================================================================
+
+  it("(T031-a) any active dimension filter triggers the filter-not-supported empty state", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a) => {
+      buckets[a.author_id] = makeBucket(1, 5, 0);
+    });
+    const rollups = [makeRollup(0, buckets)];
+
+    // Each of the four dimension axes individually triggers the
+    // filter-not-supported empty state (full FR-1-07 parity from 333).
+    const axes: (keyof FilterState)[] = [
+      "repos",
+      "teams",
+      "authors",
+      "reviewers",
+    ];
+    for (const axis of axes) {
+      const filters: FilterState = { ...emptyFilters(), [axis]: ["x"] };
+      // Re-mount a fresh container so each axis is observed in isolation
+      // (avoids state leak via the per-container sortMetric WeakMap).
+      const fresh = document.createElement("div");
+      document.body.appendChild(fresh);
+      renderCommentsAuthorDensityChart(fresh, rollups, {
+        filters,
+        authorsDimension: authors,
+      });
+      expect(
+        fresh.querySelectorAll(".comments-author-density-row").length,
+      ).toBe(0);
+      expect(fresh.textContent ?? "").toContain("filterable");
+      fresh.remove();
+    }
+  });
+
+  it("(T031-b) clearing the dimension filter restores the rendered rows", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a, i) => {
+      buckets[a.author_id] = makeBucket(2, 50 - i, 1);
+    });
+    const rollups = [makeRollup(0, buckets)];
+    const repoFilter: FilterState = {
+      ...emptyFilters(),
+      repos: ["repo-a"],
+    };
+
+    // Step 1: filter active → no rows, filter-not-supported text present.
+    renderCommentsAuthorDensityChart(container, rollups, {
+      filters: repoFilter,
+      authorsDimension: authors,
+    });
+    expect(
+      container.querySelectorAll(".comments-author-density-row").length,
+    ).toBe(0);
+    expect(container.textContent ?? "").toContain("filterable");
+
+    // Step 2: filter cleared → rows restored, filter-not-supported text gone.
+    renderCommentsAuthorDensityChart(container, rollups, {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+    expect(
+      container.querySelectorAll(".comments-author-density-row").length,
+    ).toBe(3);
+    expect(container.textContent ?? "").not.toContain("filterable");
+  });
+
+  it("(T031-c) filter-not-supported empty state is visibly distinct from no-data-in-range", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a) => {
+      buckets[a.author_id] = makeBucket(1, 5, 0);
+    });
+    const rollups = [makeRollup(0, buckets)];
+
+    // Filter-not-supported empty state.
+    renderCommentsAuthorDensityChart(container, rollups, {
+      filters: { ...emptyFilters(), repos: ["repo-a"] },
+      authorsDimension: authors,
+    });
+    const filterText = container.textContent ?? "";
+
+    // No-data-in-range empty state (rollups carry NO by_author_comments,
+    // so the reduce yields an empty Map and the chart short-circuits to
+    // the no-data branch instead of the filter-not-supported branch).
+    const fresh = document.createElement("div");
+    document.body.appendChild(fresh);
+    renderCommentsAuthorDensityChart(
+      fresh,
+      [makeRollup(0, undefined), makeRollup(1, undefined)],
+      { filters: emptyFilters(), authorsDimension: authors },
+    );
+    const noDataText = fresh.textContent ?? "";
+
+    // Distinct message text — neither phrase appears in the other state.
+    expect(filterText).toContain("filterable");
+    expect(filterText).not.toContain("No comments data");
+    expect(noDataText).toContain("No comments data");
+    expect(noDataText).not.toContain("filterable");
+
+    // Both empty states omit the rows table entirely (no DOM bleed-over).
+    expect(
+      container.querySelectorAll(".comments-author-density-row").length,
+    ).toBe(0);
+    expect(fresh.querySelectorAll(".comments-author-density-row").length).toBe(
+      0,
+    );
+    fresh.remove();
+  });
+
   it("(T028-c) dataset with zero unknown-to-users PRs in range emits NO sentinel row", () => {
     const authors = buildAuthorsDimension(3);
     const buckets: Record<string, AuthorBucket> = {};

--- a/extension/tests/modules/charts/comments-author-density.test.ts
+++ b/extension/tests/modules/charts/comments-author-density.test.ts
@@ -20,7 +20,8 @@
  *       and no click handler attached by the chart module.
  *   (g) FR-4-10 a11y: rows expose metrics via screen-reader-readable
  *       aria-label; sort-selector buttons are wired into a WAI-ARIA
- *       radio-group (role="radio" + aria-checked + tabindex).
+ *       toolbar (role="toolbar" + aria-pressed; each <button> is
+ *       independently Tab-reachable).
  *   (h) Chart-layer idempotency: rendering twice on the same container
  *       produces ONE chart, not two — content replaced via the
  *       throughput / 333-style renderTrustedHtml pattern.
@@ -287,20 +288,25 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
       authorsDimension: authors,
     });
 
-    const radioGroup = container.querySelector(
-      '.comments-author-density-sort[role="radiogroup"]',
+    const toolbar = container.querySelector(
+      '.comments-author-density-sort[role="toolbar"]',
     );
-    expect(radioGroup).not.toBeNull();
+    expect(toolbar).not.toBeNull();
     const buttons = container.querySelectorAll<HTMLButtonElement>(
-      '.comments-author-density-sort-btn[role="radio"]',
+      ".comments-author-density-sort-btn",
     );
     expect(buttons).toHaveLength(3);
+    // Toolbar pattern: every button is independently Tab-reachable
+    // (default <button> tabindex=0, no explicit tabindex attribute).
+    buttons.forEach((btn) => {
+      expect(btn.tagName).toBe("BUTTON");
+      expect(btn.hasAttribute("tabindex")).toBe(false);
+    });
     const checked = container.querySelectorAll(
-      '.comments-author-density-sort-btn[aria-checked="true"]',
+      '.comments-author-density-sort-btn[aria-pressed="true"]',
     );
     expect(checked).toHaveLength(1);
     expect(checked[0]?.getAttribute("data-sort-metric")).toBe("comment_count");
-    expect(checked[0]?.getAttribute("tabindex")).toBe("0");
 
     // Rows carry an aria-label that includes all 3 metric values.
     const firstRow = container.querySelector<HTMLElement>(
@@ -448,7 +454,7 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
     expect(orderedKeys?.[1]).toBe(authors[2]!.author_id); // 20 threads
     expect(orderedKeys?.[2]).toBe(authors[0]!.author_id); // 1 thread
     const checked = container.querySelector(
-      '.comments-author-density-sort-btn[aria-checked="true"]',
+      '.comments-author-density-sort-btn[aria-pressed="true"]',
     );
     expect(checked?.getAttribute("data-sort-metric")).toBe("thread_count");
   });
@@ -493,16 +499,16 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
     expect(tables).toHaveLength(1);
     const rows = container.querySelectorAll(".comments-author-density-row");
     expect(rows).toHaveLength(5);
-    const radioGroups = container.querySelectorAll(
-      '.comments-author-density-sort[role="radiogroup"]',
+    const toolbars = container.querySelectorAll(
+      '.comments-author-density-sort[role="toolbar"]',
     );
-    expect(radioGroups).toHaveLength(1);
+    expect(toolbars).toHaveLength(1);
   });
 
   // ===========================================================================
   // US2 (T025): sort-toggle behaviour — clicking a button or activating it
   // via Enter/Space re-orders the rows by the new metric and updates the
-  // aria-checked indicator.  Tie-break determinism (display name asc →
+  // aria-pressed indicator.  Tie-break determinism (display name asc →
   // author key asc) is reproducible across re-renders.
   // ===========================================================================
 
@@ -517,7 +523,7 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
     return btn;
   }
 
-  it("(T025-a) clicking the thread_count button re-orders rows and updates aria-checked", () => {
+  it("(T025-a) clicking the thread_count button re-orders rows and updates aria-pressed", () => {
     const authors = buildAuthorsDimension(3);
     // thread_count and comment_count rank authors differently so the
     // re-order is unambiguously visible.
@@ -542,10 +548,11 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
       authors[0]!.author_id,
     ]);
     const checked = container.querySelector(
-      '.comments-author-density-sort-btn[aria-checked="true"]',
+      '.comments-author-density-sort-btn[aria-pressed="true"]',
     );
     expect(checked?.getAttribute("data-sort-metric")).toBe("thread_count");
-    expect(checked?.getAttribute("tabindex")).toBe("0");
+    // Toolbar pattern: <button> default tabindex=0; no explicit attribute.
+    expect(checked?.hasAttribute("tabindex")).toBe(false);
   });
 
   it("(T025-b) clicking the active_thread_count button re-orders rows by active-thread desc", () => {
@@ -645,7 +652,7 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
     ).map((r) => r.getAttribute("data-author-key"));
     expect(after).toEqual(before);
     const checked = container.querySelector(
-      '.comments-author-density-sort-btn[aria-checked="true"]',
+      '.comments-author-density-sort-btn[aria-pressed="true"]',
     );
     expect(checked?.getAttribute("data-sort-metric")).toBe("comment_count");
   });
@@ -668,7 +675,7 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
       new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
     );
     const checked = container.querySelector(
-      '.comments-author-density-sort-btn[aria-checked="true"]',
+      '.comments-author-density-sort-btn[aria-pressed="true"]',
     );
     expect(checked?.getAttribute("data-sort-metric")).toBe("comment_count");
   });
@@ -698,7 +705,7 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
     );
 
     const checked = container.querySelector(
-      '.comments-author-density-sort-btn[aria-checked="true"]',
+      '.comments-author-density-sort-btn[aria-pressed="true"]',
     );
     expect(checked?.getAttribute("data-sort-metric")).toBe("comment_count");
   });
@@ -731,7 +738,7 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
     ).map((r) => r.getAttribute("data-author-key"));
     expect(after).toEqual(before);
     const checked = container.querySelector(
-      '.comments-author-density-sort-btn[aria-checked="true"]',
+      '.comments-author-density-sort-btn[aria-pressed="true"]',
     );
     expect(checked?.getAttribute("data-sort-metric")).toBe("comment_count");
   });

--- a/extension/tests/modules/charts/comments-author-density.test.ts
+++ b/extension/tests/modules/charts/comments-author-density.test.ts
@@ -498,4 +498,278 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
     );
     expect(radioGroups).toHaveLength(1);
   });
+
+  // ===========================================================================
+  // US2 (T025): sort-toggle behaviour — clicking a button or activating it
+  // via Enter/Space re-orders the rows by the new metric and updates the
+  // aria-checked indicator.  Tie-break determinism (display name asc →
+  // author key asc) is reproducible across re-renders.
+  // ===========================================================================
+
+  function clickSortButton(metric: string): HTMLButtonElement {
+    const btn = container.querySelector<HTMLButtonElement>(
+      `.comments-author-density-sort-btn[data-sort-metric="${metric}"]`,
+    );
+    if (!btn) {
+      throw new Error(`sort button for metric ${metric} not found`);
+    }
+    btn.click();
+    return btn;
+  }
+
+  it("(T025-a) clicking the thread_count button re-orders rows and updates aria-checked", () => {
+    const authors = buildAuthorsDimension(3);
+    // thread_count and comment_count rank authors differently so the
+    // re-order is unambiguously visible.
+    const buckets: Record<string, AuthorBucket> = {
+      [authors[0]!.author_id]: makeBucket(1, 100, 0),
+      [authors[1]!.author_id]: makeBucket(50, 1, 25),
+      [authors[2]!.author_id]: makeBucket(20, 50, 10),
+    };
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+
+    clickSortButton("thread_count");
+
+    const orderedKeys = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(orderedKeys).toEqual([
+      authors[1]!.author_id,
+      authors[2]!.author_id,
+      authors[0]!.author_id,
+    ]);
+    const checked = container.querySelector(
+      '.comments-author-density-sort-btn[aria-checked="true"]',
+    );
+    expect(checked?.getAttribute("data-sort-metric")).toBe("thread_count");
+    expect(checked?.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("(T025-b) clicking the active_thread_count button re-orders rows by active-thread desc", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {
+      [authors[0]!.author_id]: makeBucket(10, 50, 1),
+      [authors[1]!.author_id]: makeBucket(10, 50, 8),
+      [authors[2]!.author_id]: makeBucket(10, 50, 4),
+    };
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+
+    clickSortButton("active_thread_count");
+
+    const orderedKeys = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(orderedKeys).toEqual([
+      authors[1]!.author_id,
+      authors[2]!.author_id,
+      authors[0]!.author_id,
+    ]);
+  });
+
+  it("(T025-c) tie-break is reproducible — duplicate display names + duplicate metric tie ⇒ author key asc", () => {
+    // Five authors all named "Alice" with the same comment_count — every
+    // pair hits the final author-key tie-break.  Re-running the same
+    // render call MUST produce the identical row order.
+    const authors = [
+      { author_id: "user-eee", author_name: "Alice" },
+      { author_id: "user-bbb", author_name: "Alice" },
+      { author_id: "user-aaa", author_name: "Alice" },
+      { author_id: "user-ddd", author_name: "Alice" },
+      { author_id: "user-ccc", author_name: "Alice" },
+    ];
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a) => {
+      buckets[a.author_id] = makeBucket(1, 7, 0);
+    });
+    const expected = [
+      "user-aaa",
+      "user-bbb",
+      "user-ccc",
+      "user-ddd",
+      "user-eee",
+    ];
+
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+    const firstOrder = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(firstOrder).toEqual(expected);
+
+    // Simulate a "page reload" by clearing the container and re-rendering
+    // with a fresh container element (drops the prior state in the
+    // sortMetricByContainer WeakMap so the default ordering applies).
+    container.remove();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+    const secondOrder = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(secondOrder).toEqual(expected);
+  });
+
+  it("ignores click events that do not land on a sort button (delegated click handler)", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a, i) => {
+      buckets[a.author_id] = makeBucket(2, 100 - i, 1);
+    });
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+    const before = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+
+    // Click on the row table area (NOT a sort button) — handler should
+    // resolve closest() to null and short-circuit.
+    const firstRow = container.querySelector<HTMLElement>(
+      ".comments-author-density-row",
+    );
+    firstRow?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    const after = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(after).toEqual(before);
+    const checked = container.querySelector(
+      '.comments-author-density-sort-btn[aria-checked="true"]',
+    );
+    expect(checked?.getAttribute("data-sort-metric")).toBe("comment_count");
+  });
+
+  it("ignores keydown events that do not land on a sort button (delegated keydown handler)", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a, i) => {
+      buckets[a.author_id] = makeBucket(2, 100 - i, 1);
+    });
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+    const firstRow = container.querySelector<HTMLElement>(
+      ".comments-author-density-row",
+    );
+    // Enter on a row (not a sort button) — short-circuits via closest()===null.
+    firstRow?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    const checked = container.querySelector(
+      '.comments-author-density-sort-btn[aria-checked="true"]',
+    );
+    expect(checked?.getAttribute("data-sort-metric")).toBe("comment_count");
+  });
+
+  it("ignores click + keydown when data-sort-metric is mutated to an unknown metric", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a, i) => {
+      buckets[a.author_id] = makeBucket(2, 100 - i, 1);
+    });
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+
+    // Mutate the thread_count button's metric attribute to a value that is
+    // NOT in COMMENTS_AUTHOR_DENSITY_SORT_METRICS.  Click + Enter must
+    // both resolve metric=undefined and short-circuit without re-rendering.
+    const threadBtn = container.querySelector<HTMLButtonElement>(
+      '.comments-author-density-sort-btn[data-sort-metric="thread_count"]',
+    );
+    threadBtn!.setAttribute("data-sort-metric", "bogus_metric");
+
+    threadBtn?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    threadBtn?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+
+    const checked = container.querySelector(
+      '.comments-author-density-sort-btn[aria-checked="true"]',
+    );
+    expect(checked?.getAttribute("data-sort-metric")).toBe("comment_count");
+  });
+
+  it("ignores keys other than Enter/Space on a focused sort button (covers the keydown false branch)", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {
+      [authors[0]!.author_id]: makeBucket(1, 100, 0),
+      [authors[1]!.author_id]: makeBucket(50, 1, 25),
+      [authors[2]!.author_id]: makeBucket(20, 50, 10),
+    };
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+    const before = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+
+    // Tab on the thread_count button MUST NOT re-order — only Enter / Space
+    // are activation keys per the WAI-ARIA radio-group contract.
+    const threadBtn = container.querySelector<HTMLButtonElement>(
+      '.comments-author-density-sort-btn[data-sort-metric="thread_count"]',
+    );
+    threadBtn?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Tab", bubbles: true }),
+    );
+    const after = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(after).toEqual(before);
+    const checked = container.querySelector(
+      '.comments-author-density-sort-btn[aria-checked="true"]',
+    );
+    expect(checked?.getAttribute("data-sort-metric")).toBe("comment_count");
+  });
+
+  it("(T025-d) keyboard activation (Enter / Space) on a focused button re-orders rows", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {
+      [authors[0]!.author_id]: makeBucket(1, 100, 0),
+      [authors[1]!.author_id]: makeBucket(50, 1, 25),
+      [authors[2]!.author_id]: makeBucket(20, 50, 10),
+    };
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+
+    // Enter on the thread_count button.
+    const threadBtn = container.querySelector<HTMLButtonElement>(
+      '.comments-author-density-sort-btn[data-sort-metric="thread_count"]',
+    );
+    threadBtn?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    let orderedKeys = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(orderedKeys[0]).toBe(authors[1]!.author_id); // 50 threads top
+
+    // Space on the active_thread_count button.
+    const activeBtn = container.querySelector<HTMLButtonElement>(
+      '.comments-author-density-sort-btn[data-sort-metric="active_thread_count"]',
+    );
+    activeBtn?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: " ", bubbles: true }),
+    );
+    orderedKeys = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(orderedKeys[0]).toBe(authors[1]!.author_id); // 25 active top
+  });
 });

--- a/extension/tests/modules/charts/comments-author-density.test.ts
+++ b/extension/tests/modules/charts/comments-author-density.test.ts
@@ -1,0 +1,501 @@
+/**
+ * Per-Author Comments-Density Chart Module Tests (Feature 334 US1)
+ *
+ * JSDOM behaviour tests for renderCommentsAuthorDensityChart covering the
+ * MVP contract surface (FR-4-01..FR-4-06 + FR-4-09 + FR-4-10 + chart-layer
+ * idempotency):
+ *
+ *   (a) 12-author fixture renders top-50-by-comment_count-desc; each row
+ *       carries author display name + 3 numeric metrics.
+ *   (b) Range-filter narrowing (subset of rollups) re-renders rows with
+ *       sums over the narrowed range.
+ *   (c) Truncation indicator surfaces when input exceeds the cap
+ *       (53-author fixture → 50 visible + indicator).
+ *   (d) Partial-coverage qualifier on rows whose reduced
+ *       coverage_partial=true; non-partial rows MUST NOT carry it
+ *       (FR-4-03).
+ *   (e) Deterministic UI tie-break — chosen-metric desc → display name
+ *       asc → author key asc as final tie-breaker.
+ *   (f) FR-4-09 no click-through: rows have no data-drilldown-* attribute
+ *       and no click handler attached by the chart module.
+ *   (g) FR-4-10 a11y: rows expose metrics via screen-reader-readable
+ *       aria-label; sort-selector buttons are wired into a WAI-ARIA
+ *       radio-group (role="radio" + aria-checked + tabindex).
+ *   (h) Chart-layer idempotency: rendering twice on the same container
+ *       produces ONE chart, not two — content replaced via the
+ *       throughput / 333-style renderTrustedHtml pattern.
+ */
+
+import {
+  MAX_COMMENTS_AUTHOR_DENSITY_ROWS,
+  renderCommentsAuthorDensityChart,
+} from "../../../ui/modules/charts/comments-author-density";
+import type { Rollup } from "../../../ui/dataset-loader";
+import type { FilterState } from "../../../ui/modules/filters";
+
+interface AuthorBucket {
+  thread_count: number;
+  comment_count: number;
+  active_thread_count: number;
+  coverage_partial: boolean;
+}
+
+function makeRollup(
+  index: number,
+  byAuthorComments: Record<string, AuthorBucket> | undefined,
+): Rollup {
+  const rollup: Rollup = {
+    week: `2025-W${String(index + 1).padStart(2, "0")}`,
+    pr_count: 10,
+    cycle_time_p50: 60,
+    cycle_time_p90: 120,
+    authors_count: 4,
+    reviewers_count: 3,
+    by_repository: null,
+    by_team: null,
+  };
+  if (byAuthorComments) {
+    rollup.by_author_comments = byAuthorComments;
+  }
+  return rollup;
+}
+
+function emptyFilters(): FilterState {
+  return { repos: [], teams: [], reviewers: [], authors: [] };
+}
+
+function buildAuthorsDimension(
+  count: number,
+  prefix = "user",
+): { author_id: string; author_name: string }[] {
+  const out: { author_id: string; author_name: string }[] = [];
+  for (let i = 0; i < count; i++) {
+    out.push({
+      author_id: `${prefix}-${String(i).padStart(3, "0")}`,
+      author_name: `${prefix} ${i}`,
+    });
+  }
+  return out;
+}
+
+function makeBucket(
+  thread: number,
+  comment: number,
+  active: number,
+  partial = false,
+): AuthorBucket {
+  return {
+    thread_count: thread,
+    comment_count: comment,
+    active_thread_count: active,
+    coverage_partial: partial,
+  };
+}
+
+describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+  });
+
+  it("(a) renders one row per author sorted by comment_count desc; each row carries display name + 3 metrics", () => {
+    const authors = buildAuthorsDimension(12);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a, i) => {
+      // Distinct comment_count per author so the desc sort is deterministic.
+      buckets[a.author_id] = makeBucket(2, 100 - i, 1);
+    });
+    const rollups: Rollup[] = [makeRollup(0, buckets)];
+
+    renderCommentsAuthorDensityChart(container, rollups, {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    );
+    expect(rows).toHaveLength(12);
+
+    const firstRowName = rows[0]?.querySelector(
+      ".comments-author-density-name",
+    )?.textContent;
+    expect(firstRowName).toBe("user 0"); // highest comment_count = 100
+
+    // Author display name + 3 numeric metrics — table renders 4 cells per row.
+    const firstRowCells = rows[0]?.querySelectorAll('[role="cell"]');
+    expect(firstRowCells).toHaveLength(4);
+  });
+
+  it("(b) re-renders rows over a narrowed rollup range", () => {
+    const authors = buildAuthorsDimension(3);
+    const wideRollups: Rollup[] = [];
+    for (let i = 0; i < 4; i++) {
+      const buckets: Record<string, AuthorBucket> = {};
+      authors.forEach((a) => {
+        buckets[a.author_id] = makeBucket(1, 5, 0);
+      });
+      wideRollups.push(makeRollup(i, buckets));
+    }
+    renderCommentsAuthorDensityChart(container, wideRollups, {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+    const wideRows = container.querySelectorAll<HTMLElement>(
+      ".comments-author-density-row",
+    );
+    expect(wideRows).toHaveLength(3);
+    // 4 weeks × 5 comments = 20 per author on the wide range.
+    const wideFirstCommentCell = wideRows[0]?.querySelectorAll(
+      ".comments-author-density-numeric",
+    )[2];
+    expect(wideFirstCommentCell?.textContent).toBe("20");
+
+    // Narrow to first 2 weeks → 2 × 5 = 10 per author.
+    renderCommentsAuthorDensityChart(container, wideRollups.slice(0, 2), {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+    const narrowRows = container.querySelectorAll<HTMLElement>(
+      ".comments-author-density-row",
+    );
+    expect(narrowRows).toHaveLength(3);
+    const narrowFirstCommentCell = narrowRows[0]?.querySelectorAll(
+      ".comments-author-density-numeric",
+    )[2];
+    expect(narrowFirstCommentCell?.textContent).toBe("10");
+  });
+
+  it("(c) renders the truncation indicator when authors exceed the cap", () => {
+    const overCap = MAX_COMMENTS_AUTHOR_DENSITY_ROWS + 3;
+    const authors = buildAuthorsDimension(overCap);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a, i) => {
+      buckets[a.author_id] = makeBucket(1, overCap - i, 0);
+    });
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+
+    const rows = container.querySelectorAll(".comments-author-density-row");
+    expect(rows).toHaveLength(MAX_COMMENTS_AUTHOR_DENSITY_ROWS);
+    const indicator = container.querySelector(".truncation-indicator");
+    expect(indicator).not.toBeNull();
+    expect(indicator?.textContent).toContain(
+      String(MAX_COMMENTS_AUTHOR_DENSITY_ROWS),
+    );
+  });
+
+  it("(d) applies the partial-coverage qualifier ONLY to rows whose reduced coverage_partial=true", () => {
+    const authors = buildAuthorsDimension(3);
+    const week1Buckets: Record<string, AuthorBucket> = {
+      [authors[0]!.author_id]: makeBucket(2, 4, 1, true),
+      [authors[1]!.author_id]: makeBucket(2, 4, 1, false),
+      [authors[2]!.author_id]: makeBucket(2, 4, 1, false),
+    };
+    const week2Buckets: Record<string, AuthorBucket> = {
+      [authors[0]!.author_id]: makeBucket(2, 4, 1, false),
+      [authors[1]!.author_id]: makeBucket(2, 4, 1, false),
+      [authors[2]!.author_id]: makeBucket(2, 4, 1, true),
+    };
+    renderCommentsAuthorDensityChart(
+      container,
+      [makeRollup(0, week1Buckets), makeRollup(1, week2Buckets)],
+      { filters: emptyFilters(), authorsDimension: authors },
+    );
+
+    const partial = container.querySelectorAll(
+      '.comments-author-density-row.coverage-partial[data-coverage-partial="true"]',
+    );
+    // user 0 (partial in W1) + user 2 (partial in W2) = 2 rows; user 1 has
+    // no partial weeks → no qualifier.
+    expect(partial).toHaveLength(2);
+    const partialKeys = Array.from(partial).map((r) =>
+      r.getAttribute("data-author-key"),
+    );
+    expect(partialKeys.sort()).toEqual(
+      [authors[0]!.author_id, authors[2]!.author_id].sort(),
+    );
+  });
+
+  it("(e) tie-breaks deterministically on chosen-metric desc → display name asc → author key asc", () => {
+    // Three authors with the SAME comment_count.  After display-name asc
+    // tie-break, the two "Alice" rows are ordered by author_id asc
+    // (user-aaa-1 then user-bob-2), then Zelda's user-zzz-3.
+    const authors = [
+      { author_id: "user-bob-2", author_name: "Alice" },
+      { author_id: "user-aaa-1", author_name: "Alice" },
+      { author_id: "user-zzz-3", author_name: "Zelda" },
+    ];
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a) => {
+      buckets[a.author_id] = makeBucket(1, 7, 0);
+    });
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    );
+    const orderedKeys = rows.map((r) => r.getAttribute("data-author-key"));
+    expect(orderedKeys).toEqual(["user-aaa-1", "user-bob-2", "user-zzz-3"]);
+  });
+
+  it("(f) emits no drill-down attributes or handlers (FR-4-09)", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a) => {
+      buckets[a.author_id] = makeBucket(1, 5, 0);
+    });
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+
+    // No element under the chart container carries any data-drilldown-* attr.
+    const drilldownAttrCarriers = container.querySelectorAll(
+      "[data-drilldown-week], [data-drilldown-author], [data-drilldown-pr], [data-drilldown-repo]",
+    );
+    expect(drilldownAttrCarriers).toHaveLength(0);
+    // Rows are not rendered as buttons (no role="button"), and have no
+    // tabindex (informational rows, not interactive — sort buttons are the
+    // sole interactive primitive).
+    const rows = container.querySelectorAll(".comments-author-density-row");
+    rows.forEach((row) => {
+      expect(row.getAttribute("role")).toBe("row");
+      expect(row.hasAttribute("tabindex")).toBe(false);
+    });
+  });
+
+  it("(g) wires the sort selector as a WAI-ARIA radio-group with screen-reader-readable rows", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a) => {
+      buckets[a.author_id] = makeBucket(2, 7, 1);
+    });
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+
+    const radioGroup = container.querySelector(
+      '.comments-author-density-sort[role="radiogroup"]',
+    );
+    expect(radioGroup).not.toBeNull();
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      '.comments-author-density-sort-btn[role="radio"]',
+    );
+    expect(buttons).toHaveLength(3);
+    const checked = container.querySelectorAll(
+      '.comments-author-density-sort-btn[aria-checked="true"]',
+    );
+    expect(checked).toHaveLength(1);
+    expect(checked[0]?.getAttribute("data-sort-metric")).toBe("comment_count");
+    expect(checked[0]?.getAttribute("tabindex")).toBe("0");
+
+    // Rows carry an aria-label that includes all 3 metric values.
+    const firstRow = container.querySelector<HTMLElement>(
+      ".comments-author-density-row",
+    );
+    const ariaLabel = firstRow?.getAttribute("aria-label") ?? "";
+    expect(ariaLabel).toContain("threads");
+    expect(ariaLabel).toContain("active threads");
+    expect(ariaLabel).toContain("comments");
+  });
+
+  it("is a no-op when the container is null", () => {
+    const authors = buildAuthorsDimension(2);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a) => {
+      buckets[a.author_id] = makeBucket(1, 5, 0);
+    });
+    // Deliberately invoke with null container — must not throw.
+    expect(() =>
+      renderCommentsAuthorDensityChart(null, [makeRollup(0, buckets)], {
+        filters: emptyFilters(),
+        authorsDimension: authors,
+      }),
+    ).not.toThrow();
+  });
+
+  it("renders the filter-not-supported empty state when ANY dimension filter is active", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a) => {
+      buckets[a.author_id] = makeBucket(1, 5, 0);
+    });
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: { repos: ["repo-1"], teams: [], reviewers: [], authors: [] },
+      authorsDimension: authors,
+    });
+    const rows = container.querySelectorAll(".comments-author-density-row");
+    expect(rows).toHaveLength(0);
+    // The shared empty-state primitive renders into the container; the
+    // exact selector / wording is owned by ``renderNoData`` so we assert
+    // on the absence of rows + presence of *some* container content.
+    expect(container.textContent ?? "").toContain("filterable");
+  });
+
+  it("renders the no-data empty state when no rollup carries by_author_comments", () => {
+    const rollups = [makeRollup(0, undefined), makeRollup(1, undefined)];
+    renderCommentsAuthorDensityChart(container, rollups, {
+      filters: emptyFilters(),
+      authorsDimension: buildAuthorsDimension(2),
+    });
+    const rows = container.querySelectorAll(".comments-author-density-row");
+    expect(rows).toHaveLength(0);
+    expect(container.textContent ?? "").toContain("No comments data");
+  });
+
+  it("falls back to the raw author key when authorsDimension is missing entirely", () => {
+    const buckets: Record<string, AuthorBucket> = {
+      "raw-author-key": makeBucket(1, 3, 0),
+    };
+    // Intentionally omit ``authorsDimension`` so the directory is null —
+    // resolveDisplayName must fall back to the raw key.
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {});
+    const row = container.querySelector(".comments-author-density-row");
+    const name = row?.querySelector(
+      ".comments-author-density-name",
+    )?.textContent;
+    expect(name).toBe("raw-author-key");
+  });
+
+  it("ignores authorsDimension entries with missing author_id or author_name", () => {
+    const buckets: Record<string, AuthorBucket> = {
+      "known-author": makeBucket(1, 5, 0),
+      "unknown-author": makeBucket(1, 4, 0),
+    };
+    // Mixed-shape dimension: one valid + one each invalid shape.  The
+    // chart MUST silently skip the invalid entries and render the valid
+    // mapping plus the raw key for the un-resolvable author.
+    const dim = [
+      { author_id: "known-author", author_name: "Known Author" },
+      { author_id: "no-name" },
+      { author_name: "no-id" },
+    ];
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: dim,
+    });
+    const names = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        ".comments-author-density-row .comments-author-density-name",
+      ),
+    ).map((n) => n.textContent ?? "");
+    expect(names).toContain("Known Author");
+    expect(names).toContain("unknown-author");
+  });
+
+  it("exercises the tie-break with insertion order ascending by author key (covers `<` branch)", () => {
+    // Insertion order [aaa, bob, ccc, ddd] all named "Alice" forces the
+    // sort to call compareRows with successive (a, b) pairs where
+    // a.authorKey < b.authorKey at the tie-break stage — exercises the
+    // -1 arm of the final ternary in compareRows that the existing test
+    // (e) (insertion order [bob, aaa, zzz]) hits with a.authorKey >
+    // b.authorKey only.
+    const authors = [
+      { author_id: "user-aaa", author_name: "Alice" },
+      { author_id: "user-bob", author_name: "Alice" },
+      { author_id: "user-ccc", author_name: "Alice" },
+      { author_id: "user-ddd", author_name: "Alice" },
+    ];
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a) => {
+      buckets[a.author_id] = makeBucket(1, 7, 0);
+    });
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+    const orderedKeys = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(orderedKeys).toEqual([
+      "user-aaa",
+      "user-bob",
+      "user-ccc",
+      "user-ddd",
+    ]);
+  });
+
+  it("re-orders rows when sortMetric=thread_count is requested", () => {
+    const authors = buildAuthorsDimension(3);
+    // Make thread_count and comment_count rank authors differently.
+    const buckets: Record<string, AuthorBucket> = {
+      [authors[0]!.author_id]: makeBucket(1, 100, 0),
+      [authors[1]!.author_id]: makeBucket(50, 1, 25),
+      [authors[2]!.author_id]: makeBucket(20, 50, 10),
+    };
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+      sortMetric: "thread_count",
+    });
+    const orderedKeys = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(orderedKeys?.[0]).toBe(authors[1]!.author_id); // 50 threads
+    expect(orderedKeys?.[1]).toBe(authors[2]!.author_id); // 20 threads
+    expect(orderedKeys?.[2]).toBe(authors[0]!.author_id); // 1 thread
+    const checked = container.querySelector(
+      '.comments-author-density-sort-btn[aria-checked="true"]',
+    );
+    expect(checked?.getAttribute("data-sort-metric")).toBe("thread_count");
+  });
+
+  it("re-orders rows when sortMetric=active_thread_count is requested", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {
+      [authors[0]!.author_id]: makeBucket(10, 50, 1),
+      [authors[1]!.author_id]: makeBucket(10, 50, 8),
+      [authors[2]!.author_id]: makeBucket(10, 50, 4),
+    };
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+      sortMetric: "active_thread_count",
+    });
+    const orderedKeys = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(orderedKeys?.[0]).toBe(authors[1]!.author_id); // 8 active
+    expect(orderedKeys?.[1]).toBe(authors[2]!.author_id); // 4 active
+    expect(orderedKeys?.[2]).toBe(authors[0]!.author_id); // 1 active
+  });
+
+  it("(h) is idempotent under repeated render calls on the same container", () => {
+    const authors = buildAuthorsDimension(5);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a, i) => {
+      buckets[a.author_id] = makeBucket(2, 50 - i, 1);
+    });
+    const rollups = [makeRollup(0, buckets)];
+    renderCommentsAuthorDensityChart(container, rollups, {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+    renderCommentsAuthorDensityChart(container, rollups, {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+
+    const tables = container.querySelectorAll(".comments-author-density-table");
+    expect(tables).toHaveLength(1);
+    const rows = container.querySelectorAll(".comments-author-density-row");
+    expect(rows).toHaveLength(5);
+    const radioGroups = container.querySelectorAll(
+      '.comments-author-density-sort[role="radiogroup"]',
+    );
+    expect(radioGroups).toHaveLength(1);
+  });
+});

--- a/extension/tests/modules/charts/comments-author-density.test.ts
+++ b/extension/tests/modules/charts/comments-author-density.test.ts
@@ -743,6 +743,116 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
     expect(checked?.getAttribute("data-sort-metric")).toBe("comment_count");
   });
 
+  // ===========================================================================
+  // US4 (T028): sentinel-key → sentinel-label mapping.  When the bucket
+  // key is the reserved literal ``__former_or_unavailable_author__``, the
+  // rendered row label MUST be the fixed-string "Former / unavailable
+  // author" (NOT the raw key) and the sentinel row MUST participate in
+  // sort exactly like real-author rows (not pinned to top / bottom).
+  // ===========================================================================
+
+  const SENTINEL_KEY = "__former_or_unavailable_author__";
+  const SENTINEL_LABEL = "Former / unavailable author";
+
+  it("(T028-a) sentinel-keyed row renders the fixed-string label, not the raw key", () => {
+    const authors = buildAuthorsDimension(2);
+    const buckets: Record<string, AuthorBucket> = {
+      [authors[0]!.author_id]: makeBucket(2, 50, 1),
+      [authors[1]!.author_id]: makeBucket(2, 30, 1),
+      // Even if a malicious / drifted authorsDimension contained an
+      // entry under the literal key, the renderer's sentinel branch
+      // takes precedence — the row label MUST be the fixed string.
+      [SENTINEL_KEY]: makeBucket(2, 40, 1),
+    };
+    const dim = [
+      ...authors,
+      // Defensive: the producer guarantees the literal does not collide
+      // with real author IDs (Feature 334 A-07), but if a fixture drift
+      // ever inserted such an entry, the chart MUST still surface the
+      // sentinel label — not the dimensional display name.
+      { author_id: SENTINEL_KEY, author_name: "Should NEVER show" },
+    ];
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: dim,
+    });
+
+    const sentinelRow = container.querySelector<HTMLElement>(
+      `.comments-author-density-row[data-author-key="${SENTINEL_KEY}"]`,
+    );
+    expect(sentinelRow).not.toBeNull();
+    const sentinelName = sentinelRow?.querySelector(
+      ".comments-author-density-name",
+    )?.textContent;
+    expect(sentinelName).toBe(SENTINEL_LABEL);
+    // Negative: the raw key string MUST NOT appear in any rendered row's
+    // visible text (the data attribute carrying it is fine — that's
+    // queryable infrastructure, not user-visible text).
+    const visibleText = container.textContent ?? "";
+    expect(visibleText).not.toContain(SENTINEL_KEY);
+    expect(visibleText).toContain(SENTINEL_LABEL);
+  });
+
+  it("(T028-b) sentinel row participates in sort — not pinned to top or bottom", () => {
+    const authors = buildAuthorsDimension(3);
+    // Comment counts: alice=100, bob=50, sentinel=75, ccc=10. The
+    // sentinel ranks SECOND (between alice and bob) in comment_count
+    // desc. NOT pinned at top or bottom.
+    const buckets: Record<string, AuthorBucket> = {
+      [authors[0]!.author_id]: makeBucket(2, 100, 1), // alice — top
+      [authors[1]!.author_id]: makeBucket(2, 50, 1), // bob — third
+      [authors[2]!.author_id]: makeBucket(2, 10, 1), // ccc — bottom
+      [SENTINEL_KEY]: makeBucket(2, 75, 1), // sentinel — second
+    };
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+    const orderedKeys = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(orderedKeys).toEqual([
+      authors[0]!.author_id,
+      SENTINEL_KEY,
+      authors[1]!.author_id,
+      authors[2]!.author_id,
+    ]);
+    // Switching the sort metric MUST keep the sentinel participating in
+    // sort (not pinned).  thread_count is uniform here, so the secondary
+    // tie-breaker (display name asc) decides. Display names: "Former /
+    // unavailable author" < "user 0" < "user 1" < "user 2" lexically.
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+      sortMetric: "thread_count",
+    });
+    const orderedAfter = Array.from(
+      container.querySelectorAll<HTMLElement>(".comments-author-density-row"),
+    ).map((r) => r.getAttribute("data-author-key"));
+    expect(orderedAfter[0]).toBe(SENTINEL_KEY);
+  });
+
+  it("(T028-c) dataset with zero unknown-to-users PRs in range emits NO sentinel row", () => {
+    const authors = buildAuthorsDimension(3);
+    const buckets: Record<string, AuthorBucket> = {};
+    authors.forEach((a, i) => {
+      buckets[a.author_id] = makeBucket(2, 100 - i, 1);
+    });
+    // Deliberately omit any sentinel-keyed bucket: the producer omits
+    // the entry when zero unknown-to-users PRs exist in W's canonical
+    // set per FR-2-03 / CL-03.
+    renderCommentsAuthorDensityChart(container, [makeRollup(0, buckets)], {
+      filters: emptyFilters(),
+      authorsDimension: authors,
+    });
+    expect(
+      container.querySelector(
+        `.comments-author-density-row[data-author-key="${SENTINEL_KEY}"]`,
+      ),
+    ).toBeNull();
+    expect(container.textContent ?? "").not.toContain(SENTINEL_LABEL);
+  });
+
   it("(T025-d) keyboard activation (Enter / Space) on a focused button re-orders rows", () => {
     const authors = buildAuthorsDimension(3);
     const buckets: Record<string, AuthorBucket> = {

--- a/extension/tests/schema/rollup.test.ts
+++ b/extension/tests/schema/rollup.test.ts
@@ -1453,4 +1453,173 @@ describe("Rollup Schema Validator", () => {
       expect(result.errors).toHaveLength(0);
     });
   });
+
+  // =========================================================================
+  // Feature 334 per-author comments-density: rollup-root `by_author_comments`
+  // outer dict.  Each entry is atomic per INV-2-08 (mirrors 333's per-week
+  // INV-1-08 at sub-object granularity).  ADR T003 atomicity posture is
+  // STRICT ERROR in BOTH strict and permissive modes — same justification as
+  // the 333 `comments` validator (no legacy emissions to grandfather).
+  // Capability-off (FR-3-03 + INV-2-09) signals via the entire key being
+  // absent.  The reserved sentinel literal `__former_or_unavailable_author__`
+  // is a permitted bucket key.
+  // =========================================================================
+  describe("rollup-root by_author_comments outer dict (feature 334 INV-2-08)", () => {
+    const BASE_334 = {
+      week: "2026-W02",
+      start_date: "2026-01-06",
+      end_date: "2026-01-12",
+      pr_count: 10,
+    };
+    const SENTINEL_LITERAL = "__former_or_unavailable_author__";
+
+    it("(a) passes validation with a complete by_author_comments entry", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: {
+          "alice-uid": {
+            thread_count: 3,
+            comment_count: 7,
+            active_thread_count: 1,
+            coverage_partial: false,
+          },
+        },
+      };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(
+        result.warnings.some((w) => w.field === "by_author_comments"),
+      ).toBe(false);
+    });
+
+    it("(b) FAILS atomicity in BOTH strict and permissive modes when an entry is partial (ADR T003)", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: {
+          "alice-uid": {
+            thread_count: 3,
+            comment_count: 7,
+            active_thread_count: 1,
+            // coverage_partial intentionally absent — INV-2-08 violation.
+          },
+        },
+      };
+      for (const strict of [false, true] as const) {
+        const result = validateRollup(rollup, strict);
+        expect(result.valid).toBe(false);
+        expect(
+          result.errors.some(
+            (e) =>
+              e.field.includes("by_author_comments") &&
+              e.message.toLowerCase().includes("coverage_partial"),
+          ),
+        ).toBe(true);
+      }
+    });
+
+    it("(c) FAILS when a numeric field is null (INV-2-08: zero is the empty-extracted-subset sum, null is not a sentinel)", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: {
+          "alice-uid": {
+            thread_count: null,
+            comment_count: 7,
+            active_thread_count: 1,
+            coverage_partial: false,
+          },
+        },
+      };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) =>
+            e.field.includes("by_author_comments") &&
+            e.field.includes("thread_count") &&
+            e.message.toLowerCase().includes("null"),
+        ),
+      ).toBe(true);
+    });
+
+    it("(d) passes validation when by_author_comments key is entirely absent (capability-off path)", () => {
+      const rollup = { ...BASE_334 };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+      expect(
+        result.warnings.some((w) => w.field === "by_author_comments"),
+      ).toBe(false);
+    });
+
+    it("(e) FAILS with wrong-typed numeric field (e.g., thread_count is a string)", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: {
+          "alice-uid": {
+            thread_count: "5" as unknown as number,
+            comment_count: 7,
+            active_thread_count: 1,
+            coverage_partial: false,
+          },
+        },
+      };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) =>
+            e.field.includes("by_author_comments") &&
+            e.field.includes("thread_count"),
+        ),
+      ).toBe(true);
+    });
+
+    it("(f) FAILS when active_thread_count > thread_count per entry (INV-2-07 ordering)", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: {
+          "alice-uid": {
+            thread_count: 3,
+            comment_count: 7,
+            active_thread_count: 4, // > thread_count, INV-2-07 violation
+            coverage_partial: false,
+          },
+        },
+      };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) =>
+            e.field.includes("by_author_comments") &&
+            e.field.includes("active_thread_count") &&
+            e.message.toLowerCase().includes("inv-2-07"),
+        ),
+      ).toBe(true);
+    });
+
+    it("(g) accepts the reserved sentinel literal as a bucket key with an atomic entry", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: {
+          [SENTINEL_LITERAL]: {
+            thread_count: 2,
+            comment_count: 5,
+            active_thread_count: 1,
+            coverage_partial: true,
+          },
+          "alice-uid": {
+            thread_count: 1,
+            comment_count: 1,
+            active_thread_count: 0,
+            coverage_partial: false,
+          },
+        },
+      };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
 });

--- a/extension/tests/schema/rollup.test.ts
+++ b/extension/tests/schema/rollup.test.ts
@@ -1621,5 +1621,146 @@ describe("Rollup Schema Validator", () => {
       expect(result.valid).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
+
+    it("FAILS when by_author_comments is not an object (non-Record top-level type)", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: "not-an-object" as unknown as Record<
+          string,
+          unknown
+        >,
+      };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.field === "by_author_comments")).toBe(
+        true,
+      );
+    });
+
+    it("FAILS when by_author_comments is the empty object (capability-on must omit, not emit `{}`)", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: {},
+      };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) =>
+            e.field === "by_author_comments" &&
+            e.message.toLowerCase().includes("must be omitted"),
+        ),
+      ).toBe(true);
+    });
+
+    it("FAILS when an entry value is not an object", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: {
+          "alice-uid": "not-an-entry" as unknown as Record<string, unknown>,
+        },
+      };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((e) => e.field.includes("by_author_comments")),
+      ).toBe(true);
+    });
+
+    it("FAILS when a numeric field is negative", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: {
+          "alice-uid": {
+            thread_count: -1,
+            comment_count: 4,
+            active_thread_count: 0,
+            coverage_partial: false,
+          },
+        },
+      };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) =>
+            e.field.includes("by_author_comments") &&
+            e.field.includes("thread_count") &&
+            e.message.toLowerCase().includes("non-negative"),
+        ),
+      ).toBe(true);
+    });
+
+    it("FAILS when a numeric field is a non-integer (counts must be whole numbers)", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: {
+          "alice-uid": {
+            thread_count: 1.5,
+            comment_count: 4,
+            active_thread_count: 0,
+            coverage_partial: false,
+          },
+        },
+      };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) =>
+            e.field.includes("by_author_comments") &&
+            e.field.includes("thread_count") &&
+            e.message.toLowerCase().includes("integer"),
+        ),
+      ).toBe(true);
+    });
+
+    it("FAILS when coverage_partial is not a boolean", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: {
+          "alice-uid": {
+            thread_count: 1,
+            comment_count: 1,
+            active_thread_count: 0,
+            coverage_partial: "yes" as unknown as boolean,
+          },
+        },
+      };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) =>
+            e.field.includes("by_author_comments") &&
+            e.field.includes("coverage_partial"),
+        ),
+      ).toBe(true);
+    });
+
+    it("FAILS when one numeric field is missing (single-field omission, not full atomicity)", () => {
+      const rollup = {
+        ...BASE_334,
+        by_author_comments: {
+          "alice-uid": {
+            // thread_count intentionally absent — atomicity violation that
+            // must still fire on a single-field omission (case (b) covers
+            // coverage_partial; this case covers a numeric-field omission).
+            comment_count: 4,
+            active_thread_count: 0,
+            coverage_partial: false,
+          } as unknown as Record<string, unknown>,
+        },
+      };
+      const result = validateRollup(rollup, false);
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some(
+          (e) =>
+            e.field.includes("by_author_comments") &&
+            e.message.toLowerCase().includes("thread_count"),
+        ),
+      ).toBe(true);
+    });
   });
 });

--- a/extension/ui/dashboard.ts
+++ b/extension/ui/dashboard.ts
@@ -53,6 +53,7 @@ import {
   renderCommentsTrendChart as renderCommentsTrendChartModule,
   attachCommentsTrendInfoIcon,
   detachCommentsTrendInfoIcon,
+  renderCommentsAuthorDensityChart as renderCommentsAuthorDensityChartModule,
   // Data availability signal derivation
   deriveAvailabilitySignal,
   // Filter constraint resolver
@@ -1095,6 +1096,24 @@ async function refreshMetrics(): Promise<void> {
       removeCommentsTrendContainer();
     }
 
+    // Feature 334 (US1): per-author comments-density breakdown row, mounted
+    // BELOW the 333 comments-trend chart per FR-4-01.  Same capability gate
+    // as 333, same lifecycle pattern (idempotent ensure / no-op remove).
+    // Anchors on the 333 row when present; falls back to cycle-distribution
+    // for atypical orderings.  Per FR-4-09 the chart is informational —
+    // no drill-down handle is installed below.
+    if (loader?.getCapabilityState?.()?.commentsMetricsAvailable === true) {
+      const cadContainer = ensureCommentsAuthorDensityContainer();
+      if (cadContainer) {
+        renderCommentsAuthorDensityChartModule(cadContainer, rollups, {
+          filters: currentFilters,
+          authorsDimension: currentDimensions?.authors,
+        });
+      }
+    } else {
+      removeCommentsAuthorDensityContainer();
+    }
+
     // Install per-chart drill-down handles AFTER the render block so the
     // container elements exist. US2–US4 push peers onto the same array.
     const throughputContainer = document.getElementById("throughput-chart");
@@ -1634,6 +1653,69 @@ function removeCommentsTrendContainer(): void {
   if (heading instanceof HTMLElement) {
     detachCommentsTrendInfoIcon(heading);
   }
+  row.parentElement?.removeChild(row);
+}
+
+/**
+ * Idempotently ensure the per-author comments-density chart row exists
+ * (Feature 334 US1).  Mirrors ``ensureCommentsTrendContainer`` (333 round-12
+ * idempotency contract) but anchors BELOW the 333 row per FR-4-01.
+ *
+ * Anchor preference: the existing comments-trend row (333) when mounted —
+ * this guarantees the per-author breakdown lands immediately under the
+ * weekly trend chart in the typical capability-on render order.  Fallback
+ * to ``cycle-distribution`` for atypical orderings (e.g., a future render
+ * path that mounts 334 before 333).  Returns ``null`` if neither anchor
+ * is locatable.
+ */
+function ensureCommentsAuthorDensityContainer(): HTMLElement | null {
+  const existing = document.getElementById("comments-author-density");
+  if (existing) return existing;
+
+  const commentsTrendRow = document.querySelector(
+    '[data-comments-trend-row="true"]',
+  );
+  let anchorRow: Element | null = commentsTrendRow;
+  if (!anchorRow) {
+    const cycleDist = document.getElementById("cycle-distribution");
+    anchorRow = cycleDist?.closest(".charts-row") ?? null;
+  }
+  if (!anchorRow || !anchorRow.parentElement) return null;
+
+  const row = document.createElement("div");
+  row.className = "charts-row";
+  row.setAttribute("data-comments-author-density-row", "true");
+
+  const containerCell = document.createElement("div");
+  containerCell.className = "chart-container";
+
+  const heading = document.createElement("h3");
+  heading.textContent = "Comment Density by Author";
+  containerCell.appendChild(heading);
+
+  const chart = document.createElement("div");
+  chart.id = "comments-author-density";
+  chart.className = "chart";
+
+  containerCell.appendChild(chart);
+  row.appendChild(containerCell);
+
+  anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+
+  return chart;
+}
+
+/**
+ * Remove the per-author comments-density chart row from the DOM if
+ * present.  No-op when absent (initial capability-off; repeated
+ * capability-off renders).  Active cleanup happens on the on→off
+ * mid-session transition (FR-3-02).
+ */
+function removeCommentsAuthorDensityContainer(): void {
+  const row = document.querySelector(
+    '[data-comments-author-density-row="true"]',
+  );
+  if (!row) return;
   row.parentElement?.removeChild(row);
 }
 

--- a/extension/ui/dataset-loader.ts
+++ b/extension/ui/dataset-loader.ts
@@ -209,6 +209,23 @@ export interface Rollup {
     active_thread_count: number;
     coverage_partial: boolean;
   };
+  // Feature 334 per-author comments-density (FR-1-01..FR-1-08). Optional
+  // outer dict emitted only when capabilities.comments_metrics is enabled
+  // (FR-3-03 / INV-2-09). Each entry carries the same four atomic fields
+  // as the 333 ``comments`` aggregate (per-bucket scope rather than
+  // per-week). Validator: validateAuthorCommentsDensity in
+  // rollup.schema.ts (ADR T003 STRICT-ERROR posture, both modes).
+  // Renderer: comments-author-density chart module under
+  // modules/charts/comments-author-density.ts (Feature 334 US1).
+  by_author_comments?: Record<
+    string,
+    {
+      thread_count: number;
+      comment_count: number;
+      active_thread_count: number;
+      coverage_partial: boolean;
+    }
+  >;
   [key: string]: unknown; // Allow for extra fields preserved during normalization
 }
 

--- a/extension/ui/modules/charts/comments-author-density.ts
+++ b/extension/ui/modules/charts/comments-author-density.ts
@@ -199,6 +199,98 @@ export interface CommentsAuthorDensityOptions {
 }
 
 /**
+ * Per-container sort metric state. Keys are the chart container element
+ * so a single dashboard with multiple chart instances (none today, but
+ * the contract leaves the door open) keeps state isolated. Set when the
+ * user clicks a sort button (US2 / T026); read when ``options.sortMetric``
+ * is not provided so the chart preserves its toggle state across
+ * re-renders triggered by filter / range changes.
+ */
+const sortMetricByContainer = new WeakMap<
+  HTMLElement,
+  CommentsAuthorDensitySortMetric
+>();
+
+/**
+ * Per-container listener controllers. Each render aborts the prior set
+ * before attaching fresh button handlers so re-renders never accumulate
+ * duplicate listeners (mirrors the throughput / 333 info-icon pattern).
+ */
+const sortListenerControllers = new WeakMap<HTMLElement, AbortController>();
+
+function attachSortToggleListeners(
+  container: HTMLElement,
+  rollups: Rollup[],
+  options: CommentsAuthorDensityOptions | undefined,
+): void {
+  // Drop any prior listeners attached on a previous render.  Use a
+  // single delegated handler on the container itself rather than per-
+  // button listeners so re-attach is a one-listener swap and so the
+  // metric is resolved AT click time from the rendered ``data-sort-metric``
+  // attribute (rather than captured at attach time).  The latter lets
+  // tests exercise the malformed-attribute branch by mutating the
+  // attribute between render and click — coverage of the validation
+  // branch comes from real DOM input rather than dead code.
+  sortListenerControllers.get(container)?.abort();
+  const controller = new AbortController();
+  sortListenerControllers.set(container, controller);
+  const { signal } = controller;
+
+  const resolveMetric = (
+    raw: string | undefined,
+  ): CommentsAuthorDensitySortMetric | undefined => {
+    return COMMENTS_AUTHOR_DENSITY_SORT_METRICS.find((m) => m === raw);
+  };
+
+  const activate = (metric: CommentsAuthorDensitySortMetric): void => {
+    sortMetricByContainer.set(container, metric);
+    // Re-render with the same rollups + options but the new metric.
+    // The new render replaces these listeners via the controller-abort
+    // pattern at the top of this function.
+    renderCommentsAuthorDensityChart(container, rollups, {
+      ...options,
+      sortMetric: metric,
+    });
+  };
+
+  const findSortButton = (event: Event): HTMLElement | null => {
+    // ``event.target`` is always the dispatching element under
+    // ``container.addEventListener`` so the cast is sound; a defensive
+    // ``instanceof Element`` check would create a dead branch the
+    // partial-branch coverage gate cannot reach from a real test.
+    const target = event.target as Element;
+    return target.closest<HTMLElement>(".comments-author-density-sort-btn");
+  };
+
+  container.addEventListener(
+    "click",
+    (event) => {
+      const button = findSortButton(event);
+      if (!button) return;
+      const metric = resolveMetric(button.dataset.sortMetric);
+      if (!metric) return;
+      activate(metric);
+    },
+    { signal },
+  );
+
+  container.addEventListener(
+    "keydown",
+    (event) => {
+      const button = findSortButton(event);
+      if (!button) return;
+      const key = (event as KeyboardEvent).key;
+      if (key !== "Enter" && key !== " ") return;
+      const metric = resolveMetric(button.dataset.sortMetric);
+      if (!metric) return;
+      event.preventDefault();
+      activate(metric);
+    },
+    { signal },
+  );
+}
+
+/**
  * Render the per-author comments-density breakdown.
  *
  * @param container Target container element. The dashboard call site is
@@ -253,8 +345,17 @@ export function renderCommentsAuthorDensityChart(
     });
   }
 
-  const activeMetric: CommentsAuthorDensitySortMetric =
-    options?.sortMetric ?? "comment_count";
+  // Resolve the active sort metric: explicit option wins (e.g., the
+  // dashboard hard-overrides per render), then per-container state set
+  // by the user's last button click (US2 / T026), then the default
+  // ``comment_count`` per CL-05.
+  let activeMetric: CommentsAuthorDensitySortMetric;
+  if (options?.sortMetric) {
+    activeMetric = options.sortMetric;
+    sortMetricByContainer.set(container, activeMetric);
+  } else {
+    activeMetric = sortMetricByContainer.get(container) ?? "comment_count";
+  }
   rows.sort((a, b) => compareRows(a, b, activeMetric));
 
   const truncated = rows.length > MAX_COMMENTS_AUTHOR_DENSITY_ROWS;
@@ -277,6 +378,8 @@ export function renderCommentsAuthorDensityChart(
     container,
     `${truncationHtml}${sortControlsHtml}${tableHtml}${partialLegendHtml}`,
   );
+
+  attachSortToggleListeners(container, rollups, options);
 }
 
 function metricLabel(metric: CommentsAuthorDensitySortMetric): string {

--- a/extension/ui/modules/charts/comments-author-density.ts
+++ b/extension/ui/modules/charts/comments-author-density.ts
@@ -399,14 +399,23 @@ function metricLabel(metric: CommentsAuthorDensitySortMetric): string {
 function renderSortControls(
   activeMetric: CommentsAuthorDensitySortMetric,
 ): string {
+  // Toolbar pattern (WAI-ARIA Authoring Practices "Toolbar"): each
+  // button is an independently Tab-reachable <button> with aria-pressed
+  // tracking the active sort metric.  Toolbar is preferred over a
+  // single-tabstop radio-group here because the previous radio-group
+  // implementation gated the other two buttons behind arrow-key
+  // navigation that the chart did not implement — making them
+  // keyboard-unreachable (Codex stop-time review caught the regression).
+  // <button> elements default to tabindex=0 and natively activate on
+  // Enter / Space; the delegated click + keydown handlers below catch
+  // both sequences.
   const buttons = COMMENTS_AUTHOR_DENSITY_SORT_METRICS.map((metric) => {
     const checked = metric === activeMetric;
-    const ariaChecked = checked ? "true" : "false";
-    const tabIndex = checked ? "0" : "-1";
+    const ariaPressed = checked ? "true" : "false";
     const label = metricLabel(metric);
-    return `<button type="button" class="comments-author-density-sort-btn${checked ? " is-active" : ""}" role="radio" aria-checked="${ariaChecked}" tabindex="${tabIndex}" data-sort-metric="${escapeHtml(metric)}">${escapeHtml(label)}</button>`;
+    return `<button type="button" class="comments-author-density-sort-btn${checked ? " is-active" : ""}" aria-pressed="${ariaPressed}" data-sort-metric="${escapeHtml(metric)}">${escapeHtml(label)}</button>`;
   }).join("");
-  return `<div class="comments-author-density-sort" role="radiogroup" aria-label="Sort author rows by metric">${buttons}</div>`;
+  return `<div class="comments-author-density-sort" role="toolbar" aria-label="Sort author rows by metric">${buttons}</div>`;
 }
 
 function renderTable(rows: readonly AuthorDensityRow[]): string {

--- a/extension/ui/modules/charts/comments-author-density.ts
+++ b/extension/ui/modules/charts/comments-author-density.ts
@@ -49,6 +49,28 @@ import { renderTruncationIndicator } from "../shared/chart-layout";
 /** Maximum rows rendered before truncation kicks in (CL-05 / FR-4-06). */
 export const MAX_COMMENTS_AUTHOR_DENSITY_ROWS = 50;
 
+/**
+ * Reserved aggregator-side bucket key for ALL PRs whose ``author_id`` is
+ * absent from the ``users`` table per Feature 334 CL-03 / FR-1-03.  The
+ * canonical Python constant lives at
+ * ``src/ado_git_repo_insights/transform/constants.py`` and the literal
+ * ``"__former_or_unavailable_author__"`` is the producer / consumer
+ * contract.  ADR T006 keeps the renderer self-contained — the literal
+ * is hard-coded here rather than imported from a shared module so the
+ * extension chart bundle does not couple to the transform package.
+ * Drift between the two is gated by ``test_sentinel_safety`` in the
+ * Python aggregator-author-comments test suite (T029) which asserts no
+ * real ``author_id`` collides with this literal.
+ */
+const FORMER_OR_UNAVAILABLE_AUTHOR_KEY = "__former_or_unavailable_author__";
+
+/**
+ * Renderer-side label for the sentinel bucket per CL-03.  Fixed English
+ * string for v1; localization is deferred (out of scope per the
+ * Feature 334 spec).
+ */
+const FORMER_OR_UNAVAILABLE_AUTHOR_LABEL = "Former / unavailable author";
+
 /** Sort metrics exposed in the radio-group sort selector (FR-4-05). */
 export const COMMENTS_AUTHOR_DENSITY_SORT_METRICS = [
   "comment_count",
@@ -142,10 +164,16 @@ function resolveDisplayName(
   authorKey: string,
   directory: Map<string, string> | null,
 ): string {
-  // US4 (T030) will map ``__former_or_unavailable_author__`` to the fixed
-  // label "Former / unavailable author". US1 renders the raw key for
-  // unknown-to-directory authors so the FR-4-01 row contract still emits
-  // a deterministic display string.
+  // CL-03 / T030: the reserved sentinel bucket key always renders as
+  // the fixed-string label "Former / unavailable author", regardless of
+  // whether ``authorsDimension`` happens to contain an entry under the
+  // literal key (defensive — the producer guarantees the literal does
+  // not collide with real author IDs per A-07, but the renderer keeps
+  // the contract one-sided so a future fixture drift cannot mask a
+  // real-author row as the sentinel or vice versa).
+  if (authorKey === FORMER_OR_UNAVAILABLE_AUTHOR_KEY) {
+    return FORMER_OR_UNAVAILABLE_AUTHOR_LABEL;
+  }
   if (directory) {
     const found = directory.get(authorKey);
     if (typeof found === "string" && found.length > 0) {

--- a/extension/ui/modules/charts/comments-author-density.ts
+++ b/extension/ui/modules/charts/comments-author-density.ts
@@ -1,0 +1,322 @@
+/**
+ * Per-Author Comments-Density Chart Module (Feature 334)
+ *
+ * Renders one row per author across the user-selected date range, sorted by
+ * a chosen count metric (default ``comment_count`` descending). Reads the
+ * ``rollup[W].by_author_comments`` outer dict emitted by the aggregator
+ * under ``capabilities.comments_metrics`` (FR-1-01..FR-1-08).
+ *
+ * Modeled structurally on ``comments-trend.ts`` (333) — same shared
+ * primitives (``renderTrustedHtml``, ``renderTruncationIndicator``,
+ * ``renderNoData``, ``hasActiveFilters``), same content-replace idempotency
+ * pattern, same partial-coverage qualifier convention. The visual is a
+ * row-table (one row per author) instead of a bar chart; the per-row
+ * metrics are integer counts surfaced via ``Number.toLocaleString()``.
+ *
+ * Capability gating: weeks lacking the ``by_author_comments`` outer dict
+ * are filtered out at the chart boundary (capability-off path emitted by
+ * the aggregator per FR-3-03). The dashboard call site (T024) also gates
+ * the chart's existence on ``capabilityState.commentsMetricsAvailable``,
+ * but the chart-side filter is the load-bearing defense for capability-
+ * mixed inputs.
+ *
+ * Filter-not-supported posture (FR-4-07, full 333 FR-1-07 parity per
+ * CL-02 = a): when ANY of the dashboard's per-PR dimension filters
+ * (repos / teams / authors / reviewers) is active, the chart renders a
+ * self-explanatory empty state instead of rows. ``buildFilteredRollup``
+ * spreads ``...rollup`` and only overrides top-level throughput fields,
+ * so the rollup-root ``by_author_comments`` carries through unchanged
+ * under filters — emitting rows off filtered rollups would silently show
+ * unfiltered totals (the inverse of an honest UI).
+ *
+ * No click-through (FR-4-09): rows are informational. No
+ * ``data-drilldown-*`` attributes; no click handler attachment. A
+ * future per-author drill-down panel is deferred outside this feature.
+ *
+ * Sentinel rendering (US4 / T030): the reserved bucket key
+ * ``__former_or_unavailable_author__`` will be mapped to the fixed-string
+ * label "Former / unavailable author" when US4 lands. US1 (this commit)
+ * renders the raw key for unknown-to-directory authors; the directory
+ * lookup uses ``authorsDimension`` for known authors.
+ */
+
+import type { Rollup } from "../../dataset-loader";
+import type { FilterState } from "../filters";
+import { hasActiveFilters } from "../filters";
+import { escapeHtml, renderNoData, renderTrustedHtml } from "../shared/render";
+import { renderTruncationIndicator } from "../shared/chart-layout";
+
+/** Maximum rows rendered before truncation kicks in (CL-05 / FR-4-06). */
+export const MAX_COMMENTS_AUTHOR_DENSITY_ROWS = 50;
+
+/** Sort metrics exposed in the radio-group sort selector (FR-4-05). */
+export const COMMENTS_AUTHOR_DENSITY_SORT_METRICS = [
+  "comment_count",
+  "thread_count",
+  "active_thread_count",
+] as const;
+
+export type CommentsAuthorDensitySortMetric =
+  (typeof COMMENTS_AUTHOR_DENSITY_SORT_METRICS)[number];
+
+interface AuthorBucketEntry {
+  thread_count: number;
+  comment_count: number;
+  active_thread_count: number;
+  coverage_partial: boolean;
+}
+
+/** Minimal duck-typed shape for the dashboard's authors dimension entries.
+ * Matches the dimensions.json contract validated by
+ * ``schemas/dimensions.schema.ts`` (``KNOWN_AUTHOR_FIELDS``). */
+interface AuthorDirectoryEntry {
+  author_id?: string;
+  author_name?: string;
+}
+
+interface RollupWithByAuthorComments extends Rollup {
+  by_author_comments: Record<string, AuthorBucketEntry>;
+}
+
+function hasByAuthorComments(
+  rollup: Rollup,
+): rollup is RollupWithByAuthorComments {
+  const value = rollup.by_author_comments;
+  return value !== undefined && value !== null && typeof value === "object";
+}
+
+interface AuthorDensityRow {
+  authorKey: string;
+  displayName: string;
+  thread_count: number;
+  comment_count: number;
+  active_thread_count: number;
+  coverage_partial: boolean;
+}
+
+function reducePerAuthor(
+  rollups: RollupWithByAuthorComments[],
+): Map<string, AuthorBucketEntry> {
+  const reduced = new Map<string, AuthorBucketEntry>();
+  for (const rollup of rollups) {
+    for (const entry of Object.entries(rollup.by_author_comments)) {
+      const key = entry[0];
+      const bucket = entry[1];
+      const existing = reduced.get(key);
+      if (existing) {
+        existing.thread_count += bucket.thread_count;
+        existing.comment_count += bucket.comment_count;
+        existing.active_thread_count += bucket.active_thread_count;
+        existing.coverage_partial =
+          existing.coverage_partial || bucket.coverage_partial;
+      } else {
+        reduced.set(key, {
+          thread_count: bucket.thread_count,
+          comment_count: bucket.comment_count,
+          active_thread_count: bucket.active_thread_count,
+          coverage_partial: bucket.coverage_partial,
+        });
+      }
+    }
+  }
+  return reduced;
+}
+
+function buildAuthorsDirectory(
+  authorsDimension: readonly AuthorDirectoryEntry[] | undefined,
+): Map<string, string> | null {
+  if (!authorsDimension) return null;
+  const map = new Map<string, string>();
+  for (const entry of authorsDimension) {
+    if (
+      typeof entry.author_id === "string" &&
+      typeof entry.author_name === "string"
+    ) {
+      map.set(entry.author_id, entry.author_name);
+    }
+  }
+  return map;
+}
+
+function resolveDisplayName(
+  authorKey: string,
+  directory: Map<string, string> | null,
+): string {
+  // US4 (T030) will map ``__former_or_unavailable_author__`` to the fixed
+  // label "Former / unavailable author". US1 renders the raw key for
+  // unknown-to-directory authors so the FR-4-01 row contract still emits
+  // a deterministic display string.
+  if (directory) {
+    const found = directory.get(authorKey);
+    if (typeof found === "string" && found.length > 0) {
+      return found;
+    }
+  }
+  return authorKey;
+}
+
+function metricValue(
+  row: AuthorDensityRow,
+  metric: CommentsAuthorDensitySortMetric,
+): number {
+  // Switch dispatch on a closed string union avoids dynamic property
+  // access (``row[metric]`` would trip security/detect-object-injection)
+  // while staying exhaustive over the SortMetric union — adding a new
+  // metric without extending this switch is a TS error.
+  switch (metric) {
+    case "comment_count":
+      return row.comment_count;
+    case "thread_count":
+      return row.thread_count;
+    case "active_thread_count":
+      return row.active_thread_count;
+  }
+}
+
+function compareRows(
+  a: AuthorDensityRow,
+  b: AuthorDensityRow,
+  metric: CommentsAuthorDensitySortMetric,
+): number {
+  // Primary: chosen metric descending.
+  const primary = metricValue(b, metric) - metricValue(a, metric);
+  if (primary !== 0) return primary;
+  // Secondary: display name ascending (handles ties on the metric).
+  const displayCmp = a.displayName.localeCompare(b.displayName);
+  if (displayCmp !== 0) return displayCmp;
+  // Final: author key ascending — handles duplicate display names AND a
+  // sentinel-vs-real-name collision per FR-4-05.  Map keys are unique by
+  // construction (one bucket per author key), so the equality branch is
+  // unreachable in practice — collapsed into a two-way ternary so coverage
+  // gates do not flag a dead third arm.
+  return a.authorKey < b.authorKey ? -1 : 1;
+}
+
+export interface CommentsAuthorDensityOptions {
+  filters?: FilterState;
+  authorsDimension?: readonly AuthorDirectoryEntry[];
+  sortMetric?: CommentsAuthorDensitySortMetric;
+}
+
+/**
+ * Render the per-author comments-density breakdown.
+ *
+ * @param container Target container element. The dashboard call site is
+ *                  responsible for capability-on container provisioning
+ *                  (T024 ``ensureCommentsAuthorDensityContainer``); the
+ *                  chart treats ``null`` as a no-op.
+ * @param rollups   Weekly rollups in chronological order. Weeks lacking
+ *                  the ``by_author_comments`` outer dict are filtered
+ *                  out (capability-off path defense).
+ * @param options   Filter state + authors directory + chosen sort metric.
+ *                  Defaults: no filters, no directory, sort by
+ *                  ``comment_count`` descending.
+ */
+export function renderCommentsAuthorDensityChart(
+  container: HTMLElement | null,
+  rollups: Rollup[],
+  options?: CommentsAuthorDensityOptions,
+): void {
+  if (!container) return;
+
+  if (options?.filters && hasActiveFilters(options.filters)) {
+    renderNoData(
+      container,
+      "Comments density is not yet filterable",
+      "Clear repo / team / author / reviewer filters to view per-author review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322.",
+    );
+    return;
+  }
+
+  const withByAuthor = rollups.filter(hasByAuthorComments);
+  const reduced = reducePerAuthor(withByAuthor);
+
+  if (reduced.size === 0) {
+    renderNoData(
+      container,
+      "No comments data for selected range",
+      "Try widening the date range, or confirm comments extraction is enabled for this dataset.",
+    );
+    return;
+  }
+
+  const directory = buildAuthorsDirectory(options?.authorsDimension);
+  const rows: AuthorDensityRow[] = [];
+  for (const [key, bucket] of reduced) {
+    rows.push({
+      authorKey: key,
+      displayName: resolveDisplayName(key, directory),
+      thread_count: bucket.thread_count,
+      comment_count: bucket.comment_count,
+      active_thread_count: bucket.active_thread_count,
+      coverage_partial: bucket.coverage_partial,
+    });
+  }
+
+  const activeMetric: CommentsAuthorDensitySortMetric =
+    options?.sortMetric ?? "comment_count";
+  rows.sort((a, b) => compareRows(a, b, activeMetric));
+
+  const truncated = rows.length > MAX_COMMENTS_AUTHOR_DENSITY_ROWS;
+  const display = truncated
+    ? rows.slice(0, MAX_COMMENTS_AUTHOR_DENSITY_ROWS)
+    : rows;
+  const truncationHtml = renderTruncationIndicator(
+    truncated,
+    MAX_COMMENTS_AUTHOR_DENSITY_ROWS,
+    "authors",
+  );
+  const sortControlsHtml = renderSortControls(activeMetric);
+  const tableHtml = renderTable(display);
+  const anyPartial = display.some((r) => r.coverage_partial);
+  const partialLegendHtml = anyPartial
+    ? `<div class="chart-legend"><div class="legend-item legend-coverage-partial-item"><span class="legend-bar legend-bar-coverage-partial"></span><span>Partial coverage</span></div></div>`
+    : "";
+
+  renderTrustedHtml(
+    container,
+    `${truncationHtml}${sortControlsHtml}${tableHtml}${partialLegendHtml}`,
+  );
+}
+
+function metricLabel(metric: CommentsAuthorDensitySortMetric): string {
+  // Switch dispatch on the closed SortMetric union — same reason as
+  // ``metricValue``: avoids dynamic bracket access into a Record while
+  // staying exhaustive at the type level.
+  switch (metric) {
+    case "comment_count":
+      return "Comments";
+    case "thread_count":
+      return "Threads";
+    case "active_thread_count":
+      return "Active threads";
+  }
+}
+
+function renderSortControls(
+  activeMetric: CommentsAuthorDensitySortMetric,
+): string {
+  const buttons = COMMENTS_AUTHOR_DENSITY_SORT_METRICS.map((metric) => {
+    const checked = metric === activeMetric;
+    const ariaChecked = checked ? "true" : "false";
+    const tabIndex = checked ? "0" : "-1";
+    const label = metricLabel(metric);
+    return `<button type="button" class="comments-author-density-sort-btn${checked ? " is-active" : ""}" role="radio" aria-checked="${ariaChecked}" tabindex="${tabIndex}" data-sort-metric="${escapeHtml(metric)}">${escapeHtml(label)}</button>`;
+  }).join("");
+  return `<div class="comments-author-density-sort" role="radiogroup" aria-label="Sort author rows by metric">${buttons}</div>`;
+}
+
+function renderTable(rows: readonly AuthorDensityRow[]): string {
+  const rowsHtml = rows.map((row) => renderRow(row)).join("");
+  return `<div class="comments-author-density-table" role="table" aria-label="Per-author comment density"><div class="comments-author-density-thead" role="row"><div role="columnheader">Author</div><div role="columnheader" class="comments-author-density-numeric">Threads</div><div role="columnheader" class="comments-author-density-numeric">Active threads</div><div role="columnheader" class="comments-author-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+}
+
+function renderRow(row: AuthorDensityRow): string {
+  const partialClass = row.coverage_partial ? " coverage-partial" : "";
+  const partialAttr = row.coverage_partial
+    ? ' data-coverage-partial="true"'
+    : "";
+  const partialNote = row.coverage_partial ? " (partial coverage)" : "";
+  const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
+  return `<div class="comments-author-density-row${partialClass}" role="row" data-author-key="${escapeHtml(row.authorKey)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-author-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+}

--- a/extension/ui/modules/charts/index.ts
+++ b/extension/ui/modules/charts/index.ts
@@ -23,5 +23,8 @@ export * from "./predictions";
 // Comments-trend chart (Feature 333 — weekly review-conversation volume)
 export * from "./comments-trend";
 
+// Comments-author-density chart (Feature 334 — per-author breakdown)
+export * from "./comments-author-density";
+
 // Re-export existing chart utilities from parent charts.ts
 // These will be moved here in a future refactor

--- a/extension/ui/schemas/rollup.schema.ts
+++ b/extension/ui/schemas/rollup.schema.ts
@@ -99,6 +99,27 @@ export interface PrRecord {
 }
 
 /**
+ * Per-author comments-density entry (Feature 334, INV-2-08).
+ *
+ * Inner-dict shape for one entry of the `rollup[W].by_author_comments`
+ * outer dict.  Atomic when the outer dict is present (INV-2-08): all
+ * four fields MUST be present together with non-null typed values, or
+ * the entire entry is a contract violation.  The outer dict's key is
+ * `author_id` (UUID string) or the reserved sentinel literal
+ * `__former_or_unavailable_author__` for PRs whose `author_id` is
+ * absent from the `users` table per CL-03.
+ *
+ * Authoritative declaration:
+ * specs/334-comments-author-density/contracts/per-author-comments-density.md §1.
+ */
+export interface AuthorCommentsDensityEntry {
+  thread_count: number;
+  comment_count: number;
+  active_thread_count: number;
+  coverage_partial: boolean;
+}
+
+/**
  * Weekly rollup structure.
  */
 export interface WeeklyRollup {
@@ -136,6 +157,13 @@ export interface WeeklyRollup {
     active_thread_count: number;
     coverage_partial: boolean;
   };
+  // Feature 334 per-author comments-density (rollup root).  Outer dict
+  // optional at the root level; when present every entry is atomic per
+  // INV-2-08 (mirrors 333 INV-1-08 at sub-object granularity).
+  // Capability-off (FR-3-03) omits the entire key (NOT `{}`, NOT `null`).
+  // Authoritative declaration:
+  // specs/334-comments-author-density/contracts/per-author-comments-density.md §1.
+  by_author_comments?: Record<string, AuthorCommentsDensityEntry>;
 }
 
 // ============================================================================
@@ -167,6 +195,10 @@ const KNOWN_ROOT_FIELDS = new Set([
   // Feature 333 weekly comments-aggregate (gated on capabilities.comments_metrics).
   // Atomic when present per INV-1-08; absent entirely when capability-off (FR-3-03).
   "comments",
+  // Feature 334 per-author comments-density (gated on capabilities.comments_metrics).
+  // Outer dict at rollup root; per-entry atomic per INV-2-08; absent entirely
+  // when capability-off (FR-3-03 + INV-2-09).
+  "by_author_comments",
 ]);
 
 const PR_RECORD_REQUIRED_FIELDS: readonly (keyof PrRecord)[] = [
@@ -772,6 +804,187 @@ function validateCommentsAggregate(
   return { errors };
 }
 
+/**
+ * Validate the rollup-root `by_author_comments` outer dict (Feature 334,
+ * INV-2-08 atomicity).
+ *
+ * Atomicity posture per ADR T003 (mirrors 333 ADR T004): STRICT ERROR in
+ * BOTH strict and permissive modes.  The validator pushes to `errors`,
+ * NOT `warnings` — INV-2-08 is a fresh contract introduced by Feature
+ * 334 with no legacy emissions to grandfather, so renderers may trust
+ * each entry's atomicity without per-field defensive null-checks.
+ *
+ * When `by_author_comments` is present:
+ *   - It MUST be an object (the outer Record<authorKey, entry>).
+ *   - Every entry value MUST satisfy the four-field atomicity contract
+ *     (`thread_count` / `comment_count` / `active_thread_count` /
+ *     `coverage_partial` all present, numeric fields non-null integers,
+ *     boolean coverage_partial, INV-2-07 ordering).
+ *   - The reserved sentinel literal `__former_or_unavailable_author__`
+ *     is a permitted outer-dict key — no special handling, just another
+ *     string keying its own atomic entry.
+ *
+ * Capability-off (FR-3-03) is signalled by the entire `by_author_comments`
+ * key being absent — that path simply skips this validator with no
+ * warning.  Empty outer dict (`{}`) under capability-on is a contract
+ * violation (the producer omits the key entirely when no buckets).
+ */
+function validateAuthorCommentsDensity(
+  data: unknown,
+  path: string,
+): { errors: ValidationError[] } {
+  const errors: ValidationError[] = [];
+
+  if (!isObject(data)) {
+    errors.push(createError(path, "object", getTypeName(data)));
+    return { errors };
+  }
+
+  // Use `Object.entries` to iterate own-property [key, value] pairs without
+  // triggering `security/detect-object-injection` on a dynamic bracket
+  // lookup — the iteration is over guaranteed-own-properties (Object.entries
+  // skips inherited / symbol keys), so prototype injection is impossible.
+  const entries: ReadonlyArray<readonly [string, unknown]> = Object.entries(
+    data as Record<string, unknown>,
+  );
+  if (entries.length === 0) {
+    errors.push(
+      createError(
+        path,
+        "non-empty Record<string, AuthorCommentsDensityEntry>",
+        "{}",
+        `by_author_comments MUST be omitted entirely when no per-author buckets exist (FR-3-03 + INV-2-09); empty object is a contract violation`,
+      ),
+    );
+    return { errors };
+  }
+
+  const requiredFields: readonly (
+    | "thread_count"
+    | "comment_count"
+    | "active_thread_count"
+    | "coverage_partial"
+  )[] = [
+    "thread_count",
+    "comment_count",
+    "active_thread_count",
+    "coverage_partial",
+  ];
+
+  for (const [key, entry] of entries) {
+    const entryPath = buildPath(path, key);
+
+    if (!isObject(entry)) {
+      errors.push(createError(entryPath, "object", getTypeName(entry)));
+      continue;
+    }
+
+    // INV-2-08 atomicity: all four required fields must be present.
+    const missing = requiredFields.filter(
+      (field) => !Object.prototype.hasOwnProperty.call(entry, field),
+    );
+    if (missing.length > 0) {
+      errors.push(
+        createError(
+          entryPath,
+          "all four of thread_count / comment_count / active_thread_count / coverage_partial",
+          `missing: ${missing.join(", ")}`,
+          `by_author_comments[${key}] atomicity violated (INV-2-08): expected all four of thread_count / comment_count / active_thread_count / coverage_partial; missing: ${missing.join(", ")}`,
+        ),
+      );
+    }
+
+    const numericFieldChecks: readonly {
+      name: "thread_count" | "comment_count" | "active_thread_count";
+      value: unknown;
+    }[] = [
+      { name: "thread_count", value: entry.thread_count },
+      { name: "comment_count", value: entry.comment_count },
+      { name: "active_thread_count", value: entry.active_thread_count },
+    ];
+    for (const { name, value } of numericFieldChecks) {
+      if (!Object.prototype.hasOwnProperty.call(entry, name)) {
+        continue;
+      }
+      if (value === null) {
+        errors.push(
+          createError(
+            buildPath(entryPath, name),
+            "number (non-null per INV-2-08; zero is the valid sum over an empty extracted-subset)",
+            "null",
+            `by_author_comments[${key}].${name} MUST be a non-null number (INV-2-08); null is not a valid sentinel — use 0 for an empty extracted-subset`,
+          ),
+        );
+      } else if (!isNumber(value)) {
+        errors.push(
+          createError(
+            buildPath(entryPath, name),
+            "number",
+            getTypeName(value),
+            `expected number at 'by_author_comments[${key}].${name}', got ${getTypeName(value)}`,
+          ),
+        );
+      } else if (value < 0) {
+        errors.push(
+          createError(
+            buildPath(entryPath, name),
+            "non-negative number (counts cannot be negative)",
+            String(value),
+            `by_author_comments[${key}].${name} MUST be non-negative; got ${value}`,
+          ),
+        );
+      } else if (!Number.isInteger(value)) {
+        errors.push(
+          createError(
+            buildPath(entryPath, name),
+            "integer (counts must be whole numbers)",
+            String(value),
+            `by_author_comments[${key}].${name} MUST be an integer; got ${value}`,
+          ),
+        );
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(entry, "coverage_partial")) {
+      const coveragePartial = entry.coverage_partial;
+      if (!isBoolean(coveragePartial)) {
+        errors.push(
+          createError(
+            buildPath(entryPath, "coverage_partial"),
+            "boolean",
+            getTypeName(coveragePartial),
+            `expected boolean at 'by_author_comments[${key}].coverage_partial', got ${getTypeName(coveragePartial)}`,
+          ),
+        );
+      }
+    }
+
+    // INV-2-07 ordering: active_thread_count <= thread_count per entry.
+    const entryThread = entry.thread_count;
+    const entryActive = entry.active_thread_count;
+    if (
+      isNumber(entryThread) &&
+      isNumber(entryActive) &&
+      Number.isInteger(entryThread) &&
+      Number.isInteger(entryActive) &&
+      entryThread >= 0 &&
+      entryActive >= 0 &&
+      entryActive > entryThread
+    ) {
+      errors.push(
+        createError(
+          buildPath(entryPath, "active_thread_count"),
+          "<= thread_count (INV-2-07; active is a subset of total)",
+          `${entryActive} > ${entryThread}`,
+          `by_author_comments[${key}] ordering violated (INV-2-07): active_thread_count (${entryActive}) MUST NOT exceed thread_count (${entryThread})`,
+        ),
+      );
+    }
+  }
+
+  return { errors };
+}
+
 // ============================================================================
 // Main Validator
 // ============================================================================
@@ -991,6 +1204,23 @@ export function validateRollup(
   ) {
     const commentsResult = validateCommentsAggregate(data.comments, "comments");
     errors.push(...commentsResult.errors);
+  }
+
+  // Feature 334 per-author comments-density (rollup root).  Optional outer
+  // dict; per-entry atomic per INV-2-08.  ADR T003 atomicity posture is
+  // STRICT ERROR in both modes — same justification as Feature 333's
+  // `comments` validator (no legacy emissions to grandfather).
+  // Capability-off (FR-3-03) is signalled by the entire `by_author_comments`
+  // key being absent — that path skips the validator with no warning.
+  if (
+    Object.prototype.hasOwnProperty.call(data, "by_author_comments") &&
+    data.by_author_comments !== undefined
+  ) {
+    const byAuthorCommentsResult = validateAuthorCommentsDensity(
+      data.by_author_comments,
+      "by_author_comments",
+    );
+    errors.push(...byAuthorCommentsResult.errors);
   }
 
   // Check for unknown fields at root

--- a/extension/ui/styles.css
+++ b/extension/ui/styles.css
@@ -3839,3 +3839,91 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
         transparent 5px
     );
 }
+
+/* =====================================================================
+ * Feature 334: per-author comments-density chart
+ * Row-table layout (one row per author) with a 3-button radio-group
+ * sort selector, top-50 cap, and a per-row partial-coverage qualifier
+ * mirroring the 333 .coverage-partial CSS class hook.
+ * ===================================================================*/
+.comments-author-density-sort {
+    display: flex;
+    gap: 0.5rem;
+    margin: 0.5rem 0 0.75rem 0;
+    flex-wrap: wrap;
+}
+
+.comments-author-density-sort-btn {
+    border: 1px solid var(--border-color, #d0d7de);
+    background: var(--bg-secondary, #f6f8fa);
+    color: var(--text-primary, inherit);
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    line-height: 1.4;
+}
+
+.comments-author-density-sort-btn:focus-visible {
+    outline: 2px solid var(--primary, #0969da);
+    outline-offset: 2px;
+}
+
+.comments-author-density-sort-btn.is-active {
+    background: var(--primary, #0969da);
+    color: var(--bg-primary, #ffffff);
+    border-color: var(--primary, #0969da);
+}
+
+.comments-author-density-table {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
+    column-gap: 1rem;
+    row-gap: 0.125rem;
+    align-items: center;
+}
+
+.comments-author-density-thead,
+.comments-author-density-row {
+    display: contents;
+}
+
+.comments-author-density-thead > [role="columnheader"] {
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary, #57606a);
+    padding: 0.25rem 0;
+    border-bottom: 1px solid var(--border-color, #d0d7de);
+}
+
+.comments-author-density-row > [role="cell"] {
+    padding: 0.25rem 0;
+    font-size: 0.9375rem;
+}
+
+.comments-author-density-row .comments-author-density-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.comments-author-density-numeric {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
+/* Partial-coverage qualifier on rows whose reduced coverage_partial=true
+ * (FR-4-03).  Shares the .coverage-partial class hook with 333 so the
+ * convention stays visually consistent across the two surfaces. */
+.comments-author-density-row.coverage-partial > [role="cell"] {
+    color: var(--text-tertiary, #6e7781);
+    background-image: repeating-linear-gradient(
+        45deg,
+        rgba(110, 119, 129, 0.08) 0,
+        rgba(110, 119, 129, 0.08) 4px,
+        transparent 4px,
+        transparent 8px
+    );
+}

--- a/scripts/generate-demo-data.py
+++ b/scripts/generate-demo-data.py
@@ -2230,25 +2230,26 @@ def main(argv: list[str] | None = None) -> int:
             # stay byte-identical across runs.
             if _EMIT_COMMENTS_METRICS:
                 rollup_data["prs"] = synthetic_prs
-                # Feature 333 (FR-2-06): rollup-level weekly comments aggregate.
-                # Sum per-PR triplet over the EXTRACTED-SUBSET (PRs where the
-                # per-PR partial sentinel is NOT applied — i.e., thread_count
-                # is not None per 310 INV-10).  PRs with thread_count is None
-                # contribute zero per FR-2-03 and flip coverage_partial to
-                # True.  Matches aggregators.py::_compute_weekly_comments_
-                # aggregate semantics exactly so synthetic and real-data
-                # rollups have identical shape (per the test_schema_guard
-                # KNOWN_ROOT_FIELDS contract).
-                rollup_data["comments"] = _aggregate_comments_for_week(synthetic_prs)
-                # Feature 334 (FR-1-01..FR-1-08, INV-2-10): rollup-level
-                # per-author comments-density outer dict.  One bucket per
-                # author_id, numeric sums over the bucket's extracted-subset,
-                # per-bucket coverage_partial.  Aggregated from the FULL
-                # synthetic_prs_full set (not the capped synthetic_prs)
-                # so the demo matches production's
-                # ``_compute_weekly_by_author_comments`` semantics on
-                # truncated weeks (qualified_count > _PR_DETAIL_CAP).
-                # Omits the key when no buckets exist per FR-3-03 / INV-2-09.
+                # Feature 333 (FR-2-06) + Feature 334 (FR-1-01..08, INV-2-10):
+                # both rollup-root comments aggregates MUST span W's FULL
+                # extracted-subset, NOT the 500-row drill-down slice.
+                # Production aggregators.py::_compute_weekly_comments_aggregate
+                # and _compute_weekly_by_author_comments are both keyed on
+                # week_pr_uids (the full week's PR set) — emitting them
+                # from the capped synthetic_prs would diverge from
+                # production on truncated weeks (qualified_count >
+                # _PR_DETAIL_CAP=500) AND inconsistently between the two
+                # rollup-root keys.  Aggregating both from
+                # synthetic_prs_full keeps the demo aligned with production
+                # and internally consistent (the per-week comments total
+                # equals the sum across by_author_comments buckets on every
+                # week, including W26 with 520 PRs).
+                rollup_data["comments"] = _aggregate_comments_for_week(
+                    synthetic_prs_full
+                )
+                # Feature 334 per-author bucketing.  Mirrors production
+                # ``_compute_weekly_by_author_comments``; omits the key
+                # when no buckets exist per FR-3-03 / INV-2-09.
                 weekly_by_author_comments = _aggregate_by_author_comments_for_week(
                     synthetic_prs_full
                 )

--- a/scripts/generate-demo-data.py
+++ b/scripts/generate-demo-data.py
@@ -553,6 +553,63 @@ def _aggregate_comments_for_week(prs: list[PrRecord]) -> dict[str, int | bool]:
     }
 
 
+def _aggregate_by_author_comments_for_week(
+    prs: list[PrRecord],
+) -> dict[str, dict[str, int | bool]] | None:
+    """Per-(week, author) comments-density emission for the synthetic demo.
+
+    Mirrors ``aggregators.py::_compute_weekly_by_author_comments``
+    semantics so the demo and the real-data aggregator emit byte-aligned
+    shapes for the Feature 334 ``by_author_comments`` rollup-root key.
+
+    One bucket per ``author_id`` appearing on any PR in ``prs``.  Numeric
+    fields sum over the bucket's extracted-subset (PRs whose
+    ``thread_count`` is not None per 310 INV-10).  ``coverage_partial``
+    is True iff at least one PR in the bucket has ``thread_count is None``
+    (FR-1-06).  Outer dict keys are emitted in ascending order by
+    author key for byte-determinism (matches the aggregator's
+    ``ORDER BY author_or_sentinel ASC`` plus ``json.dumps(sort_keys=True)``).
+
+    All synthetic-demo authors exist in the users surface, so the
+    reserved sentinel literal ``__former_or_unavailable_author__`` is
+    never used here — sentinel-value parity is exercised by the SC05
+    reconciliation test against the production aggregator on a fixture
+    that DOES include a ghost author (see ``GHOST_USER_ID`` in
+    ``tests/fixtures/sc05/fixture_builder.py``).
+
+    Returns ``None`` when ``prs`` is empty so callers can omit the
+    ``by_author_comments`` key entirely (FR-3-03 / INV-2-09 omission
+    contract).  Caller is responsible for capability gating.
+    """
+    if not prs:
+        return None
+    grouped: dict[str, list[PrRecord]] = {}
+    for pr in prs:
+        author = str(pr["author_id"])
+        grouped.setdefault(author, []).append(pr)
+    buckets: dict[str, dict[str, int | bool]] = {}
+    for author in sorted(grouped):
+        thread_total = 0
+        comment_total = 0
+        active_total = 0
+        coverage_partial = False
+        for pr in grouped[author]:
+            thread = pr.get("thread_count")
+            if thread is None:
+                coverage_partial = True
+                continue
+            thread_total += int(thread)
+            comment_total += int(pr.get("comment_count") or 0)
+            active_total += int(pr.get("active_thread_count") or 0)
+        buckets[author] = {
+            "thread_count": thread_total,
+            "comment_count": comment_total,
+            "active_thread_count": active_total,
+            "coverage_partial": coverage_partial,
+        }
+    return buckets if buckets else None
+
+
 # =============================================================================
 # UUID v5 Generation (T007)
 # =============================================================================
@@ -2147,6 +2204,17 @@ def main(argv: list[str] | None = None) -> int:
                 # rollups have identical shape (per the test_schema_guard
                 # KNOWN_ROOT_FIELDS contract).
                 rollup_data["comments"] = _aggregate_comments_for_week(synthetic_prs)
+                # Feature 334 (FR-1-01..FR-1-08): rollup-level per-author
+                # comments-density outer dict.  One bucket per author_id,
+                # numeric sums over the bucket's extracted-subset, per-bucket
+                # coverage_partial.  Mirrors aggregators.py::_compute_weekly_
+                # by_author_comments semantics; omits the key when no buckets
+                # exist per FR-3-03 / INV-2-09.
+                weekly_by_author_comments = _aggregate_by_author_comments_for_week(
+                    synthetic_prs
+                )
+                if weekly_by_author_comments:
+                    rollup_data["by_author_comments"] = weekly_by_author_comments
             else:
                 rollup_data["prs"] = [
                     _strip_comments_metrics_from_pr(pr) for pr in synthetic_prs

--- a/scripts/generate-demo-data.py
+++ b/scripts/generate-demo-data.py
@@ -399,15 +399,16 @@ def generate_pr_records(
     author_entries: list[object],
     pr_record_rng: random.Random,
     comments_metrics_rng: random.Random | None = None,
+    cap: int = _PR_DETAIL_CAP,
 ) -> list[PrRecord]:
     """Produce synthetic PR records for a single rollup week.
 
     Each entry in ``repo_entries`` represents one qualified PR in the week
     (the caller computes the qualified count; the helper assigns title,
-    cycle time, author, and id to each). Returns at most ``_PR_DETAIL_CAP``
-    records, sorted by ``(-cycle_time, id)``. Slice 2c scaffolds the
-    helper; slice 2d wires emission into the rollup loop and regenerates
-    ``docs/data/``.
+    cycle time, author, and id to each). Returns at most ``cap`` records
+    (default ``_PR_DETAIL_CAP``), sorted by ``(-cycle_time, id)``. Slice
+    2c scaffolds the helper; slice 2d wires emission into the rollup
+    loop and regenerates ``docs/data/``.
 
     Feature 310 (#182): the three comments-metrics fields
     (``thread_count`` / ``comment_count`` / ``active_thread_count``)
@@ -415,6 +416,16 @@ def generate_pr_records(
     Defaulting to the module-level stream keeps the standalone CLI
     path simple; test harnesses that check RNG isolation MUST pass a
     fresh ``random.Random`` so the two streams stay independent.
+
+    Feature 334 (#334): the optional ``cap`` parameter lets callers
+    request the FULL week of qualified PRs (``cap=len(repo_entries)``)
+    so the per-author comments-density aggregate (``by_author_comments``)
+    can be summed over W's full extracted-subset per INV-2-10 — not the
+    500-row drill-down slice.  Default behaviour is unchanged
+    (``cap=_PR_DETAIL_CAP``) so byte-determinism for the legacy
+    drill-down emission stays intact; callers wanting the full set MUST
+    snapshot/restore both RNG streams around the call so downstream
+    weeks see the original RNG state advancement.
 
     Contract:
         * ``specs/309-demo-pr-drilldown/contracts/byte-determinism-regen.md``
@@ -432,7 +443,7 @@ def generate_pr_records(
         name: (mu, sigma) for name, mu, sigma in categories_tuple
     }
     base_id = _week_pr_id_base(week)
-    capped_entries = list(repo_entries)[:_PR_DETAIL_CAP]
+    capped_entries = list(repo_entries)[:cap]
 
     if not author_entries:
         raise ValueError("author_entries must be non-empty")
@@ -2180,6 +2191,31 @@ def main(argv: list[str] | None = None) -> int:
                 if rollup.by_author
                 else [f"fallback-author-{rollup.week}"]
             )
+            # Feature 334 INV-2-10: the per-author comments-density aggregate
+            # MUST sum over W's FULL extracted-subset, not the 500-row
+            # drill-down slice (production aggregator's
+            # ``_compute_weekly_by_author_comments`` is keyed on
+            # ``week_pr_uids`` which holds the entire week's PR set).
+            # To match that semantics in the synthetic demo without
+            # advancing the RNG streams differently from the legacy
+            # drill-down generation, snapshot both streams, generate the
+            # full uncapped set for the per-author aggregate, restore the
+            # streams, then generate the capped set as before.  After
+            # this block both RNG states are exactly where they would
+            # have been after a single ``generate_pr_records`` call —
+            # downstream weeks see byte-identical input.
+            pr_record_rng_state = pr_record_rng.getstate()
+            comments_metrics_rng_state = comments_metrics_rng.getstate()
+            synthetic_prs_full = generate_pr_records(
+                rollup.week,
+                repo_entries,
+                author_entries,
+                pr_record_rng,
+                comments_metrics_rng=comments_metrics_rng,
+                cap=len(repo_entries),
+            )
+            pr_record_rng.setstate(pr_record_rng_state)
+            comments_metrics_rng.setstate(comments_metrics_rng_state)
             synthetic_prs = generate_pr_records(
                 rollup.week, repo_entries, author_entries, pr_record_rng
             )
@@ -2204,14 +2240,17 @@ def main(argv: list[str] | None = None) -> int:
                 # rollups have identical shape (per the test_schema_guard
                 # KNOWN_ROOT_FIELDS contract).
                 rollup_data["comments"] = _aggregate_comments_for_week(synthetic_prs)
-                # Feature 334 (FR-1-01..FR-1-08): rollup-level per-author
-                # comments-density outer dict.  One bucket per author_id,
-                # numeric sums over the bucket's extracted-subset, per-bucket
-                # coverage_partial.  Mirrors aggregators.py::_compute_weekly_
-                # by_author_comments semantics; omits the key when no buckets
-                # exist per FR-3-03 / INV-2-09.
+                # Feature 334 (FR-1-01..FR-1-08, INV-2-10): rollup-level
+                # per-author comments-density outer dict.  One bucket per
+                # author_id, numeric sums over the bucket's extracted-subset,
+                # per-bucket coverage_partial.  Aggregated from the FULL
+                # synthetic_prs_full set (not the capped synthetic_prs)
+                # so the demo matches production's
+                # ``_compute_weekly_by_author_comments`` semantics on
+                # truncated weeks (qualified_count > _PR_DETAIL_CAP).
+                # Omits the key when no buckets exist per FR-3-03 / INV-2-09.
                 weekly_by_author_comments = _aggregate_by_author_comments_for_week(
-                    synthetic_prs
+                    synthetic_prs_full
                 )
                 if weekly_by_author_comments:
                     rollup_data["by_author_comments"] = weekly_by_author_comments

--- a/src/ado_git_repo_insights/transform/aggregators.py
+++ b/src/ado_git_repo_insights/transform/aggregators.py
@@ -40,6 +40,7 @@ from ..types import (
     UserRecord,
     WeeklyRollupIndexEntry,
 )
+from .constants import FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL
 from .schema_versions import (
     AGGREGATES_SCHEMA_VERSION,
     DATASET_SCHEMA_VERSION,
@@ -714,6 +715,19 @@ class AggregateGenerator:
             if weekly_comments is not None:
                 rollup_dict["comments"] = weekly_comments
 
+            # Feature 334: per-(week, author) comments-density emission
+            # (FR-1-01..FR-1-08).  Capability-on emits the
+            # ``by_author_comments`` outer dict on the rollup root, keyed
+            # by author_id (or the reserved sentinel literal when the
+            # author is absent from ``users``).  Capability-off omits the
+            # key entirely (FR-3-03 + INV-2-08 atomicity).  Empty outer
+            # dict (no PRs in the canonical set) is also omitted.
+            weekly_by_author_comments = self._compute_weekly_by_author_comments(
+                week_pr_uids
+            )
+            if weekly_by_author_comments:
+                rollup_dict["by_author_comments"] = weekly_by_author_comments
+
             if by_repository:
                 rollup_dict["by_repository"] = by_repository
             if by_author:
@@ -1070,6 +1084,141 @@ class AggregateGenerator:
             "active_thread_count": int(row["active_thread_count"]),
             "coverage_partial": coverage_partial,
         }
+
+    def _compute_weekly_by_author_comments(
+        self, week_pr_uids: set[str]
+    ) -> dict[str, dict[str, int | bool]] | None:
+        """Compute per-(week, author) ``by_author_comments`` emission for one week.
+
+        Returns ``None`` when ``_has_comments()`` is False or when
+        ``week_pr_uids`` is empty so callers can omit the
+        ``by_author_comments`` key entirely (FR-3-03 + INV-2-08
+        atomicity — the key MUST be absent under capability-off, NOT
+        ``None``-valued, NOT ``{}``-valued, NOT partial).
+
+        When capability-on with a non-empty canonical set, returns an
+        outer dict keyed by ``author_id`` (or the reserved sentinel
+        literal ``FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL`` when the
+        author is absent from the ``users`` table per CL-03 + FR-1-03).
+        Each inner dict carries the four atomic fields:
+
+          - ``thread_count``: SUM over the bucket's extracted-subset
+            (PRs with ``comments_extracted_at IS NOT NULL``) of the
+            per-PR active-or-closed thread count, after C1 inclusion
+            (``pr_threads.is_deleted = 0``).  PRs in the canonical
+            set with ``comments_extracted_at IS NULL`` contribute zero
+            to this sum (FR-1-05).
+          - ``comment_count``: SUM over the same extracted-subset of
+            per-PR comment count after C1 (``pr_comments.is_deleted = 0``).
+          - ``active_thread_count``: SUM over the same extracted-subset
+            of per-PR active-thread count (threads with
+            ``status = 'active'`` after C1).
+          - ``coverage_partial``: ``True`` iff at least one PR in W's
+            canonical throughput PR set keyed under the same bucket
+            has ``comments_extracted_at IS NULL`` (FR-1-06).  Each
+            bucket's flag is independent of every other bucket's flag.
+
+        Outer dict key order is ascending by author key (the stable
+        identity string, including the sentinel literal which sorts
+        between digit-starting and letter-starting UUIDs in ASCII)
+        per QG-05 + plan.md directive 3.  Display name is NOT used
+        for producer-side ordering — that's renderer-side tie-breaking
+        per FR-4-05.
+
+        SQL pattern mirrors ``_compute_weekly_comments_aggregate`` but
+        adds a ``LEFT JOIN users`` for sentinel detection and a
+        ``GROUP BY author_or_sentinel``.  Sentinel literal is bound
+        via parameter (not f-string interpolation) — S608 compliance
+        per ``reference_s608_refactor_pattern.md``.
+
+        Spec anchors: FR-1-01..FR-1-08, FR-3-03, INV-2-07, INV-2-08,
+        ADR T005, ADR T006, CL-03, CL-07.  C1 contract authority:
+        ``specs/310-comments-visualization/spec.md`` "Shared
+        inclusion-rule contract (C1)".
+        """
+        if not self._has_comments():
+            return None
+
+        if not week_pr_uids:
+            # Defensive: empty canonical set yields no bucket emission.
+            # Callers see ``None`` and omit the ``by_author_comments``
+            # key (consistent with FR-3-03 omission contract).
+            return None
+
+        self.db.execute(
+            "CREATE TEMP TABLE IF NOT EXISTS "
+            "_aggr_week_by_author_comments_slice "
+            "(pull_request_uid TEXT PRIMARY KEY)"
+        )
+        self.db.execute("DELETE FROM _aggr_week_by_author_comments_slice")
+        self.db.executemany(
+            "INSERT INTO _aggr_week_by_author_comments_slice "
+            "(pull_request_uid) VALUES (?)",
+            [(uid,) for uid in week_pr_uids],
+        )
+
+        cursor = self.db.execute(
+            "SELECT "
+            "  CASE WHEN u.user_id IS NULL THEN ? ELSE pr.user_id END "
+            "    AS author_or_sentinel, "
+            "  COALESCE(SUM(CASE WHEN pr.comments_extracted_at IS NOT NULL "
+            "                    THEN t.thread_count ELSE 0 END), 0) "
+            "    AS thread_count, "
+            "  COALESCE(SUM(CASE WHEN pr.comments_extracted_at IS NOT NULL "
+            "                    THEN c.comment_count ELSE 0 END), 0) "
+            "    AS comment_count, "
+            "  COALESCE(SUM(CASE WHEN pr.comments_extracted_at IS NOT NULL "
+            "                    THEN t.active_thread_count ELSE 0 END), 0) "
+            "    AS active_thread_count, "
+            "  MAX(CASE WHEN pr.comments_extracted_at IS NULL "
+            "          THEN 1 ELSE 0 END) "
+            "    AS coverage_partial "
+            "FROM pull_requests pr "
+            "INNER JOIN _aggr_week_by_author_comments_slice s "
+            "  ON s.pull_request_uid = pr.pull_request_uid "
+            "LEFT JOIN users u ON u.user_id = pr.user_id "
+            "LEFT JOIN ( "
+            "  SELECT pull_request_uid, "
+            "         COUNT(*) AS thread_count, "
+            "         SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) "
+            "           AS active_thread_count "
+            "  FROM pr_threads "
+            "  WHERE is_deleted = 0 "
+            "  GROUP BY pull_request_uid "
+            ") t ON t.pull_request_uid = pr.pull_request_uid "
+            "LEFT JOIN ( "
+            "  SELECT pull_request_uid, COUNT(*) AS comment_count "
+            "  FROM pr_comments "
+            "  WHERE is_deleted = 0 "
+            "  GROUP BY pull_request_uid "
+            ") c ON c.pull_request_uid = pr.pull_request_uid "
+            "GROUP BY author_or_sentinel "
+            "ORDER BY author_or_sentinel ASC",
+            (FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL,),
+        )
+
+        buckets: dict[str, dict[str, int | bool]] = {}
+        for row in cursor.fetchall():
+            key_raw = row["author_or_sentinel"]
+            if key_raw is None:
+                # Defensive: a NULL author_id with no users-row would
+                # have been mapped to the sentinel by the CASE; a NULL
+                # author key here means an unexpected schema state.
+                # Skip rather than emit a NULL key into the JSON.
+                continue
+            key = str(key_raw)
+            coverage_raw = row["coverage_partial"]
+            coverage_partial = coverage_raw is not None and int(coverage_raw) > 0
+            buckets[key] = {
+                "thread_count": int(row["thread_count"]),
+                "comment_count": int(row["comment_count"]),
+                "active_thread_count": int(row["active_thread_count"]),
+                "coverage_partial": coverage_partial,
+            }
+
+        if not buckets:
+            return None
+        return buckets
 
     def _generate_author_slice(
         self, week_group: pd.DataFrame, week_reviewers: pd.DataFrame

--- a/src/ado_git_repo_insights/transform/constants.py
+++ b/src/ado_git_repo_insights/transform/constants.py
@@ -1,0 +1,27 @@
+"""Module-scoped constants for the transform package.
+
+This module holds constants that BOTH ``aggregators.py`` and the
+Feature 333 + 334 reconciliation tests must agree on.  Keeping them
+here (instead of inside ``aggregators.py``) lets the reconciliation
+test in ``tests/integration/test_comments_trend_reconciliation.py``
+import the constants without violating the Feature 333 round-9
+import-block isolation rule (``aggregators.py`` import is forbidden
+by file from that test).
+
+Spec anchors:
+- ``specs/334-comments-author-density/spec.md`` FR-1-03, CL-03, ADR T006
+- ``specs/310-comments-visualization/spec.md`` "Shared inclusion-rule
+  contract (C1)" — single-sentinel-identity rule for unknown authors.
+"""
+
+from typing import Final
+
+# Reserved bucket key for ALL PRs whose ``author_id`` is absent from the
+# ``users`` table.  The leading-double-underscore namespace cannot collide
+# with author_id UUID strings (32 hex chars + 4 hyphens per the existing
+# extractor) — see Feature 334 spec Assumption A-07.
+#
+# Renderer-side label is the fixed English string
+# ``"Former / unavailable author"`` (CL-03), kept hard-coded in the
+# extension chart module per ADR T006 (renderer-self-contained).
+FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL: Final[str] = "__former_or_unavailable_author__"

--- a/src/ado_git_repo_insights/ui_bundle/artifact-client.js
+++ b/src/ado_git_repo_insights/ui_bundle/artifact-client.js
@@ -1330,7 +1330,11 @@ var PRInsightsArtifactClient = (() => {
     "_prs_cap",
     // Feature 333 weekly comments-aggregate (gated on capabilities.comments_metrics).
     // Atomic when present per INV-1-08; absent entirely when capability-off (FR-3-03).
-    "comments"
+    "comments",
+    // Feature 334 per-author comments-density (gated on capabilities.comments_metrics).
+    // Outer dict at rollup root; per-entry atomic per INV-2-08; absent entirely
+    // when capability-off (FR-3-03 + INV-2-09).
+    "by_author_comments"
   ]);
   var PR_RECORD_REQUIRED_FIELDS = [
     "id",
@@ -1742,6 +1746,126 @@ var PRInsightsArtifactClient = (() => {
     }
     return { errors };
   }
+  function validateAuthorCommentsDensity(data, path) {
+    const errors = [];
+    if (!isObject(data)) {
+      errors.push(createError(path, "object", getTypeName(data)));
+      return { errors };
+    }
+    const entries = Object.entries(
+      data
+    );
+    if (entries.length === 0) {
+      errors.push(
+        createError(
+          path,
+          "non-empty Record<string, AuthorCommentsDensityEntry>",
+          "{}",
+          `by_author_comments MUST be omitted entirely when no per-author buckets exist (FR-3-03 + INV-2-09); empty object is a contract violation`
+        )
+      );
+      return { errors };
+    }
+    const requiredFields = [
+      "thread_count",
+      "comment_count",
+      "active_thread_count",
+      "coverage_partial"
+    ];
+    for (const [key, entry] of entries) {
+      const entryPath = buildPath(path, key);
+      if (!isObject(entry)) {
+        errors.push(createError(entryPath, "object", getTypeName(entry)));
+        continue;
+      }
+      const missing = requiredFields.filter(
+        (field) => !Object.prototype.hasOwnProperty.call(entry, field)
+      );
+      if (missing.length > 0) {
+        errors.push(
+          createError(
+            entryPath,
+            "all four of thread_count / comment_count / active_thread_count / coverage_partial",
+            `missing: ${missing.join(", ")}`,
+            `by_author_comments[${key}] atomicity violated (INV-2-08): expected all four of thread_count / comment_count / active_thread_count / coverage_partial; missing: ${missing.join(", ")}`
+          )
+        );
+      }
+      const numericFieldChecks = [
+        { name: "thread_count", value: entry.thread_count },
+        { name: "comment_count", value: entry.comment_count },
+        { name: "active_thread_count", value: entry.active_thread_count }
+      ];
+      for (const { name, value } of numericFieldChecks) {
+        if (!Object.prototype.hasOwnProperty.call(entry, name)) {
+          continue;
+        }
+        if (value === null) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number (non-null per INV-2-08; zero is the valid sum over an empty extracted-subset)",
+              "null",
+              `by_author_comments[${key}].${name} MUST be a non-null number (INV-2-08); null is not a valid sentinel \u2014 use 0 for an empty extracted-subset`
+            )
+          );
+        } else if (!isNumber(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number",
+              getTypeName(value),
+              `expected number at 'by_author_comments[${key}].${name}', got ${getTypeName(value)}`
+            )
+          );
+        } else if (value < 0) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "non-negative number (counts cannot be negative)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be non-negative; got ${value}`
+            )
+          );
+        } else if (!Number.isInteger(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "integer (counts must be whole numbers)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be an integer; got ${value}`
+            )
+          );
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, "coverage_partial")) {
+        const coveragePartial = entry.coverage_partial;
+        if (!isBoolean(coveragePartial)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, "coverage_partial"),
+              "boolean",
+              getTypeName(coveragePartial),
+              `expected boolean at 'by_author_comments[${key}].coverage_partial', got ${getTypeName(coveragePartial)}`
+            )
+          );
+        }
+      }
+      const entryThread = entry.thread_count;
+      const entryActive = entry.active_thread_count;
+      if (isNumber(entryThread) && isNumber(entryActive) && Number.isInteger(entryThread) && Number.isInteger(entryActive) && entryThread >= 0 && entryActive >= 0 && entryActive > entryThread) {
+        errors.push(
+          createError(
+            buildPath(entryPath, "active_thread_count"),
+            "<= thread_count (INV-2-07; active is a subset of total)",
+            `${entryActive} > ${entryThread}`,
+            `by_author_comments[${key}] ordering violated (INV-2-07): active_thread_count (${entryActive}) MUST NOT exceed thread_count (${entryThread})`
+          )
+        );
+      }
+    }
+    return { errors };
+  }
   function validateRollup(data, strict) {
     const errors = [];
     const warnings = [];
@@ -1892,6 +2016,13 @@ var PRInsightsArtifactClient = (() => {
     if (Object.prototype.hasOwnProperty.call(data, "comments") && data.comments !== void 0) {
       const commentsResult = validateCommentsAggregate(data.comments, "comments");
       errors.push(...commentsResult.errors);
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "by_author_comments") && data.by_author_comments !== void 0) {
+      const byAuthorCommentsResult = validateAuthorCommentsDensity(
+        data.by_author_comments,
+        "by_author_comments"
+      );
+      errors.push(...byAuthorCommentsResult.errors);
     }
     const unknown = findUnknownFields(data, KNOWN_ROOT_FIELDS2, "", strict);
     errors.push(...unknown.errors);

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -8782,12 +8782,11 @@ var PRInsightsDashboard = (() => {
   function renderSortControls(activeMetric) {
     const buttons = COMMENTS_AUTHOR_DENSITY_SORT_METRICS.map((metric) => {
       const checked = metric === activeMetric;
-      const ariaChecked = checked ? "true" : "false";
-      const tabIndex = checked ? "0" : "-1";
+      const ariaPressed = checked ? "true" : "false";
       const label = metricLabel(metric);
-      return `<button type="button" class="comments-author-density-sort-btn${checked ? " is-active" : ""}" role="radio" aria-checked="${ariaChecked}" tabindex="${tabIndex}" data-sort-metric="${escapeHtml(metric)}">${escapeHtml(label)}</button>`;
+      return `<button type="button" class="comments-author-density-sort-btn${checked ? " is-active" : ""}" aria-pressed="${ariaPressed}" data-sort-metric="${escapeHtml(metric)}">${escapeHtml(label)}</button>`;
     }).join("");
-    return `<div class="comments-author-density-sort" role="radiogroup" aria-label="Sort author rows by metric">${buttons}</div>`;
+    return `<div class="comments-author-density-sort" role="toolbar" aria-label="Sort author rows by metric">${buttons}</div>`;
   }
   function renderTable(rows) {
     const rowsHtml = rows.map((row) => renderRow(row)).join("");

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -8665,6 +8665,53 @@ var PRInsightsDashboard = (() => {
     if (displayCmp !== 0) return displayCmp;
     return a2.authorKey < b2.authorKey ? -1 : 1;
   }
+  var sortMetricByContainer = /* @__PURE__ */ new WeakMap();
+  var sortListenerControllers = /* @__PURE__ */ new WeakMap();
+  function attachSortToggleListeners(container, rollups, options) {
+    sortListenerControllers.get(container)?.abort();
+    const controller = new AbortController();
+    sortListenerControllers.set(container, controller);
+    const { signal } = controller;
+    const resolveMetric = (raw) => {
+      return COMMENTS_AUTHOR_DENSITY_SORT_METRICS.find((m2) => m2 === raw);
+    };
+    const activate = (metric) => {
+      sortMetricByContainer.set(container, metric);
+      renderCommentsAuthorDensityChart(container, rollups, {
+        ...options,
+        sortMetric: metric
+      });
+    };
+    const findSortButton = (event) => {
+      const target = event.target;
+      return target.closest(".comments-author-density-sort-btn");
+    };
+    container.addEventListener(
+      "click",
+      (event) => {
+        const button = findSortButton(event);
+        if (!button) return;
+        const metric = resolveMetric(button.dataset.sortMetric);
+        if (!metric) return;
+        activate(metric);
+      },
+      { signal }
+    );
+    container.addEventListener(
+      "keydown",
+      (event) => {
+        const button = findSortButton(event);
+        if (!button) return;
+        const key = event.key;
+        if (key !== "Enter" && key !== " ") return;
+        const metric = resolveMetric(button.dataset.sortMetric);
+        if (!metric) return;
+        event.preventDefault();
+        activate(metric);
+      },
+      { signal }
+    );
+  }
   function renderCommentsAuthorDensityChart(container, rollups, options) {
     if (!container) return;
     if (options?.filters && hasActiveFilters2(options.filters)) {
@@ -8697,7 +8744,13 @@ var PRInsightsDashboard = (() => {
         coverage_partial: bucket.coverage_partial
       });
     }
-    const activeMetric = options?.sortMetric ?? "comment_count";
+    let activeMetric;
+    if (options?.sortMetric) {
+      activeMetric = options.sortMetric;
+      sortMetricByContainer.set(container, activeMetric);
+    } else {
+      activeMetric = sortMetricByContainer.get(container) ?? "comment_count";
+    }
     rows.sort((a2, b2) => compareRows(a2, b2, activeMetric));
     const truncated = rows.length > MAX_COMMENTS_AUTHOR_DENSITY_ROWS;
     const display = truncated ? rows.slice(0, MAX_COMMENTS_AUTHOR_DENSITY_ROWS) : rows;
@@ -8714,6 +8767,7 @@ var PRInsightsDashboard = (() => {
       container,
       `${truncationHtml}${sortControlsHtml}${tableHtml}${partialLegendHtml}`
     );
+    attachSortToggleListeners(container, rollups, options);
   }
   function metricLabel(metric) {
     switch (metric) {

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -8596,6 +8596,8 @@ var PRInsightsDashboard = (() => {
 
   // ../ui/modules/charts/comments-author-density.ts
   var MAX_COMMENTS_AUTHOR_DENSITY_ROWS = 50;
+  var FORMER_OR_UNAVAILABLE_AUTHOR_KEY = "__former_or_unavailable_author__";
+  var FORMER_OR_UNAVAILABLE_AUTHOR_LABEL = "Former / unavailable author";
   var COMMENTS_AUTHOR_DENSITY_SORT_METRICS = [
     "comment_count",
     "thread_count",
@@ -8640,6 +8642,9 @@ var PRInsightsDashboard = (() => {
     return map;
   }
   function resolveDisplayName(authorKey, directory) {
+    if (authorKey === FORMER_OR_UNAVAILABLE_AUTHOR_KEY) {
+      return FORMER_OR_UNAVAILABLE_AUTHOR_LABEL;
+    }
     if (directory) {
       const found = directory.get(authorKey);
       if (typeof found === "string" && found.length > 0) {

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -1312,7 +1312,11 @@ var PRInsightsDashboard = (() => {
     "_prs_cap",
     // Feature 333 weekly comments-aggregate (gated on capabilities.comments_metrics).
     // Atomic when present per INV-1-08; absent entirely when capability-off (FR-3-03).
-    "comments"
+    "comments",
+    // Feature 334 per-author comments-density (gated on capabilities.comments_metrics).
+    // Outer dict at rollup root; per-entry atomic per INV-2-08; absent entirely
+    // when capability-off (FR-3-03 + INV-2-09).
+    "by_author_comments"
   ]);
   var PR_RECORD_REQUIRED_FIELDS = [
     "id",
@@ -1724,6 +1728,126 @@ var PRInsightsDashboard = (() => {
     }
     return { errors };
   }
+  function validateAuthorCommentsDensity(data, path) {
+    const errors = [];
+    if (!isObject(data)) {
+      errors.push(createError(path, "object", getTypeName(data)));
+      return { errors };
+    }
+    const entries = Object.entries(
+      data
+    );
+    if (entries.length === 0) {
+      errors.push(
+        createError(
+          path,
+          "non-empty Record<string, AuthorCommentsDensityEntry>",
+          "{}",
+          `by_author_comments MUST be omitted entirely when no per-author buckets exist (FR-3-03 + INV-2-09); empty object is a contract violation`
+        )
+      );
+      return { errors };
+    }
+    const requiredFields = [
+      "thread_count",
+      "comment_count",
+      "active_thread_count",
+      "coverage_partial"
+    ];
+    for (const [key, entry] of entries) {
+      const entryPath = buildPath(path, key);
+      if (!isObject(entry)) {
+        errors.push(createError(entryPath, "object", getTypeName(entry)));
+        continue;
+      }
+      const missing = requiredFields.filter(
+        (field) => !Object.prototype.hasOwnProperty.call(entry, field)
+      );
+      if (missing.length > 0) {
+        errors.push(
+          createError(
+            entryPath,
+            "all four of thread_count / comment_count / active_thread_count / coverage_partial",
+            `missing: ${missing.join(", ")}`,
+            `by_author_comments[${key}] atomicity violated (INV-2-08): expected all four of thread_count / comment_count / active_thread_count / coverage_partial; missing: ${missing.join(", ")}`
+          )
+        );
+      }
+      const numericFieldChecks = [
+        { name: "thread_count", value: entry.thread_count },
+        { name: "comment_count", value: entry.comment_count },
+        { name: "active_thread_count", value: entry.active_thread_count }
+      ];
+      for (const { name, value } of numericFieldChecks) {
+        if (!Object.prototype.hasOwnProperty.call(entry, name)) {
+          continue;
+        }
+        if (value === null) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number (non-null per INV-2-08; zero is the valid sum over an empty extracted-subset)",
+              "null",
+              `by_author_comments[${key}].${name} MUST be a non-null number (INV-2-08); null is not a valid sentinel \u2014 use 0 for an empty extracted-subset`
+            )
+          );
+        } else if (!isNumber(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number",
+              getTypeName(value),
+              `expected number at 'by_author_comments[${key}].${name}', got ${getTypeName(value)}`
+            )
+          );
+        } else if (value < 0) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "non-negative number (counts cannot be negative)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be non-negative; got ${value}`
+            )
+          );
+        } else if (!Number.isInteger(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "integer (counts must be whole numbers)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be an integer; got ${value}`
+            )
+          );
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, "coverage_partial")) {
+        const coveragePartial = entry.coverage_partial;
+        if (!isBoolean(coveragePartial)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, "coverage_partial"),
+              "boolean",
+              getTypeName(coveragePartial),
+              `expected boolean at 'by_author_comments[${key}].coverage_partial', got ${getTypeName(coveragePartial)}`
+            )
+          );
+        }
+      }
+      const entryThread = entry.thread_count;
+      const entryActive = entry.active_thread_count;
+      if (isNumber(entryThread) && isNumber(entryActive) && Number.isInteger(entryThread) && Number.isInteger(entryActive) && entryThread >= 0 && entryActive >= 0 && entryActive > entryThread) {
+        errors.push(
+          createError(
+            buildPath(entryPath, "active_thread_count"),
+            "<= thread_count (INV-2-07; active is a subset of total)",
+            `${entryActive} > ${entryThread}`,
+            `by_author_comments[${key}] ordering violated (INV-2-07): active_thread_count (${entryActive}) MUST NOT exceed thread_count (${entryThread})`
+          )
+        );
+      }
+    }
+    return { errors };
+  }
   function validateRollup(data, strict) {
     const errors = [];
     const warnings = [];
@@ -1874,6 +1998,13 @@ var PRInsightsDashboard = (() => {
     if (Object.prototype.hasOwnProperty.call(data, "comments") && data.comments !== void 0) {
       const commentsResult = validateCommentsAggregate(data.comments, "comments");
       errors.push(...commentsResult.errors);
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "by_author_comments") && data.by_author_comments !== void 0) {
+      const byAuthorCommentsResult = validateAuthorCommentsDensity(
+        data.by_author_comments,
+        "by_author_comments"
+      );
+      errors.push(...byAuthorCommentsResult.errors);
     }
     const unknown = findUnknownFields(data, KNOWN_ROOT_FIELDS2, "", strict);
     errors.push(...unknown.errors);

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -6365,7 +6365,7 @@ var PRInsightsDashboard = (() => {
     const historicalPath = calculateLinePath(historicalPoints);
     const forecastPath = calculateLinePath(forecastPoints);
     const bandPath = calculateBandPath(upperPoints, lowerPoints);
-    const metricLabel = forecast.metric.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+    const metricLabel2 = forecast.metric.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
     const allWeeks = [];
     if (historicalData) {
       historicalData.forEach((h2) => allWeeks.push(h2.week));
@@ -6379,12 +6379,12 @@ var PRInsightsDashboard = (() => {
     }).join("");
     const latestValue = values[values.length - 1];
     const rangeClause = latestValue.lower_bound != null && latestValue.upper_bound != null ? ` (range ${latestValue.lower_bound.toFixed(1)} to ${latestValue.upper_bound.toFixed(1)})` : "";
-    const accessibleSummary = `${metricLabel} forecast: ${latestValue.predicted.toFixed(1)} ${forecast.unit}${rangeClause}`;
+    const accessibleSummary = `${metricLabel2} forecast: ${latestValue.predicted.toFixed(1)} ${forecast.unit}${rangeClause}`;
     const safeMetricId = sanitizeForId(forecast.metric);
     return `
-    <div class="forecast-chart" role="region" aria-label="${escapeHtml(metricLabel)} forecast">
+    <div class="forecast-chart" role="region" aria-label="${escapeHtml(metricLabel2)} forecast">
       <div class="chart-header">
-        <h4 id="chart-${safeMetricId}">${escapeHtml(metricLabel)}</h4>
+        <h4 id="chart-${safeMetricId}">${escapeHtml(metricLabel2)}</h4>
         <span class="chart-unit">(${escapeHtml(forecast.unit)})</span>
         ${wasTruncated ? `<span class="truncation-badge" title="Showing last ${MAX_CHART_POINTS} data points">Partial history</span>` : ""}
       </div>
@@ -6920,14 +6920,14 @@ var PRInsightsDashboard = (() => {
   }
   function renderInsightDataSection(data) {
     if (!data) return "";
-    const metricLabel = data.metric.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+    const metricLabel2 = data.metric.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
     const trendIcon = TREND_ICONS[data.trend_direction] || "";
     const trendClass = `trend-${data.trend_direction}`;
     const changeDisplay = data.change_percent !== void 0 ? `${data.change_percent > 0 ? "+" : ""}${data.change_percent.toFixed(1)}%` : "";
     return `
     <div class="insight-data-section">
       <div class="insight-metric">
-        <span class="metric-label">${escapeHtml(metricLabel)}</span>
+        <span class="metric-label">${escapeHtml(metricLabel2)}</span>
         <span class="metric-value">${escapeHtml(String(data.current_value))}</span>
         ${changeDisplay ? `<span class="metric-change ${trendClass}">${trendIcon} ${escapeHtml(changeDisplay)}</span>` : ""}
       </div>
@@ -8594,6 +8594,159 @@ var PRInsightsDashboard = (() => {
           ${partialNote}`;
   }
 
+  // ../ui/modules/charts/comments-author-density.ts
+  var MAX_COMMENTS_AUTHOR_DENSITY_ROWS = 50;
+  var COMMENTS_AUTHOR_DENSITY_SORT_METRICS = [
+    "comment_count",
+    "thread_count",
+    "active_thread_count"
+  ];
+  function hasByAuthorComments(rollup) {
+    const value = rollup.by_author_comments;
+    return value !== void 0 && value !== null && typeof value === "object";
+  }
+  function reducePerAuthor(rollups) {
+    const reduced = /* @__PURE__ */ new Map();
+    for (const rollup of rollups) {
+      for (const entry of Object.entries(rollup.by_author_comments)) {
+        const key = entry[0];
+        const bucket = entry[1];
+        const existing = reduced.get(key);
+        if (existing) {
+          existing.thread_count += bucket.thread_count;
+          existing.comment_count += bucket.comment_count;
+          existing.active_thread_count += bucket.active_thread_count;
+          existing.coverage_partial = existing.coverage_partial || bucket.coverage_partial;
+        } else {
+          reduced.set(key, {
+            thread_count: bucket.thread_count,
+            comment_count: bucket.comment_count,
+            active_thread_count: bucket.active_thread_count,
+            coverage_partial: bucket.coverage_partial
+          });
+        }
+      }
+    }
+    return reduced;
+  }
+  function buildAuthorsDirectory(authorsDimension) {
+    if (!authorsDimension) return null;
+    const map = /* @__PURE__ */ new Map();
+    for (const entry of authorsDimension) {
+      if (typeof entry.author_id === "string" && typeof entry.author_name === "string") {
+        map.set(entry.author_id, entry.author_name);
+      }
+    }
+    return map;
+  }
+  function resolveDisplayName(authorKey, directory) {
+    if (directory) {
+      const found = directory.get(authorKey);
+      if (typeof found === "string" && found.length > 0) {
+        return found;
+      }
+    }
+    return authorKey;
+  }
+  function metricValue(row, metric) {
+    switch (metric) {
+      case "comment_count":
+        return row.comment_count;
+      case "thread_count":
+        return row.thread_count;
+      case "active_thread_count":
+        return row.active_thread_count;
+    }
+  }
+  function compareRows(a2, b2, metric) {
+    const primary = metricValue(b2, metric) - metricValue(a2, metric);
+    if (primary !== 0) return primary;
+    const displayCmp = a2.displayName.localeCompare(b2.displayName);
+    if (displayCmp !== 0) return displayCmp;
+    return a2.authorKey < b2.authorKey ? -1 : 1;
+  }
+  function renderCommentsAuthorDensityChart(container, rollups, options) {
+    if (!container) return;
+    if (options?.filters && hasActiveFilters2(options.filters)) {
+      renderNoData(
+        container,
+        "Comments density is not yet filterable",
+        "Clear repo / team / author / reviewer filters to view per-author review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+      );
+      return;
+    }
+    const withByAuthor = rollups.filter(hasByAuthorComments);
+    const reduced = reducePerAuthor(withByAuthor);
+    if (reduced.size === 0) {
+      renderNoData(
+        container,
+        "No comments data for selected range",
+        "Try widening the date range, or confirm comments extraction is enabled for this dataset."
+      );
+      return;
+    }
+    const directory = buildAuthorsDirectory(options?.authorsDimension);
+    const rows = [];
+    for (const [key, bucket] of reduced) {
+      rows.push({
+        authorKey: key,
+        displayName: resolveDisplayName(key, directory),
+        thread_count: bucket.thread_count,
+        comment_count: bucket.comment_count,
+        active_thread_count: bucket.active_thread_count,
+        coverage_partial: bucket.coverage_partial
+      });
+    }
+    const activeMetric = options?.sortMetric ?? "comment_count";
+    rows.sort((a2, b2) => compareRows(a2, b2, activeMetric));
+    const truncated = rows.length > MAX_COMMENTS_AUTHOR_DENSITY_ROWS;
+    const display = truncated ? rows.slice(0, MAX_COMMENTS_AUTHOR_DENSITY_ROWS) : rows;
+    const truncationHtml = renderTruncationIndicator(
+      truncated,
+      MAX_COMMENTS_AUTHOR_DENSITY_ROWS,
+      "authors"
+    );
+    const sortControlsHtml = renderSortControls(activeMetric);
+    const tableHtml = renderTable(display);
+    const anyPartial = display.some((r2) => r2.coverage_partial);
+    const partialLegendHtml = anyPartial ? `<div class="chart-legend"><div class="legend-item legend-coverage-partial-item"><span class="legend-bar legend-bar-coverage-partial"></span><span>Partial coverage</span></div></div>` : "";
+    renderTrustedHtml(
+      container,
+      `${truncationHtml}${sortControlsHtml}${tableHtml}${partialLegendHtml}`
+    );
+  }
+  function metricLabel(metric) {
+    switch (metric) {
+      case "comment_count":
+        return "Comments";
+      case "thread_count":
+        return "Threads";
+      case "active_thread_count":
+        return "Active threads";
+    }
+  }
+  function renderSortControls(activeMetric) {
+    const buttons = COMMENTS_AUTHOR_DENSITY_SORT_METRICS.map((metric) => {
+      const checked = metric === activeMetric;
+      const ariaChecked = checked ? "true" : "false";
+      const tabIndex = checked ? "0" : "-1";
+      const label = metricLabel(metric);
+      return `<button type="button" class="comments-author-density-sort-btn${checked ? " is-active" : ""}" role="radio" aria-checked="${ariaChecked}" tabindex="${tabIndex}" data-sort-metric="${escapeHtml(metric)}">${escapeHtml(label)}</button>`;
+    }).join("");
+    return `<div class="comments-author-density-sort" role="radiogroup" aria-label="Sort author rows by metric">${buttons}</div>`;
+  }
+  function renderTable(rows) {
+    const rowsHtml = rows.map((row) => renderRow(row)).join("");
+    return `<div class="comments-author-density-table" role="table" aria-label="Per-author comment density"><div class="comments-author-density-thead" role="row"><div role="columnheader">Author</div><div role="columnheader" class="comments-author-density-numeric">Threads</div><div role="columnheader" class="comments-author-density-numeric">Active threads</div><div role="columnheader" class="comments-author-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+  }
+  function renderRow(row) {
+    const partialClass = row.coverage_partial ? " coverage-partial" : "";
+    const partialAttr = row.coverage_partial ? ' data-coverage-partial="true"' : "";
+    const partialNote = row.coverage_partial ? " (partial coverage)" : "";
+    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
+    return `<div class="comments-author-density-row${partialClass}" role="row" data-author-key="${escapeHtml(row.authorKey)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-author-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+  }
+
   // ../ui/modules/filter-constraint-resolver.ts
   function resolveFilterConstraints(raw, lastChanged) {
     const notices = [];
@@ -9281,7 +9434,7 @@ var PRInsightsDashboard = (() => {
   window.addEventListener(COMPARISON_TOGGLED_EVENT, comparisonListener);
 
   // ../ui/modules/shared/identity-fallback.ts
-  function resolveDisplayName(id, map) {
+  function resolveDisplayName2(id, map) {
     const mapped = map.get(id);
     return mapped !== void 0 ? mapped : id;
   }
@@ -9320,7 +9473,7 @@ var PRInsightsDashboard = (() => {
       return makeEmptyState(title, emptyDetail);
     }
     const rows = Object.entries(entries).sort((a2, b2) => b2[1].pr_count - a2[1].pr_count).map(([key, entry]) => ({
-      label: nameByKey ? resolveDisplayName(key, nameByKey) : key,
+      label: nameByKey ? resolveDisplayName2(key, nameByKey) : key,
       values: [String(entry.pr_count)]
     }));
     return makeBreakdownTable(title, columns, rows);
@@ -9705,7 +9858,7 @@ var PRInsightsDashboard = (() => {
   function buildPanelContent3(rollups, reviewerId, reviewerNameByKey) {
     const stats = buildStatRow(rollups, reviewerId);
     const subtitle = `${stats.totalPrs} ${stats.totalPrs === 1 ? "PR" : "PRs"} reviewed`;
-    const displayName = resolveDisplayName(reviewerId, reviewerNameByKey);
+    const displayName = resolveDisplayName2(reviewerId, reviewerNameByKey);
     return makePanelContent(displayName, subtitle, [
       stats.section,
       buildWeeklyTable(rollups, reviewerId)
@@ -10493,6 +10646,17 @@ var PRInsightsDashboard = (() => {
       } else {
         removeCommentsTrendContainer();
       }
+      if (loader?.getCapabilityState?.()?.commentsMetricsAvailable === true) {
+        const cadContainer = ensureCommentsAuthorDensityContainer();
+        if (cadContainer) {
+          renderCommentsAuthorDensityChart(cadContainer, rollups, {
+            filters: currentFilters,
+            authorsDimension: currentDimensions?.authors
+          });
+        }
+      } else {
+        removeCommentsAuthorDensityContainer();
+      }
       const throughputContainer = document.getElementById("throughput-chart");
       if (throughputContainer) {
         activeDrilldownHandles.push(
@@ -10719,7 +10883,7 @@ var PRInsightsDashboard = (() => {
         r2.reviewer_name
       ])
     );
-    const filterReviewerName = filterReviewerId !== void 0 ? resolveDisplayName(filterReviewerId, reviewerNameByKey) : void 0;
+    const filterReviewerName = filterReviewerId !== void 0 ? resolveDisplayName2(filterReviewerId, reviewerNameByKey) : void 0;
     renderReviewerActivity(
       elements.get("reviewer-activity") ?? null,
       rollups,
@@ -10762,6 +10926,41 @@ var PRInsightsDashboard = (() => {
     if (heading instanceof HTMLElement) {
       detachCommentsTrendInfoIcon(heading);
     }
+    row.parentElement?.removeChild(row);
+  }
+  function ensureCommentsAuthorDensityContainer() {
+    const existing = document.getElementById("comments-author-density");
+    if (existing) return existing;
+    const commentsTrendRow = document.querySelector(
+      '[data-comments-trend-row="true"]'
+    );
+    let anchorRow = commentsTrendRow;
+    if (!anchorRow) {
+      const cycleDist = document.getElementById("cycle-distribution");
+      anchorRow = cycleDist?.closest(".charts-row") ?? null;
+    }
+    if (!anchorRow || !anchorRow.parentElement) return null;
+    const row = document.createElement("div");
+    row.className = "charts-row";
+    row.setAttribute("data-comments-author-density-row", "true");
+    const containerCell = document.createElement("div");
+    containerCell.className = "chart-container";
+    const heading = document.createElement("h3");
+    heading.textContent = "Comment Density by Author";
+    containerCell.appendChild(heading);
+    const chart = document.createElement("div");
+    chart.id = "comments-author-density";
+    chart.className = "chart";
+    containerCell.appendChild(chart);
+    row.appendChild(containerCell);
+    anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+    return chart;
+  }
+  function removeCommentsAuthorDensityContainer() {
+    const row = document.querySelector(
+      '[data-comments-author-density-row="true"]'
+    );
+    if (!row) return;
     row.parentElement?.removeChild(row);
   }
   function toArtifactLoadResult(loaderResult, artifactPath) {

--- a/src/ado_git_repo_insights/ui_bundle/dataset-loader.js
+++ b/src/ado_git_repo_insights/ui_bundle/dataset-loader.js
@@ -1337,7 +1337,11 @@ var PRInsightsDatasetLoader = (() => {
     "_prs_cap",
     // Feature 333 weekly comments-aggregate (gated on capabilities.comments_metrics).
     // Atomic when present per INV-1-08; absent entirely when capability-off (FR-3-03).
-    "comments"
+    "comments",
+    // Feature 334 per-author comments-density (gated on capabilities.comments_metrics).
+    // Outer dict at rollup root; per-entry atomic per INV-2-08; absent entirely
+    // when capability-off (FR-3-03 + INV-2-09).
+    "by_author_comments"
   ]);
   var PR_RECORD_REQUIRED_FIELDS = [
     "id",
@@ -1749,6 +1753,126 @@ var PRInsightsDatasetLoader = (() => {
     }
     return { errors };
   }
+  function validateAuthorCommentsDensity(data, path) {
+    const errors = [];
+    if (!isObject(data)) {
+      errors.push(createError(path, "object", getTypeName(data)));
+      return { errors };
+    }
+    const entries = Object.entries(
+      data
+    );
+    if (entries.length === 0) {
+      errors.push(
+        createError(
+          path,
+          "non-empty Record<string, AuthorCommentsDensityEntry>",
+          "{}",
+          `by_author_comments MUST be omitted entirely when no per-author buckets exist (FR-3-03 + INV-2-09); empty object is a contract violation`
+        )
+      );
+      return { errors };
+    }
+    const requiredFields = [
+      "thread_count",
+      "comment_count",
+      "active_thread_count",
+      "coverage_partial"
+    ];
+    for (const [key, entry] of entries) {
+      const entryPath = buildPath(path, key);
+      if (!isObject(entry)) {
+        errors.push(createError(entryPath, "object", getTypeName(entry)));
+        continue;
+      }
+      const missing = requiredFields.filter(
+        (field) => !Object.prototype.hasOwnProperty.call(entry, field)
+      );
+      if (missing.length > 0) {
+        errors.push(
+          createError(
+            entryPath,
+            "all four of thread_count / comment_count / active_thread_count / coverage_partial",
+            `missing: ${missing.join(", ")}`,
+            `by_author_comments[${key}] atomicity violated (INV-2-08): expected all four of thread_count / comment_count / active_thread_count / coverage_partial; missing: ${missing.join(", ")}`
+          )
+        );
+      }
+      const numericFieldChecks = [
+        { name: "thread_count", value: entry.thread_count },
+        { name: "comment_count", value: entry.comment_count },
+        { name: "active_thread_count", value: entry.active_thread_count }
+      ];
+      for (const { name, value } of numericFieldChecks) {
+        if (!Object.prototype.hasOwnProperty.call(entry, name)) {
+          continue;
+        }
+        if (value === null) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number (non-null per INV-2-08; zero is the valid sum over an empty extracted-subset)",
+              "null",
+              `by_author_comments[${key}].${name} MUST be a non-null number (INV-2-08); null is not a valid sentinel \u2014 use 0 for an empty extracted-subset`
+            )
+          );
+        } else if (!isNumber(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number",
+              getTypeName(value),
+              `expected number at 'by_author_comments[${key}].${name}', got ${getTypeName(value)}`
+            )
+          );
+        } else if (value < 0) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "non-negative number (counts cannot be negative)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be non-negative; got ${value}`
+            )
+          );
+        } else if (!Number.isInteger(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "integer (counts must be whole numbers)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be an integer; got ${value}`
+            )
+          );
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, "coverage_partial")) {
+        const coveragePartial = entry.coverage_partial;
+        if (!isBoolean(coveragePartial)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, "coverage_partial"),
+              "boolean",
+              getTypeName(coveragePartial),
+              `expected boolean at 'by_author_comments[${key}].coverage_partial', got ${getTypeName(coveragePartial)}`
+            )
+          );
+        }
+      }
+      const entryThread = entry.thread_count;
+      const entryActive = entry.active_thread_count;
+      if (isNumber(entryThread) && isNumber(entryActive) && Number.isInteger(entryThread) && Number.isInteger(entryActive) && entryThread >= 0 && entryActive >= 0 && entryActive > entryThread) {
+        errors.push(
+          createError(
+            buildPath(entryPath, "active_thread_count"),
+            "<= thread_count (INV-2-07; active is a subset of total)",
+            `${entryActive} > ${entryThread}`,
+            `by_author_comments[${key}] ordering violated (INV-2-07): active_thread_count (${entryActive}) MUST NOT exceed thread_count (${entryThread})`
+          )
+        );
+      }
+    }
+    return { errors };
+  }
   function validateRollup(data, strict) {
     const errors = [];
     const warnings = [];
@@ -1899,6 +2023,13 @@ var PRInsightsDatasetLoader = (() => {
     if (Object.prototype.hasOwnProperty.call(data, "comments") && data.comments !== void 0) {
       const commentsResult = validateCommentsAggregate(data.comments, "comments");
       errors.push(...commentsResult.errors);
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "by_author_comments") && data.by_author_comments !== void 0) {
+      const byAuthorCommentsResult = validateAuthorCommentsDensity(
+        data.by_author_comments,
+        "by_author_comments"
+      );
+      errors.push(...byAuthorCommentsResult.errors);
     }
     const unknown = findUnknownFields(data, KNOWN_ROOT_FIELDS2, "", strict);
     errors.push(...unknown.errors);

--- a/src/ado_git_repo_insights/ui_bundle/settings.js
+++ b/src/ado_git_repo_insights/ui_bundle/settings.js
@@ -2048,7 +2048,11 @@ var PRInsightsSettings = (() => {
     "_prs_cap",
     // Feature 333 weekly comments-aggregate (gated on capabilities.comments_metrics).
     // Atomic when present per INV-1-08; absent entirely when capability-off (FR-3-03).
-    "comments"
+    "comments",
+    // Feature 334 per-author comments-density (gated on capabilities.comments_metrics).
+    // Outer dict at rollup root; per-entry atomic per INV-2-08; absent entirely
+    // when capability-off (FR-3-03 + INV-2-09).
+    "by_author_comments"
   ]);
   var PR_RECORD_REQUIRED_FIELDS = [
     "id",
@@ -2460,6 +2464,126 @@ var PRInsightsSettings = (() => {
     }
     return { errors };
   }
+  function validateAuthorCommentsDensity(data, path) {
+    const errors = [];
+    if (!isObject(data)) {
+      errors.push(createError(path, "object", getTypeName(data)));
+      return { errors };
+    }
+    const entries = Object.entries(
+      data
+    );
+    if (entries.length === 0) {
+      errors.push(
+        createError(
+          path,
+          "non-empty Record<string, AuthorCommentsDensityEntry>",
+          "{}",
+          `by_author_comments MUST be omitted entirely when no per-author buckets exist (FR-3-03 + INV-2-09); empty object is a contract violation`
+        )
+      );
+      return { errors };
+    }
+    const requiredFields = [
+      "thread_count",
+      "comment_count",
+      "active_thread_count",
+      "coverage_partial"
+    ];
+    for (const [key, entry] of entries) {
+      const entryPath = buildPath(path, key);
+      if (!isObject(entry)) {
+        errors.push(createError(entryPath, "object", getTypeName(entry)));
+        continue;
+      }
+      const missing = requiredFields.filter(
+        (field) => !Object.prototype.hasOwnProperty.call(entry, field)
+      );
+      if (missing.length > 0) {
+        errors.push(
+          createError(
+            entryPath,
+            "all four of thread_count / comment_count / active_thread_count / coverage_partial",
+            `missing: ${missing.join(", ")}`,
+            `by_author_comments[${key}] atomicity violated (INV-2-08): expected all four of thread_count / comment_count / active_thread_count / coverage_partial; missing: ${missing.join(", ")}`
+          )
+        );
+      }
+      const numericFieldChecks = [
+        { name: "thread_count", value: entry.thread_count },
+        { name: "comment_count", value: entry.comment_count },
+        { name: "active_thread_count", value: entry.active_thread_count }
+      ];
+      for (const { name, value } of numericFieldChecks) {
+        if (!Object.prototype.hasOwnProperty.call(entry, name)) {
+          continue;
+        }
+        if (value === null) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number (non-null per INV-2-08; zero is the valid sum over an empty extracted-subset)",
+              "null",
+              `by_author_comments[${key}].${name} MUST be a non-null number (INV-2-08); null is not a valid sentinel \u2014 use 0 for an empty extracted-subset`
+            )
+          );
+        } else if (!isNumber(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "number",
+              getTypeName(value),
+              `expected number at 'by_author_comments[${key}].${name}', got ${getTypeName(value)}`
+            )
+          );
+        } else if (value < 0) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "non-negative number (counts cannot be negative)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be non-negative; got ${value}`
+            )
+          );
+        } else if (!Number.isInteger(value)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, name),
+              "integer (counts must be whole numbers)",
+              String(value),
+              `by_author_comments[${key}].${name} MUST be an integer; got ${value}`
+            )
+          );
+        }
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, "coverage_partial")) {
+        const coveragePartial = entry.coverage_partial;
+        if (!isBoolean(coveragePartial)) {
+          errors.push(
+            createError(
+              buildPath(entryPath, "coverage_partial"),
+              "boolean",
+              getTypeName(coveragePartial),
+              `expected boolean at 'by_author_comments[${key}].coverage_partial', got ${getTypeName(coveragePartial)}`
+            )
+          );
+        }
+      }
+      const entryThread = entry.thread_count;
+      const entryActive = entry.active_thread_count;
+      if (isNumber(entryThread) && isNumber(entryActive) && Number.isInteger(entryThread) && Number.isInteger(entryActive) && entryThread >= 0 && entryActive >= 0 && entryActive > entryThread) {
+        errors.push(
+          createError(
+            buildPath(entryPath, "active_thread_count"),
+            "<= thread_count (INV-2-07; active is a subset of total)",
+            `${entryActive} > ${entryThread}`,
+            `by_author_comments[${key}] ordering violated (INV-2-07): active_thread_count (${entryActive}) MUST NOT exceed thread_count (${entryThread})`
+          )
+        );
+      }
+    }
+    return { errors };
+  }
   function validateRollup(data, strict) {
     const errors = [];
     const warnings = [];
@@ -2610,6 +2734,13 @@ var PRInsightsSettings = (() => {
     if (Object.prototype.hasOwnProperty.call(data, "comments") && data.comments !== void 0) {
       const commentsResult = validateCommentsAggregate(data.comments, "comments");
       errors.push(...commentsResult.errors);
+    }
+    if (Object.prototype.hasOwnProperty.call(data, "by_author_comments") && data.by_author_comments !== void 0) {
+      const byAuthorCommentsResult = validateAuthorCommentsDensity(
+        data.by_author_comments,
+        "by_author_comments"
+      );
+      errors.push(...byAuthorCommentsResult.errors);
     }
     const unknown = findUnknownFields(data, KNOWN_ROOT_FIELDS2, "", strict);
     errors.push(...unknown.errors);

--- a/src/ado_git_repo_insights/ui_bundle/styles.css
+++ b/src/ado_git_repo_insights/ui_bundle/styles.css
@@ -3839,3 +3839,91 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
         transparent 5px
     );
 }
+
+/* =====================================================================
+ * Feature 334: per-author comments-density chart
+ * Row-table layout (one row per author) with a 3-button radio-group
+ * sort selector, top-50 cap, and a per-row partial-coverage qualifier
+ * mirroring the 333 .coverage-partial CSS class hook.
+ * ===================================================================*/
+.comments-author-density-sort {
+    display: flex;
+    gap: 0.5rem;
+    margin: 0.5rem 0 0.75rem 0;
+    flex-wrap: wrap;
+}
+
+.comments-author-density-sort-btn {
+    border: 1px solid var(--border-color, #d0d7de);
+    background: var(--bg-secondary, #f6f8fa);
+    color: var(--text-primary, inherit);
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    line-height: 1.4;
+}
+
+.comments-author-density-sort-btn:focus-visible {
+    outline: 2px solid var(--primary, #0969da);
+    outline-offset: 2px;
+}
+
+.comments-author-density-sort-btn.is-active {
+    background: var(--primary, #0969da);
+    color: var(--bg-primary, #ffffff);
+    border-color: var(--primary, #0969da);
+}
+
+.comments-author-density-table {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto auto;
+    column-gap: 1rem;
+    row-gap: 0.125rem;
+    align-items: center;
+}
+
+.comments-author-density-thead,
+.comments-author-density-row {
+    display: contents;
+}
+
+.comments-author-density-thead > [role="columnheader"] {
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary, #57606a);
+    padding: 0.25rem 0;
+    border-bottom: 1px solid var(--border-color, #d0d7de);
+}
+
+.comments-author-density-row > [role="cell"] {
+    padding: 0.25rem 0;
+    font-size: 0.9375rem;
+}
+
+.comments-author-density-row .comments-author-density-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.comments-author-density-numeric {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
+/* Partial-coverage qualifier on rows whose reduced coverage_partial=true
+ * (FR-4-03).  Shares the .coverage-partial class hook with 333 so the
+ * convention stays visually consistent across the two surfaces. */
+.comments-author-density-row.coverage-partial > [role="cell"] {
+    color: var(--text-tertiary, #6e7781);
+    background-image: repeating-linear-gradient(
+        45deg,
+        rgba(110, 119, 129, 0.08) 0,
+        rgba(110, 119, 129, 0.08) 4px,
+        transparent 4px,
+        transparent 8px
+    );
+}

--- a/tests/fixtures/sc05/fixture_builder.py
+++ b/tests/fixtures/sc05/fixture_builder.py
@@ -70,6 +70,15 @@ USER_ID: Final[str] = "user-001"
 USER_NAME: Final[str] = "Demo User"
 USER_EMAIL: Final[str] = "demo@example.local"
 
+# Feature 334: a deliberately deprovisioned author whose ``user_id`` is
+# NOT inserted into the ``users`` table.  PRs assigned to this id (the
+# first PR of each fixture week per ``_populate_raw_rows``) exercise the
+# sentinel-bucket branch of the per-author reconciliation tests.  The
+# fixture insert path toggles ``PRAGMA foreign_keys = OFF`` before
+# inserting these PRs to mirror the production reality where deletions /
+# legacy migrations may leave orphaned PRs.
+GHOST_USER_ID: Final[str] = "ghost-001"
+
 
 @dataclass(frozen=True)
 class _ThreadSpec:
@@ -407,10 +416,27 @@ def _populate_raw_rows(sqlite_path: Path) -> None:
             (USER_ID, USER_NAME, USER_EMAIL),
         )
 
+        # Feature 334: disable FK enforcement so the first PR of each
+        # week can be authored by ``GHOST_USER_ID`` (absent from the
+        # ``users`` table) — required to exercise the sentinel-bucket
+        # branch of the per-author reconciliation tests
+        # (FR-2-03, CL-03).  The PRAGMA is restored to ON before
+        # ``build-aggregates`` runs so the production aggregator path
+        # encounters the same FK posture it would in production after
+        # an out-of-band user deletion.
+        conn.execute("PRAGMA foreign_keys = OFF")
         for week in _WEEKS:
-            for pr in week.prs:
+            for idx, pr in enumerate(week.prs):
                 pr_uid = _pr_uid(pr.pr_id)
                 comments_extracted_at = pr.closed_date if pr.extracted else None
+                # Route the FIRST PR of each fixture week to the
+                # ghost author so every week's per-author bucket dict
+                # contains exactly one sentinel-keyed entry — non-vacuous
+                # coverage for the sentinel parity assertion.  All other
+                # PRs continue to point at ``USER_ID`` so the
+                # known-author bucket also exists per week (cross-bucket
+                # coverage).
+                pr_user_id = GHOST_USER_ID if idx == 0 else USER_ID
                 conn.execute(
                     "INSERT INTO pull_requests "
                     "(pull_request_uid, pull_request_id, organization_name, "
@@ -425,7 +451,7 @@ def _populate_raw_rows(sqlite_path: Path) -> None:
                         ORG_NAME,
                         PROJECT_NAME,
                         REPO_ID,
-                        USER_ID,
+                        pr_user_id,
                         f"PR {pr.pr_id}",
                         "completed",
                         None,
@@ -494,6 +520,10 @@ def _populate_raw_rows(sqlite_path: Path) -> None:
                                 1,
                             ),
                         )
+        # Restore FK enforcement so the production ``build-aggregates``
+        # CLI invoked by ``build_fixture`` runs against the same FK
+        # posture it would in production.
+        conn.execute("PRAGMA foreign_keys = ON")
     finally:
         db.close()
 

--- a/tests/integration/test_comments_trend_meta_failure.py
+++ b/tests/integration/test_comments_trend_meta_failure.py
@@ -61,6 +61,11 @@ import sys
 from pathlib import Path
 from typing import Final
 
+import pytest
+
+from ado_git_repo_insights.transform.constants import (
+    FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL,
+)
 from tests.fixtures.sc05.fixture_builder import SC05Fixture
 
 _REPO_ROOT: Final[Path] = Path(__file__).resolve().parents[2]
@@ -209,4 +214,92 @@ def test_meta_reconciliation_fails_on_inv_1_06_violation(
         "reading the mutated working copy, or an assertion has been "
         "short-circuited. Subprocess stdout follows:\n"
         f"{completed.stdout}\n--- stderr ---\n{completed.stderr}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Feature 334 per-author meta-failure test                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _inject_per_author_inv207_violation(rollup_path: Path) -> tuple[str, str]:
+    """Inject a synthetic per-author INV-2-07 violation in by_author_comments.
+
+    Returns ``(week_key, bucket_key)`` so the meta-test failure message
+    can name both surfaces.  The injected entry uses the reserved
+    sentinel literal as its bucket key (guaranteed not to collide with
+    any real ``user_id`` per Feature 334 CL-03 / A-07), satisfies
+    INV-2-08 atomicity (all four fields present together) so the only
+    contract violated is INV-2-07's ordering rule
+    (``active_thread_count > thread_count``).  This isolates the
+    failure mode the meta-test is proving — per-author reconciliation
+    MUST detect the per-bucket active-vs-thread integrity violation
+    specifically, not simply reject any malformed sub-object.
+    """
+    payload = json.loads(rollup_path.read_text(encoding="utf-8"))
+    existing = payload.get("by_author_comments")
+    by_author_comments: dict[str, dict[str, int | bool]]
+    if isinstance(existing, dict):
+        by_author_comments = {
+            str(k): dict(v) if isinstance(v, dict) else {} for k, v in existing.items()
+        }
+    else:
+        by_author_comments = {}
+    by_author_comments[FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL] = {
+        "thread_count": _SYNTH_THREAD_COUNT,
+        "comment_count": _SYNTH_COMMENT_COUNT,
+        "active_thread_count": _SYNTH_ACTIVE_THREAD_COUNT,
+        "coverage_partial": _SYNTH_COVERAGE_PARTIAL,
+    }
+    payload["by_author_comments"] = by_author_comments
+    rollup_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return rollup_path.stem, FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "depends on the per-author reconciliation extension "
+        "(test_sc05_reconciliation_per_week_by_author_*) being green "
+        "on the clean demo before the per-author meta-failure can "
+        "evaluate cleanly; collection-stable per Principle XXVI"
+    ),
+)
+def test_meta_reconciliation_fails_on_per_author_inv_2_07_violation(
+    tmp_path: Path, sc05_fixture: SC05Fixture
+) -> None:
+    """FR-2-05 (Feature 334): reconciliation MUST fail on per-author INV-2-07 violation.
+
+    Mechanism:
+        1. Copy the SC-05 fixture into ``tmp_path``.
+        2. Pick the most recent weekly rollup; inject a synthetic
+           ``by_author_comments`` entry under the sentinel key with
+           ``active_thread_count = thread_count + 1`` (the spec-minimum
+           positive control for FR-2-05 propagated to per-author scope).
+        3. Invoke the FR-2-04 reconciliation test in a subprocess
+           pointed at the mutated working copy via ``ADO_SC05_FIXTURE_DIR``.
+        4. Assert subprocess returned non-zero (per-author reconciliation
+           detected the synthetic violation).  A return code of 0 means
+           per-author reconciliation has gone silently passive — exactly
+           the failure mode this meta-test exists to detect.
+    """
+    working_root = _copy_fixture_into(tmp_path, sc05_fixture)
+    target_rollup = _pick_target_rollup(working_root)
+    week_key, bucket_key = _inject_per_author_inv207_violation(target_rollup)
+
+    completed = _run_reconciliation_against(working_root)
+
+    assert completed.returncode != 0, (
+        "FR-2-05 violation (per-author scope): the FR-2-04 reconciliation "
+        f"test PASSED on a dataset where week {week_key} carries "
+        f"by_author_comments[{bucket_key!r}].active_thread_count="
+        f"{_SYNTH_ACTIVE_THREAD_COUNT} > thread_count={_SYNTH_THREAD_COUNT} "
+        "(INV-2-07 violation). Per-author reconciliation has gone silently "
+        "passive: either the per-bucket loop is skipping buckets, the "
+        "fixture loader is not reading the mutated working copy, or a "
+        "per-bucket assertion has been short-circuited. Subprocess stdout "
+        f"follows:\n{completed.stdout}\n--- stderr ---\n{completed.stderr}"
     )

--- a/tests/integration/test_comments_trend_reconciliation.py
+++ b/tests/integration/test_comments_trend_reconciliation.py
@@ -688,6 +688,13 @@ def test_sc05_reconciliation_per_week_by_author_sentinel_parity(
     weeks_to_prs = _attribute_prs_to_weeks(db_path)
     rollup_paths = sorted(sc05_fixture.rollups_dir.glob("*.json"))
 
+    # Non-vacuity tripwire: tally how many unknown-author PRs the test
+    # actually saw across all weeks.  Zero means the fixture has no
+    # ghost-author PRs and the sentinel-value-parity branch is never
+    # exercised — the test would pass vacuously and the contract
+    # surface would silently rot.  Asserted at the end of the loop.
+    total_unknown_prs_seen = 0
+
     with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as conn:
         conn.row_factory = sqlite3.Row
 
@@ -763,6 +770,15 @@ def test_sc05_reconciliation_per_week_by_author_sentinel_parity(
                 f"re-computation {any_unextracted!r} (FR-1-06 propagated "
                 "to sentinel bucket)"
             )
+            total_unknown_prs_seen += len(unknown_prs)
+
+    assert total_unknown_prs_seen > 0, (
+        "Vacuity guard: zero unknown-to-users PRs across every fixture "
+        "week, so the sentinel-value-parity branch above never fired.  "
+        "The fixture builder MUST seed at least one ghost-author PR "
+        "(see GHOST_USER_ID in tests/fixtures/sc05/fixture_builder.py) "
+        "so this test exercises FR-2-03's hot path on real demo data."
+    )
 
 
 def test_sc05_reconciliation_per_week_by_author_pairwise_drilldown(

--- a/tests/integration/test_comments_trend_reconciliation.py
+++ b/tests/integration/test_comments_trend_reconciliation.py
@@ -73,6 +73,9 @@ from typing import Final, TypedDict
 import pandas as pd
 import pytest
 
+from ado_git_repo_insights.transform.constants import (
+    FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL,
+)
 from tests.fixtures.sc05.fixture_builder import SC05Fixture
 
 
@@ -450,3 +453,389 @@ def test_sc05_reconciliation_per_week(sc05_fixture: SC05Fixture) -> None:
                 # all are out of scope for FR-2-04 (a) — the contract only
                 # covers PRs in the drill-down ∩ canonical intersection. No
                 # assertion here.
+
+
+# --------------------------------------------------------------------------- #
+# Feature 334 per-author reconciliation                                        #
+# --------------------------------------------------------------------------- #
+#
+# FR-2-01 / FR-2-02 / FR-2-03 (Feature 334): every (W, author_or_sentinel)
+# bucket emitted under ``rollup[W].by_author_comments`` MUST match an
+# independent re-computation grounded outside ``aggregators.py``.  The
+# round-9 isolation rule extends automatically since the import-forbid is
+# by-FILE; the helpers here re-implement bucket grouping via direct SQL
+# (LEFT JOIN to ``users`` for sentinel detection per FR-1-03 + CL-03) and
+# C1 inclusion rules (re-implemented inline per the existing 333 helpers
+# above, no aggregator imports).
+
+
+def _author_bucket_for_uid(
+    conn: sqlite3.Connection,
+    pull_request_uid: str,
+) -> str:
+    """Resolve the bucket key for one PR (author_id or sentinel literal).
+
+    Independent of ``aggregators.py``.  LEFT JOIN to ``users`` mirrors
+    the producer's resolution rule: PRs whose ``user_id`` is absent
+    from the ``users`` table collapse into the single sentinel bucket
+    ``FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL`` (CL-03 + FR-1-03).  A
+    NULL ``user_id`` on the PR row is treated as unknown-to-``users``
+    (also collapses into the sentinel bucket) — the same behavior the
+    aggregator's ``CASE WHEN u.user_id IS NULL`` produces.
+    """
+    cursor = conn.execute(
+        "SELECT pr.user_id, u.user_id AS users_match "
+        "FROM pull_requests pr "
+        "LEFT JOIN users u ON u.user_id = pr.user_id "
+        "WHERE pr.pull_request_uid = ?",
+        (pull_request_uid,),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL
+    if row["users_match"] is None:
+        return FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL
+    return str(row["user_id"])
+
+
+class _ExpectedBucket(TypedDict):
+    """Independent re-computation result for one (W, author_or_sentinel) bucket."""
+
+    thread_count: int
+    comment_count: int
+    active_thread_count: int
+    coverage_partial: bool
+
+
+def _build_expected_buckets(
+    conn: sqlite3.Connection,
+    canonical_prs: list[_CanonicalPrRow],
+) -> dict[str, _ExpectedBucket]:
+    """Independent re-computation of one week's per-author bucket emissions.
+
+    Groups ``canonical_prs`` by resolved bucket key (author_id or
+    sentinel) via direct SQL on each PR's ``user_id`` LEFT JOIN
+    ``users``.  For each bucket: filters to extracted-subset (PRs
+    with ``comments_extracted_at IS NOT NULL``), sums per-PR C1
+    counts via ``_per_pr_counts``, derives ``coverage_partial`` as
+    ``(any PR in the bucket has comments_extracted_at IS NULL)``.
+
+    Buckets with empty extracted-subset still emit (numeric=0, but
+    ``coverage_partial = True`` since by definition all the bucket's
+    PRs are unextracted — every author with any canonical PR gets a
+    bucket regardless of extraction state).
+    """
+    grouped: dict[str, list[_CanonicalPrRow]] = {}
+    for pr in canonical_prs:
+        bucket = _author_bucket_for_uid(conn, pr["pull_request_uid"])
+        grouped.setdefault(bucket, []).append(pr)
+
+    expected: dict[str, _ExpectedBucket] = {}
+    for bucket, prs in grouped.items():
+        thread_count = 0
+        comment_count = 0
+        active_thread_count = 0
+        any_unextracted = False
+        for pr in prs:
+            if pr["comments_extracted_at"] is None:
+                any_unextracted = True
+                continue
+            tc, cc, atc = _per_pr_counts(conn, pr["pull_request_uid"])
+            thread_count += tc
+            comment_count += cc
+            active_thread_count += atc
+        expected[bucket] = _ExpectedBucket(
+            thread_count=thread_count,
+            comment_count=comment_count,
+            active_thread_count=active_thread_count,
+            coverage_partial=any_unextracted,
+        )
+    return expected
+
+
+def _by_author_comments_dict(
+    rollup: dict[str, object],
+    week_key: str,
+) -> dict[str, dict[str, object]]:
+    """Return ``rollup[W].by_author_comments`` validated as a dict-of-dicts.
+
+    Fails the test with a clear message rather than a confusing type
+    error when the producer has not yet emitted the key (TDD failure
+    mode for the per-author reconciliation tests).
+    """
+    raw = rollup.get("by_author_comments")
+    assert raw is not None, (
+        f"week {week_key}: rollup[W].by_author_comments key MISSING. "
+        "FR-1-01 requires the aggregator to emit the per-author bucket "
+        "outer dict on every weekly rollup when "
+        "capabilities.comments_metrics is enabled and the canonical set "
+        "is non-empty.  Until Feature 334's aggregator emission lands, "
+        "this assertion is the TDD failure mode for the per-author "
+        "reconciliation tests."
+    )
+    assert isinstance(raw, dict), (
+        f"week {week_key}: rollup[W].by_author_comments has unexpected "
+        f"type {type(raw).__name__}; expected dict per INV-2-08 atomicity"
+    )
+    typed: dict[str, dict[str, object]] = {}
+    for key, entry in raw.items():
+        assert isinstance(entry, dict), (
+            f"week {week_key}: by_author_comments[{key!r}] has unexpected "
+            f"type {type(entry).__name__}; expected 4-field dict"
+        )
+        typed[str(key)] = entry
+    return typed
+
+
+def test_sc05_reconciliation_per_week_by_author_independent(
+    sc05_fixture: SC05Fixture,
+) -> None:
+    """FR-2-02 (Feature 334): per-(W, bucket) independent re-computation parity.
+
+    For every week W and every bucket key in ``rollup[W].by_author_comments``,
+    the four atomic fields MUST equal the result of an independent
+    re-computation that:
+
+    1. Determines W's canonical throughput PR set via direct SQL against
+       ``pull_requests`` (re-implemented week-attribution rule per ADR T005).
+    2. Groups each PR by resolved bucket key (author_id or sentinel)
+       via LEFT JOIN to ``users``.
+    3. Filters each bucket's PRs to W's extracted-subset.
+    4. Sums per-PR C1 counts (``_per_pr_counts``).
+    5. Derives ``coverage_partial`` per bucket as
+       ``(∃ PR in bucket with comments_extracted_at IS NULL)``.
+
+    Round-9 isolation: helpers re-implement everything inline; no
+    imports from ``aggregators.py``.  The sentinel literal is imported
+    from ``transform.constants`` (a non-aggregator module).
+    """
+    db_path = sc05_fixture.sqlite_path
+    weeks_to_prs = _attribute_prs_to_weeks(db_path)
+    rollup_paths = sorted(sc05_fixture.rollups_dir.glob("*.json"))
+    assert rollup_paths, (
+        f"sc05_fixture has no weekly rollups under {sc05_fixture.rollups_dir}; "
+        "fixture builder is broken"
+    )
+
+    with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as conn:
+        conn.row_factory = sqlite3.Row
+
+        for rollup_path in rollup_paths:
+            week_key = rollup_path.stem
+            rollup = _load_rollup(rollup_path)
+            canonical_prs = weeks_to_prs.get(week_key, [])
+            if not canonical_prs:
+                # Week with no canonical PRs — producer omits the key
+                # entirely (FR-3-03 omission contract).
+                assert "by_author_comments" not in rollup, (
+                    f"week {week_key}: rollup has empty canonical PR set "
+                    "but emits a non-omitted by_author_comments key"
+                )
+                continue
+
+            buckets_emitted = _by_author_comments_dict(rollup, week_key)
+            expected_buckets = _build_expected_buckets(conn, canonical_prs)
+
+            assert set(buckets_emitted.keys()) == set(expected_buckets.keys()), (
+                f"week {week_key}: by_author_comments key set "
+                f"{sorted(buckets_emitted.keys())!r} != independent "
+                f"re-computation {sorted(expected_buckets.keys())!r} "
+                "(FR-1-03 + FR-2-02: every author/sentinel with a canonical "
+                "PR in W MUST appear in the bucket dict)"
+            )
+
+            for bucket_key, emitted in buckets_emitted.items():
+                expected = expected_buckets[bucket_key]
+                assert emitted["thread_count"] == expected["thread_count"], (
+                    f"week {week_key}, bucket {bucket_key!r}: thread_count="
+                    f"{emitted['thread_count']!r} != independent re-computation "
+                    f"{expected['thread_count']} (FR-2-02 violation)"
+                )
+                assert emitted["comment_count"] == expected["comment_count"], (
+                    f"week {week_key}, bucket {bucket_key!r}: comment_count="
+                    f"{emitted['comment_count']!r} != independent re-computation "
+                    f"{expected['comment_count']} (FR-2-02 violation)"
+                )
+                assert (
+                    emitted["active_thread_count"] == expected["active_thread_count"]
+                ), (
+                    f"week {week_key}, bucket {bucket_key!r}: "
+                    f"active_thread_count={emitted['active_thread_count']!r} != "
+                    f"independent re-computation {expected['active_thread_count']} "
+                    "(FR-2-02 violation)"
+                )
+                assert emitted["coverage_partial"] is expected["coverage_partial"], (
+                    f"week {week_key}, bucket {bucket_key!r}: coverage_partial="
+                    f"{emitted['coverage_partial']!r} != independent re-computation "
+                    f"{expected['coverage_partial']!r} (FR-1-06: True iff at least "
+                    "one PR in the bucket's canonical set has "
+                    "comments_extracted_at IS NULL)"
+                )
+
+
+def test_sc05_reconciliation_per_week_by_author_sentinel_parity(
+    sc05_fixture: SC05Fixture,
+) -> None:
+    """FR-2-03 (Feature 334): sentinel bucket aggregates ALL unknown-to-users PRs.
+
+    For each week W, if ``rollup[W].by_author_comments`` carries an entry
+    keyed by the reserved sentinel literal, that entry's metrics MUST
+    equal the SUM of contributions from ALL PRs in W's canonical set
+    whose ``user_id`` is absent from the ``users`` table.  If zero such
+    PRs exist for W, the sentinel bucket MUST NOT be emitted for W.
+    """
+    db_path = sc05_fixture.sqlite_path
+    weeks_to_prs = _attribute_prs_to_weeks(db_path)
+    rollup_paths = sorted(sc05_fixture.rollups_dir.glob("*.json"))
+
+    with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as conn:
+        conn.row_factory = sqlite3.Row
+
+        for rollup_path in rollup_paths:
+            week_key = rollup_path.stem
+            rollup = _load_rollup(rollup_path)
+            canonical_prs = weeks_to_prs.get(week_key, [])
+
+            unknown_prs: list[_CanonicalPrRow] = [
+                pr
+                for pr in canonical_prs
+                if _author_bucket_for_uid(conn, pr["pull_request_uid"])
+                == FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL
+            ]
+
+            buckets_raw = rollup.get("by_author_comments")
+            sentinel_emitted: dict[str, object] | None
+            if isinstance(buckets_raw, dict):
+                raw_entry = buckets_raw.get(FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL)
+                sentinel_emitted = raw_entry if isinstance(raw_entry, dict) else None
+            else:
+                sentinel_emitted = None
+
+            if not unknown_prs:
+                assert sentinel_emitted is None, (
+                    f"week {week_key}: zero unknown-to-users PRs in canonical "
+                    "set but sentinel bucket "
+                    f"{FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL!r} is emitted "
+                    "(FR-2-03 + CL-03: sentinel MUST NOT be emitted when no "
+                    "unknown-author PRs exist for W)"
+                )
+                continue
+
+            assert sentinel_emitted is not None, (
+                f"week {week_key}: {len(unknown_prs)} unknown-to-users PRs "
+                "in canonical set but sentinel bucket "
+                f"{FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL!r} is missing from "
+                "rollup[W].by_author_comments (FR-2-03 violation)"
+            )
+
+            expected_thread = 0
+            expected_comment = 0
+            expected_active = 0
+            any_unextracted = False
+            for pr in unknown_prs:
+                if pr["comments_extracted_at"] is None:
+                    any_unextracted = True
+                    continue
+                tc, cc, atc = _per_pr_counts(conn, pr["pull_request_uid"])
+                expected_thread += tc
+                expected_comment += cc
+                expected_active += atc
+
+            assert sentinel_emitted["thread_count"] == expected_thread, (
+                f"week {week_key}: sentinel bucket thread_count="
+                f"{sentinel_emitted['thread_count']!r} != independent SUM "
+                f"{expected_thread} over {len(unknown_prs)} unknown-author PRs "
+                "(FR-2-03)"
+            )
+            assert sentinel_emitted["comment_count"] == expected_comment, (
+                f"week {week_key}: sentinel bucket comment_count="
+                f"{sentinel_emitted['comment_count']!r} != independent SUM "
+                f"{expected_comment} (FR-2-03)"
+            )
+            assert sentinel_emitted["active_thread_count"] == expected_active, (
+                f"week {week_key}: sentinel bucket active_thread_count="
+                f"{sentinel_emitted['active_thread_count']!r} != independent "
+                f"SUM {expected_active} (FR-2-03)"
+            )
+            assert sentinel_emitted["coverage_partial"] is any_unextracted, (
+                f"week {week_key}: sentinel bucket coverage_partial="
+                f"{sentinel_emitted['coverage_partial']!r} != independent "
+                f"re-computation {any_unextracted!r} (FR-1-06 propagated "
+                "to sentinel bucket)"
+            )
+
+
+def test_sc05_reconciliation_per_week_by_author_pairwise_drilldown(
+    sc05_fixture: SC05Fixture,
+) -> None:
+    """FR-2-01 (Feature 334): drill-down ∩ extracted-subset PRs map to a bucket.
+
+    For every PR P in ``rollup[W].prs`` AND in W's extracted-subset, P's
+    resolved bucket key MUST exist in ``rollup[W].by_author_comments``,
+    and P's drill-down per-PR values MUST equal an independent C1
+    re-computation (the value-equality side; the existing 333 test
+    covers this for ``rollup[W].comments`` — this test extends the
+    cross-surface coherence check to the per-author surface).
+    """
+    db_path = sc05_fixture.sqlite_path
+    weeks_to_prs = _attribute_prs_to_weeks(db_path)
+    rollup_paths = sorted(sc05_fixture.rollups_dir.glob("*.json"))
+
+    with closing(sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)) as conn:
+        conn.row_factory = sqlite3.Row
+
+        for rollup_path in rollup_paths:
+            week_key = rollup_path.stem
+            rollup = _load_rollup(rollup_path)
+            canonical_prs = weeks_to_prs.get(week_key, [])
+            extracted_prs = [
+                pr for pr in canonical_prs if pr["comments_extracted_at"] is not None
+            ]
+            if not canonical_prs:
+                continue
+
+            buckets_emitted = _by_author_comments_dict(rollup, week_key)
+            id_to_uid_extracted: dict[int, str] = {
+                pr["pull_request_id"]: pr["pull_request_uid"] for pr in extracted_prs
+            }
+
+            for record in _drilldown_pr_records(rollup):
+                pr_id_raw = record.get("id")
+                if not isinstance(pr_id_raw, int):
+                    continue
+                pr_id = pr_id_raw
+                if pr_id not in id_to_uid_extracted:
+                    # Unextracted drill-down PRs are out of scope — covered
+                    # by the existing 333 reconciliation test for the
+                    # round-9 positive sentinel.
+                    continue
+
+                pr_uid = id_to_uid_extracted[pr_id]
+                bucket_key = _author_bucket_for_uid(conn, pr_uid)
+                assert bucket_key in buckets_emitted, (
+                    f"week {week_key}, PR id={pr_id}: resolved bucket "
+                    f"{bucket_key!r} is missing from "
+                    f"rollup[W].by_author_comments (FR-2-01: every "
+                    "drill-down ∩ extracted-subset PR's author MUST have "
+                    "a bucket emission)"
+                )
+
+                expected_tc, expected_cc, expected_atc = _per_pr_counts(conn, pr_uid)
+                drill_thread = record.get("thread_count")
+                drill_comment = record.get("comment_count")
+                drill_active = record.get("active_thread_count")
+                assert drill_thread == expected_tc, (
+                    f"week {week_key}, PR id={pr_id}: drill-down thread_count="
+                    f"{drill_thread!r} != independent re-computation "
+                    f"{expected_tc} (FR-2-01: per-author surface coherence)"
+                )
+                assert drill_comment == expected_cc, (
+                    f"week {week_key}, PR id={pr_id}: drill-down comment_count="
+                    f"{drill_comment!r} != independent re-computation "
+                    f"{expected_cc} (FR-2-01)"
+                )
+                assert drill_active == expected_atc, (
+                    f"week {week_key}, PR id={pr_id}: drill-down "
+                    f"active_thread_count={drill_active!r} != independent "
+                    f"re-computation {expected_atc} (FR-2-01)"
+                )

--- a/tests/integration/test_demo_variants_byte_identity.py
+++ b/tests/integration/test_demo_variants_byte_identity.py
@@ -95,6 +95,13 @@ _GATED_MANIFEST_PATHS: Final[frozenset[tuple[str, ...]]] = frozenset(
         # rollup tree is independently gated by the four FR-3-03
         # failure-mode tests below.
         ("comments",),
+        # Feature 334 FR-3-03 / INV-2-08: rollup-level per-author
+        # comments-density outer dict.  Same gating posture as the
+        # 333 ``comments`` sibling — stripped from both variants for
+        # subtests 1/2/3, then independently gated on the off variant
+        # by the four FR-3-03 failure-mode tests below (per-author
+        # parallels of the 333 (a)/(b)/(c)/(d) tests).
+        ("by_author_comments",),
     },
 )
 _GATED_PR_FIELDS: Final[frozenset[str]] = frozenset(
@@ -107,6 +114,11 @@ _GATED_PR_FIELDS: Final[frozenset[str]] = frozenset(
 _COMMENTS_AGGREGATE_FIELDS: Final[frozenset[str]] = frozenset(
     {"thread_count", "comment_count", "active_thread_count", "coverage_partial"},
 )
+# Feature 334: each entry inside ``rollup[W].by_author_comments`` carries
+# the same four atomic fields as the 333 ``comments`` aggregate (per-bucket
+# scope rather than per-week).  Used by the FR-3-03 partial-fielded test (d)
+# for the per-author surface.
+_BY_AUTHOR_COMMENTS_ENTRY_FIELDS: Final[frozenset[str]] = _COMMENTS_AGGREGATE_FIELDS
 
 # Reroot the scratch space under REPO_ROOT/tmp_test_work/ so the generator's
 # docs/data/ bypass guard (which calls .relative_to(REPO_ROOT)) doesn't
@@ -529,4 +541,125 @@ def test_fr_3_03_d_comments_key_not_partial_fielded_in_capability_off_rollups(
                 "key MUST be omitted (FR-3-03), and even under "
                 "capability-on the four fields are atomic per "
                 "INV-1-08.  See spec FR-3-03 + INV-1-08."
+            )
+
+
+# --------------------------------------------------------------------------
+# Feature 334 FR-3-03 four-failure-mode gate on the per-author surface.
+# Parallel to the 333 (a)/(b)/(c)/(d) tests above, scoped to the
+# ``by_author_comments`` rollup-root key (Feature 334 INV-2-08 atomicity
+# applies per-entry; FR-3-03 + INV-2-09 require the entire key absent
+# under capability-off).
+# --------------------------------------------------------------------------
+
+
+def test_fr_3_03_a_by_author_comments_key_absent_in_capability_off_rollups(
+    variant_trees: tuple[Path, Path],
+) -> None:
+    """FR-3-03 (a) per-author: ``by_author_comments`` key absent on every off rollup.
+
+    Canonical absent state for the 334 surface.  Under
+    ``capabilities.comments_metrics === false`` the aggregator MUST NOT
+    emit the per-author outer dict at all.
+    """
+    _on_dir, off_dir = variant_trees
+    for rel, rollup in _iter_off_variant_rollups(off_dir):
+        assert "by_author_comments" not in rollup, (
+            f"FR-3-03 (a) per-author violation in {rel!s}: rollup root "
+            f"has ``by_author_comments`` key under capability-off "
+            f"(value: {rollup.get('by_author_comments')!r}).  The entire "
+            "per-author outer dict MUST be absent when "
+            "capabilities.comments_metrics is false."
+        )
+
+
+def test_fr_3_03_b_by_author_comments_key_not_null_valued_in_capability_off_rollups(
+    variant_trees: tuple[Path, Path],
+) -> None:
+    """FR-3-03 (b) per-author: key MUST NOT be present with null value.
+
+    Catches the regression where a producer emits
+    ``"by_author_comments": null`` under capability-off (defensive
+    "always emit, null when off" refactor).  Per FR-3-03 + INV-2-09
+    the entire key must be omitted; null is NOT acceptable.
+    """
+    _on_dir, off_dir = variant_trees
+    for rel, rollup in _iter_off_variant_rollups(off_dir):
+        if "by_author_comments" in rollup:
+            value = rollup["by_author_comments"]
+            pytest.fail(
+                f"FR-3-03 (b) per-author violation in {rel!s}: "
+                f"``by_author_comments`` key present with value {value!r} "
+                "under capability-off.  Even null is a violation — the "
+                "key MUST be omitted entirely.  See spec FR-3-03 + "
+                "INV-2-09."
+            )
+
+
+def test_fr_3_03_c_by_author_comments_key_not_empty_object_in_capability_off_rollups(
+    variant_trees: tuple[Path, Path],
+) -> None:
+    """FR-3-03 (c) per-author: key MUST NOT be present as ``{}``.
+
+    Catches the regression where a producer emits
+    ``"by_author_comments": {}`` under capability-off.  Per FR-3-03 +
+    INV-2-09 the entire key must be omitted.  Empty outer dict is
+    additionally a contract violation under capability-on (the producer
+    must omit when no buckets exist) — independent of capability state.
+    """
+    _on_dir, off_dir = variant_trees
+    for rel, rollup in _iter_off_variant_rollups(off_dir):
+        if "by_author_comments" in rollup:
+            value = rollup["by_author_comments"]
+            pytest.fail(
+                f"FR-3-03 (c) per-author violation in {rel!s}: "
+                f"``by_author_comments`` key present (value: {value!r}) "
+                "under capability-off.  An empty object ``{}`` is NOT "
+                "acceptable — the key MUST be omitted entirely.  See "
+                "spec FR-3-03 + INV-2-09."
+            )
+
+
+def test_fr_3_03_d_by_author_comments_key_not_partial_entries_in_capability_off_rollups(
+    variant_trees: tuple[Path, Path],
+) -> None:
+    """FR-3-03 (d) per-author: key MUST NOT be present with partial entries.
+
+    Catches the regression where a producer emits ``by_author_comments``
+    populated with one or more entries that violate INV-2-08 atomicity
+    (entries missing one of the four canonical fields, or with null in a
+    numeric field) under capability-off.  Per FR-3-03 the entire key
+    must be omitted; per INV-2-08 each entry is atomic when present.
+    """
+    _on_dir, off_dir = variant_trees
+    for rel, rollup in _iter_off_variant_rollups(off_dir):
+        if "by_author_comments" in rollup:
+            value = rollup["by_author_comments"]
+            if isinstance(value, dict):
+                shape_diags: list[str] = []
+                for entry_key, entry_value in value.items():
+                    if isinstance(entry_value, dict):
+                        present = frozenset(entry_value.keys())
+                        missing = sorted(_BY_AUTHOR_COMMENTS_ENTRY_FIELDS - present)
+                        extra = sorted(present - _BY_AUTHOR_COMMENTS_ENTRY_FIELDS)
+                        shape_diags.append(
+                            f"entry[{entry_key!r}]: present_fields="
+                            f"{sorted(present)!r}, missing_canonical="
+                            f"{missing!r}, extra_unknown={extra!r}"
+                        )
+                    else:
+                        shape_diags.append(
+                            f"entry[{entry_key!r}]: non-dict value={entry_value!r}"
+                        )
+                shape_diag = "; ".join(shape_diags) if shape_diags else "<empty>"
+            else:
+                shape_diag = f"non-dict outer value={value!r}"
+            pytest.fail(
+                f"FR-3-03 (d) per-author violation in {rel!s}: "
+                f"``by_author_comments`` key present under capability-off "
+                f"({shape_diag}).  Partial-entry shapes (e.g., entries "
+                "with 3 of 4 fields) are NEVER acceptable — under "
+                "capability-off the entire key MUST be omitted "
+                "(FR-3-03), and under capability-on each entry is atomic "
+                "per INV-2-08.  See spec FR-3-03 + INV-2-09."
             )

--- a/tests/unit/test_aggregators_author_comments.py
+++ b/tests/unit/test_aggregators_author_comments.py
@@ -511,6 +511,79 @@ def test_inv207_ordering_active_le_thread_per_entry(
 # --------------------------------------------------------------------------- #
 
 
+def test_sentinel_literal_does_not_collide_with_real_author_ids() -> None:
+    """T029 (US4): the reserved sentinel literal MUST NOT match any real author_id.
+
+    Spec assumption A-07 declares ``__former_or_unavailable_author__``
+    namespace-safe (production author_ids are UUID-format strings —
+    32 hex + 4 hyphens — and cannot collide with the leading-double-
+    underscore literal).  This test is the executable closure: scan
+    every committed demo fixture surface where an ``author_id`` value
+    could appear and assert the literal never shows up there.
+
+    Surfaces scanned:
+
+    * ``docs/data/aggregates/dimensions.json`` — every
+      ``authors[].author_id`` value (the canonical authors directory
+      the dashboard renders display names from).
+    * ``docs/data/aggregates/weekly_rollups/*.json`` — every key in
+      ``rollup[W].by_author`` (the throughput per-author slice; one
+      bucket per real author_id).  This is the pre-existing
+      throughput-side mirror of the same author_id space.
+
+    The test does NOT scan ``rollup[W].by_author_comments`` — that is
+    the producer's own emission and the literal IS a valid bucket key
+    there by design (CL-03).  The check only asserts that NO REAL
+    author_id collides with it.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    docs_data = repo_root / "docs" / "data" / "aggregates"
+
+    dimensions_path = docs_data / "dimensions.json"
+    assert dimensions_path.is_file(), (
+        f"docs/data/aggregates/dimensions.json missing at {dimensions_path} — "
+        "the canonical demo fixture must exist before this safety test runs"
+    )
+    dimensions = json.loads(dimensions_path.read_text(encoding="utf-8"))
+    authors_dim_raw = dimensions.get("authors")
+    assert isinstance(authors_dim_raw, list), (
+        "dimensions.json missing or non-list authors array"
+    )
+    for entry in authors_dim_raw:
+        if not isinstance(entry, dict):
+            continue
+        author_id = entry.get("author_id")
+        assert author_id != FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL, (
+            "Feature 334 A-07 violation: dimensions.json carries an authors[] "
+            f"entry whose author_id collides with the reserved sentinel "
+            f"literal {FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL!r}.  Real "
+            "author_ids must NEVER equal the sentinel literal — see "
+            "specs/334-comments-author-density/spec.md Assumption A-07."
+        )
+
+    rollups_dir = docs_data / "weekly_rollups"
+    assert rollups_dir.is_dir(), (
+        f"docs/data/aggregates/weekly_rollups missing at {rollups_dir}"
+    )
+    rollup_files = sorted(rollups_dir.glob("*.json"))
+    assert rollup_files, (
+        f"docs/data/aggregates/weekly_rollups is empty at {rollups_dir}"
+    )
+    for rollup_path in rollup_files:
+        payload = json.loads(rollup_path.read_text(encoding="utf-8"))
+        by_author = payload.get("by_author")
+        if not isinstance(by_author, dict):
+            continue
+        assert FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL not in by_author, (
+            f"Feature 334 A-07 violation: {rollup_path.name} carries a "
+            f"by_author bucket keyed by the reserved sentinel literal "
+            f"{FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL!r}.  Throughput's "
+            "per-author slice must NEVER use a real author_id equal to "
+            "the sentinel literal — that would collide with Feature 334's "
+            "by_author_comments sentinel-bucket convention (CL-03)."
+        )
+
+
 def test_determinism_outer_dict_key_order_ascending(
     author_comments_db: tuple[DatabaseManager, Path],
 ) -> None:

--- a/tests/unit/test_aggregators_author_comments.py
+++ b/tests/unit/test_aggregators_author_comments.py
@@ -1,0 +1,561 @@
+"""Feature 334 producer-side tests: per-(week, author) comments-density emission.
+
+Covers the invariants asserted by the producer contract
+(``specs/334-comments-author-density/contracts/per-author-comments-density.md``):
+
+- FR-1-01..02  Capability gating + emission shape: when ``_has_comments()``
+               is False, the aggregator omits the entire
+               ``rollup[W].by_author_comments`` key (FR-3-03 + INV-2-09).
+               When True, an outer dict keyed by ``author_id`` (or
+               sentinel literal) is emitted on the rollup root with
+               atomic 4-field entries (INV-2-08).
+- FR-1-03      Sentinel bucketing per CL-03: PRs whose ``user_id`` is
+               absent from the ``users`` table collapse into the single
+               reserved bucket key
+               ``FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL``.
+- FR-1-05      Extracted-subset rule: per-bucket numeric sums range over
+               the bucket's extracted-subset (PRs with
+               ``comments_extracted_at IS NOT NULL``).
+- FR-1-06      Per-bucket ``coverage_partial``: True iff at least one PR
+               in the bucket's canonical set has
+               ``comments_extracted_at IS NULL``.
+- FR-1-07      Atomicity: every entry has all four fields together
+               (INV-2-08); partial entries are forbidden.
+- FR-1-08      Ordering: ``active_thread_count <= thread_count`` per
+               entry including the sentinel bucket (INV-2-07).
+- Determinism  Outer dict key order is ascending by author key (the
+               stable identity string, including the sentinel which
+               sorts between digit-starting and letter-starting UUIDs
+               in ASCII).  Display name is NOT the producer's sort key.
+
+Harness mirrors ``tests/unit/test_aggregators_pr_records_comments.py``
+(Feature 310 producer test scaffold) so regressions across features are
+localized.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from datetime import date
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+from ado_git_repo_insights.persistence.database import DatabaseManager
+from ado_git_repo_insights.transform.aggregators import AggregateGenerator
+from ado_git_repo_insights.transform.constants import (
+    FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL,
+)
+
+ORG_NAME: Final[str] = "org1"
+PROJECT_NAME: Final[str] = "proj1"
+REPOSITORY_ID: Final[str] = "repo1"
+USER_ALICE: Final[str] = "alice-uid"
+USER_BOB: Final[str] = "bob-uid"
+USER_GHOST: Final[str] = "ghost-uid"  # NOT inserted into users table
+
+
+def _week_monday(year: int, iso_week: int) -> date:
+    return date.fromisocalendar(year, iso_week, 1)
+
+
+def _insert_pr(
+    db: DatabaseManager,
+    *,
+    uid: str,
+    pr_id: int,
+    user_id: str,
+    closed_date: str,
+    comments_extracted_at: str | None,
+    cycle_time_minutes: float = 100.0,
+) -> None:
+    db.execute(
+        """
+        INSERT INTO pull_requests (
+            pull_request_uid, pull_request_id, organization_name,
+            project_name, repository_id, user_id, title, status,
+            description, creation_date, closed_date, cycle_time_minutes,
+            comments_extracted_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            uid,
+            pr_id,
+            ORG_NAME,
+            PROJECT_NAME,
+            REPOSITORY_ID,
+            user_id,
+            f"PR {pr_id}",
+            "completed",
+            None,
+            "2026-01-01T00:00:00Z",
+            closed_date,
+            cycle_time_minutes,
+            comments_extracted_at,
+        ),
+    )
+
+
+def _insert_thread(
+    db: DatabaseManager,
+    *,
+    uid: str,
+    thread_id: str,
+    status: str = "active",
+    is_deleted: int = 0,
+) -> None:
+    db.execute(
+        """
+        INSERT INTO pr_threads (
+            thread_id, pull_request_uid, status, thread_context,
+            last_updated, created_at, is_deleted
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            thread_id,
+            uid,
+            status,
+            None,
+            "2026-01-02T00:00:00Z",
+            "2026-01-02T00:00:00Z",
+            is_deleted,
+        ),
+    )
+
+
+def _insert_comment(
+    db: DatabaseManager,
+    *,
+    uid: str,
+    thread_id: str,
+    comment_id: str,
+    is_deleted: int = 0,
+) -> None:
+    db.execute(
+        """
+        INSERT INTO pr_comments (
+            comment_id, thread_id, pull_request_uid, author_id,
+            content, comment_type, created_at, last_updated, is_deleted
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            comment_id,
+            thread_id,
+            uid,
+            USER_ALICE,
+            "body",
+            "text",
+            "2026-01-02T00:00:00Z",
+            "2026-01-02T00:00:00Z",
+            is_deleted,
+        ),
+    )
+
+
+@pytest.fixture
+def author_comments_db(
+    tmp_path: Path,
+) -> Iterator[tuple[DatabaseManager, Path]]:
+    """DB seeded with org/project/repo + alice + bob (NOT ghost)."""
+    db_path = tmp_path / "author-comments.sqlite"
+    db = DatabaseManager(db_path)
+    db.connect()
+    # Disable FK enforcement so the fixture can seed ghost PRs whose
+    # ``user_id`` is absent from the ``users`` table.  This mirrors the
+    # production reality (deprovisioned users leave orphaned PRs) per
+    # Feature 334 CL-03 + FR-1-03 — the aggregator's LEFT JOIN +
+    # sentinel CASE is the boundary the test exercises.
+    db.execute("PRAGMA foreign_keys = OFF")
+    db.execute("INSERT INTO organizations (organization_name) VALUES (?)", (ORG_NAME,))
+    db.execute(
+        "INSERT INTO projects (organization_name, project_name) VALUES (?, ?)",
+        (ORG_NAME, PROJECT_NAME),
+    )
+    db.execute(
+        "INSERT INTO repositories (repository_id, repository_name, project_name, "
+        "organization_name) VALUES (?, ?, ?, ?)",
+        (REPOSITORY_ID, "Repository 1", PROJECT_NAME, ORG_NAME),
+    )
+    db.execute(
+        "INSERT INTO users (user_id, display_name, email) VALUES (?, ?, ?)",
+        (USER_ALICE, "Alice", "alice@example.com"),
+    )
+    db.execute(
+        "INSERT INTO users (user_id, display_name, email) VALUES (?, ?, ?)",
+        (USER_BOB, "Bob", "bob@example.com"),
+    )
+    db.connection.commit()
+    yield db, tmp_path
+    db.close()
+
+
+def _generate_rollup(tmp_path: Path, db: DatabaseManager) -> dict[str, object]:
+    db.connection.commit()
+    AggregateGenerator(db, tmp_path / "out").generate_all()
+    rollup_files = sorted(
+        (tmp_path / "out" / "aggregates" / "weekly_rollups").glob("*.json"),
+    )
+    assert len(rollup_files) == 1, f"expected 1 rollup, got {len(rollup_files)}"
+    loaded = json.loads(rollup_files[0].read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _by_author_comments(rollup: dict[str, object]) -> dict[str, dict[str, object]]:
+    raw = rollup.get("by_author_comments")
+    assert isinstance(raw, dict), (
+        f"expected dict at by_author_comments, got {type(raw).__name__}"
+    )
+    typed: dict[str, dict[str, object]] = {}
+    for key, entry in raw.items():
+        assert isinstance(entry, dict)
+        typed[str(key)] = entry
+    return typed
+
+
+# --------------------------------------------------------------------------- #
+# T007 — FR-1-* coverage                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_capability_off_omits_by_author_comments_key(
+    author_comments_db: tuple[DatabaseManager, Path],
+) -> None:
+    """FR-3-03 + INV-2-09: no pr_threads → ``_has_comments()`` False → key absent."""
+    db, tmp_path = author_comments_db
+    monday = _week_monday(2026, 2)
+    _insert_pr(
+        db,
+        uid="pr-1",
+        pr_id=1,
+        user_id=USER_ALICE,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    rollup = _generate_rollup(tmp_path, db)
+    assert "by_author_comments" not in rollup, (
+        "FR-3-03 violation: by_author_comments key emitted under "
+        f"capability-off (no pr_threads in DB).  Got: "
+        f"{rollup.get('by_author_comments')!r}"
+    )
+
+
+def test_all_extracted_week_coverage_partial_false(
+    author_comments_db: tuple[DatabaseManager, Path],
+) -> None:
+    """FR-1-05 + FR-1-06: all-extracted week → every entry coverage_partial=False."""
+    db, tmp_path = author_comments_db
+    monday = _week_monday(2026, 2)
+    _insert_pr(
+        db,
+        uid="pr-alice",
+        pr_id=1,
+        user_id=USER_ALICE,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    _insert_thread(db, uid="pr-alice", thread_id="t1", status="active")
+    _insert_comment(db, uid="pr-alice", thread_id="t1", comment_id="c1")
+
+    _insert_pr(
+        db,
+        uid="pr-bob",
+        pr_id=2,
+        user_id=USER_BOB,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    _insert_thread(db, uid="pr-bob", thread_id="t2", status="closed")
+
+    rollup = _generate_rollup(tmp_path, db)
+    buckets = _by_author_comments(rollup)
+    assert set(buckets.keys()) == {USER_ALICE, USER_BOB}, (
+        f"expected exactly two buckets, got {sorted(buckets.keys())!r}"
+    )
+    assert buckets[USER_ALICE]["coverage_partial"] is False
+    assert buckets[USER_ALICE]["thread_count"] == 1
+    assert buckets[USER_ALICE]["comment_count"] == 1
+    assert buckets[USER_ALICE]["active_thread_count"] == 1
+    assert buckets[USER_BOB]["coverage_partial"] is False
+    assert buckets[USER_BOB]["thread_count"] == 1
+    assert buckets[USER_BOB]["comment_count"] == 0
+    assert buckets[USER_BOB]["active_thread_count"] == 0
+
+
+def test_mixed_extraction_author_coverage_partial_true(
+    author_comments_db: tuple[DatabaseManager, Path],
+) -> None:
+    """FR-1-05 + FR-1-06: mixed-extraction author → coverage_partial=True, sums over extracted only."""
+    db, tmp_path = author_comments_db
+    monday = _week_monday(2026, 2)
+    # Alice has both extracted and unextracted PRs in the same week.
+    _insert_pr(
+        db,
+        uid="pr-alice-1",
+        pr_id=1,
+        user_id=USER_ALICE,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    _insert_thread(db, uid="pr-alice-1", thread_id="t1", status="active")
+    _insert_thread(db, uid="pr-alice-1", thread_id="t2", status="closed")
+
+    _insert_pr(
+        db,
+        uid="pr-alice-2",
+        pr_id=2,
+        user_id=USER_ALICE,
+        closed_date=monday.isoformat(),
+        comments_extracted_at=None,  # unextracted
+    )
+    # pr_threads attached to the unextracted PR — must NOT be counted.
+    _insert_thread(db, uid="pr-alice-2", thread_id="t3", status="active")
+    _insert_comment(db, uid="pr-alice-2", thread_id="t3", comment_id="c-skip")
+
+    rollup = _generate_rollup(tmp_path, db)
+    buckets = _by_author_comments(rollup)
+    assert USER_ALICE in buckets
+    alice = buckets[USER_ALICE]
+    assert alice["coverage_partial"] is True, (
+        "FR-1-06 violation: bucket has unextracted PR but coverage_partial "
+        f"is {alice['coverage_partial']!r}"
+    )
+    # Sum is over extracted PRs only (FR-1-05): only pr-alice-1's threads.
+    assert alice["thread_count"] == 2
+    assert alice["active_thread_count"] == 1
+    assert alice["comment_count"] == 0
+
+
+def test_all_unextracted_author_emits_zeros_with_coverage_partial_true(
+    author_comments_db: tuple[DatabaseManager, Path],
+) -> None:
+    """FR-1-05 + FR-1-06: bucket with no extracted PRs → (0,0,0,True)."""
+    db, tmp_path = author_comments_db
+    monday = _week_monday(2026, 2)
+    # Bob has only unextracted PRs.
+    _insert_pr(
+        db,
+        uid="pr-bob-1",
+        pr_id=1,
+        user_id=USER_BOB,
+        closed_date=monday.isoformat(),
+        comments_extracted_at=None,
+    )
+    _insert_thread(db, uid="pr-bob-1", thread_id="t1", status="active")
+    _insert_comment(db, uid="pr-bob-1", thread_id="t1", comment_id="c-skip")
+    # Alice gets one extracted PR so _has_comments() is True via Alice's threads
+    # AND the rollup has at least one canonical PR.  This isolates Bob's
+    # all-unextracted bucket.
+    _insert_pr(
+        db,
+        uid="pr-alice-1",
+        pr_id=2,
+        user_id=USER_ALICE,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    _insert_thread(db, uid="pr-alice-1", thread_id="t2", status="active")
+
+    rollup = _generate_rollup(tmp_path, db)
+    buckets = _by_author_comments(rollup)
+    assert USER_BOB in buckets
+    bob = buckets[USER_BOB]
+    assert bob["thread_count"] == 0
+    assert bob["comment_count"] == 0
+    assert bob["active_thread_count"] == 0
+    assert bob["coverage_partial"] is True
+
+
+def test_sentinel_bucketing_for_unknown_to_users_authors(
+    author_comments_db: tuple[DatabaseManager, Path],
+) -> None:
+    """FR-1-03 + CL-03: PRs whose user_id is absent from users → single sentinel bucket."""
+    db, tmp_path = author_comments_db
+    monday = _week_monday(2026, 2)
+    # Two PRs by different unknown-to-users authors must collapse into the
+    # SAME sentinel bucket.
+    _insert_pr(
+        db,
+        uid="pr-ghost-1",
+        pr_id=1,
+        user_id=USER_GHOST,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    _insert_thread(db, uid="pr-ghost-1", thread_id="t1", status="active")
+
+    _insert_pr(
+        db,
+        uid="pr-ghost-2",
+        pr_id=2,
+        user_id="another-ghost",
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    _insert_thread(db, uid="pr-ghost-2", thread_id="t2", status="active")
+    _insert_thread(db, uid="pr-ghost-2", thread_id="t3", status="closed")
+
+    rollup = _generate_rollup(tmp_path, db)
+    buckets = _by_author_comments(rollup)
+    assert FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL in buckets
+    sentinel = buckets[FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL]
+    # Both PRs collapse: total threads = 1 (active) + 2 (1 active + 1 closed) = 3.
+    assert sentinel["thread_count"] == 3
+    assert sentinel["active_thread_count"] == 2
+    # No real-author bucket should appear with the raw ghost ids.
+    assert USER_GHOST not in buckets
+    assert "another-ghost" not in buckets
+
+
+def test_atomicity_every_entry_has_all_four_fields(
+    author_comments_db: tuple[DatabaseManager, Path],
+) -> None:
+    """FR-1-07 + INV-2-08: every emitted bucket entry carries all 4 atomic fields."""
+    db, tmp_path = author_comments_db
+    monday = _week_monday(2026, 2)
+    _insert_pr(
+        db,
+        uid="pr-alice",
+        pr_id=1,
+        user_id=USER_ALICE,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    _insert_thread(db, uid="pr-alice", thread_id="t1", status="active")
+    _insert_pr(
+        db,
+        uid="pr-bob",
+        pr_id=2,
+        user_id=USER_BOB,
+        closed_date=monday.isoformat(),
+        comments_extracted_at=None,
+    )
+    _insert_thread(db, uid="pr-bob", thread_id="t2", status="closed")
+    _insert_pr(
+        db,
+        uid="pr-ghost",
+        pr_id=3,
+        user_id=USER_GHOST,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    _insert_thread(db, uid="pr-ghost", thread_id="t3", status="active")
+
+    rollup = _generate_rollup(tmp_path, db)
+    buckets = _by_author_comments(rollup)
+    expected_fields = {
+        "thread_count",
+        "comment_count",
+        "active_thread_count",
+        "coverage_partial",
+    }
+    for key, entry in buckets.items():
+        assert set(entry.keys()) == expected_fields, (
+            f"INV-2-08 atomicity violation at bucket {key!r}: "
+            f"present={sorted(entry.keys())!r}, expected="
+            f"{sorted(expected_fields)!r}"
+        )
+
+
+def test_inv207_ordering_active_le_thread_per_entry(
+    author_comments_db: tuple[DatabaseManager, Path],
+) -> None:
+    """FR-1-08 + INV-2-07: active_thread_count <= thread_count per entry incl. sentinel."""
+    db, tmp_path = author_comments_db
+    monday = _week_monday(2026, 2)
+    # Alice: 3 threads (2 active, 1 closed) → active=2, thread=3.
+    _insert_pr(
+        db,
+        uid="pr-a",
+        pr_id=1,
+        user_id=USER_ALICE,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    for tid, status in [("t1", "active"), ("t2", "active"), ("t3", "closed")]:
+        _insert_thread(db, uid="pr-a", thread_id=tid, status=status)
+
+    # Sentinel bucket: 2 threads (1 active, 1 closed).
+    _insert_pr(
+        db,
+        uid="pr-g",
+        pr_id=2,
+        user_id=USER_GHOST,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    for tid, status in [("t4", "active"), ("t5", "closed")]:
+        _insert_thread(db, uid="pr-g", thread_id=tid, status=status)
+
+    rollup = _generate_rollup(tmp_path, db)
+    buckets = _by_author_comments(rollup)
+    for key, entry in buckets.items():
+        thread = entry["thread_count"]
+        active = entry["active_thread_count"]
+        assert isinstance(thread, int), (
+            f"non-integer thread_count in bucket {key!r}: {thread!r}"
+        )
+        assert isinstance(active, int), (
+            f"non-integer active_thread_count in bucket {key!r}: {active!r}"
+        )
+        assert active <= thread, (
+            f"INV-2-07 violation at bucket {key!r}: "
+            f"active_thread_count={active} > thread_count={thread}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# T008 — determinism                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_determinism_outer_dict_key_order_ascending(
+    author_comments_db: tuple[DatabaseManager, Path],
+) -> None:
+    """Determinism: outer dict keys are ascending by stable identity string."""
+    db, tmp_path = author_comments_db
+    monday = _week_monday(2026, 2)
+    # Insert PRs in an order DIFFERENT from the expected sort order so a
+    # producer that didn't sort would emit in insert order.
+    _insert_pr(
+        db,
+        uid="pr-bob",
+        pr_id=1,
+        user_id=USER_BOB,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    _insert_thread(db, uid="pr-bob", thread_id="t-b", status="active")
+    _insert_pr(
+        db,
+        uid="pr-alice",
+        pr_id=2,
+        user_id=USER_ALICE,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    _insert_thread(db, uid="pr-alice", thread_id="t-a", status="active")
+    _insert_pr(
+        db,
+        uid="pr-ghost",
+        pr_id=3,
+        user_id=USER_GHOST,
+        closed_date=monday.isoformat(),
+        comments_extracted_at="2026-01-02T00:00:00Z",
+    )
+    _insert_thread(db, uid="pr-ghost", thread_id="t-g", status="active")
+
+    rollup = _generate_rollup(tmp_path, db)
+    buckets = _by_author_comments(rollup)
+    keys = list(buckets.keys())
+    assert keys == sorted(keys), (
+        f"Determinism violation: outer dict keys are not ascending. Got: {keys!r}"
+    )
+    # Bonus: the sentinel literal sorts BEFORE 'a'-prefixed UUIDs because
+    # '_' (0x5F) < 'a' (0x61) in ASCII, but AFTER any digit-prefixed key.
+    # Both alice-uid and bob-uid start with letters in this fixture; the
+    # sentinel sorts before both.
+    assert keys.index(FORMER_OR_UNAVAILABLE_AUTHOR_SENTINEL) < keys.index(USER_ALICE)
+    assert keys.index(USER_ALICE) < keys.index(USER_BOB)


### PR DESCRIPTION
## Summary

Feature 334 (split from #322 — Capability 2, author dimension): adds the per-author comment-density breakdown to the dashboard's Metrics tab, gated on `capabilities.comments_metrics`, sorted by chosen count metric (default `comment_count` desc), capped at 50 rows, with partial-coverage row qualifier and a single "Former / unavailable author" sentinel row aggregating all PRs whose `author_id` is absent from the `users` table (CL-03 / 310 C1 inheritance).

- **Backend**: new `_compute_weekly_by_author_comments` helper in `aggregators.py` emits `rollup[W].by_author_comments` (4-field atomic entries per INV-2-08; sentinel bucket via `LEFT JOIN users` + reserved literal in a fresh leaf-only `transform/constants.py` so reconciliation tests can import without violating Feature 333 round-9 import-block isolation).
- **Schema**: new `validateAuthorCommentsDensity` in `rollup.schema.ts` (STRICT in both modes per ADR T003); `KNOWN_ROOT_FIELDS` extended; `Rollup` interface gains the typed `by_author_comments?` field.
- **Extension**: new `extension/ui/modules/charts/comments-author-density.ts` chart module (toolbar pattern with three independently Tab-reachable buttons after a Codex catch on a11y reachability); dashboard `ensure*` / `remove*` helpers anchored on the 333 row so the new row sits below the trend chart per FR-4-01.
- **Tests**: 16 producer / reconciliation / meta-failure / byte-identity tests on the Python side; 30 chart-module + 4 lifecycle + 2 F3 live-loader-gate regression tests on the TypeScript side; 7 schema-validator atomicity tests.
- **Demo**: SC05 fixture seeded with one ghost-author PR per fixture week so the sentinel-parity reconciliation branch exercises its hot path; demo generator's `_aggregate_by_author_comments_for_week` mirrors the production aggregator's full-week-PR-set semantics (INV-2-10) — paired with the 333 `comments` aggregate now also using the full set so the cross-aggregate sums stay consistent on the truncated week (W26).

## Test plan

- [x] `pytest tests/unit/test_aggregators_author_comments.py` — 9 tests
- [x] `pytest tests/integration/test_comments_trend_reconciliation.py` — existing 1 + 3 new (per-author independent recomp, sentinel parity, drilldown pairwise)
- [x] `pytest tests/integration/test_comments_trend_meta_failure.py` — existing 1 + 1 new (xfail-strict-False, xpass on clean demo)
- [x] `pytest tests/integration/test_demo_variants_byte_identity.py` — existing 7 + 4 new FR-3-03 omission-failure-mode tests
- [x] `pnpm test:ci` (extension full suite) — 2962 passed
- [x] `pnpm run test:partial-branches` — observed=316 baseline=316
- [x] `python scripts/check_ratchet_bump.py` — Python floor 2312, Extension floor 2962, preflight==ci.yml parity
- [x] `python scripts/manage_generated_artifacts.py sync --scope all --stage` + `verify` — clean
- [x] `python scripts/run_pr_preflight.py` — green end-to-end
- [x] Coverage delta — Python +3.93%, TS lines +4.39%, TS branches +6.14%

## Notes

- Schema-parity gate (`check_pr_record_schema_parity.py`, Row 38) is **intentionally NOT extended** for `by_author_comments` per CL-08; the SC-05 reconciliation extension is the parity authority for this feature.
- Sibling features deferred by spec: #335 per-repo and #336 per-reviewer (pattern locked here per A-08); #321 per-team on-hold.

Closes #334

Co-Authored-By: Sloppy Claude <noreply@anthropic.com>