### PR TITLE
fix(#348): warmup + median for chart-render and drilldown perf budgets

### DIFF
--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 3056,
+    "min_collected": 3062,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/extension/scripts/update-perf-baseline.ts
+++ b/extension/scripts/update-perf-baseline.ts
@@ -45,14 +45,29 @@ const baselinesPath = path.join(
 console.log("[PERF] Updating performance baselines...");
 console.log("[PERF] Running performance tests to collect actual timings...\n");
 
-// Run performance tests in trend mode and capture output
+// Run performance tests in trend mode and capture output. The pattern
+// list covers every Jest file that emits a `{"test": "...", "duration_ms": ...}`
+// JSON log via the shared helper at `tests/helpers/perf-measure.ts` —
+// extend this list (and the mapping table below) when a new perf test
+// is added.
+//
+// Shell quoting: the `--testPathPatterns=<regex>` value is wrapped in
+// double quotes inside the command string so the regex's `|` is
+// preserved as a regex-alternation char, not interpreted as a shell
+// pipe. Both `/bin/sh` (POSIX) and `cmd.exe` (Windows) treat double
+// quotes as a literal-preserving wrapper for `|`, so this is the
+// cross-OS form. (Without quoting, the shell would parse the line as
+// three piped commands and the test runner would never see the args.)
 let testOutput: string;
 try {
-  testOutput = execSync("npm test -- performance.test.ts --verbose", {
-    cwd: path.join(__dirname, ".."),
-    encoding: "utf-8",
-    env: { ...process.env, PERF_MODE: "trend" },
-  });
+  testOutput = execSync(
+    'npm test -- "--testPathPatterns=performance|chart-scalability|throughput-drilldown-perf" --verbose',
+    {
+      cwd: path.join(__dirname, ".."),
+      encoding: "utf-8",
+      env: { ...process.env, PERF_MODE: "trend" },
+    },
+  );
 } catch (error: unknown) {
   console.error(
     "[ERROR] Performance tests failed. Fix failures before updating baselines.",
@@ -69,20 +84,34 @@ jsonLogs.forEach((log) => {
   try {
     const data: TestLogData = JSON.parse(log);
     if (data.test && data.duration_ms) {
-      // Map test names to baseline keys
+      // Map test names to baseline metrics. The mapping variable is
+      // named `metricName` (not `key`) so that gitleaks's
+      // `generic-api-key` rule does not classify the high-entropy
+      // metric-name literals (e.g. "156wk_throughput_render_ms") as
+      // suspected secrets — issue #348 push surfaced one such false
+      // positive before this rename.
       const testName = data.test;
-      let key: string | undefined;
+      let metricName: string | undefined;
 
       if (testName.includes("fixture_generation_1000pr"))
-        key = "1000pr_fixture_gen_ms";
+        metricName = "1000pr_fixture_gen_ms";
       else if (testName.includes("fixture_generation_5000pr"))
-        key = "5000pr_fixture_gen_ms";
+        metricName = "5000pr_fixture_gen_ms";
       else if (testName.includes("fixture_generation_10000pr"))
-        key = "10000pr_fixture_gen_ms";
+        metricName = "10000pr_fixture_gen_ms";
+      // Issue #348 — chart-scalability + throughput-drilldown perf tests
+      // emit logs under these `test:` field values via the shared
+      // `tests/helpers/perf-measure.ts` helper.
+      else if (testName.includes("156wk_throughput_render"))
+        metricName = "156wk_throughput_render_ms";
+      else if (testName.includes("156wk_cycle_time_render"))
+        metricName = "156wk_cycle_time_render_ms";
+      else if (testName.includes("drilldown_500pr_open"))
+        metricName = "drilldown_500pr_open_ms";
       // Add more mappings as needed
 
-      if (key) {
-        timings[key] = Math.round(data.duration_ms);
+      if (metricName) {
+        timings[metricName] = Math.round(data.duration_ms);
       }
     }
   } catch (_e) {

--- a/extension/tests/helpers/perf-measure.test.ts
+++ b/extension/tests/helpers/perf-measure.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the shared perf-measurement helper (issue #348).
+ *
+ * Locks the Codex stop-time review catches:
+ *   1. `measureRuns < 1` and non-integer counts must throw, not silently
+ *      return `undefined` cast to `number`.
+ *   2. `baselineMs <= 0` must be treated as missing/invalid, not divided
+ *      into the regression ratio.
+ *
+ * Plus a smoke test for the happy path and a coverage check on the
+ * absolute-mode regression-throw branch (the load-bearing behavior the
+ * helper enables for production gating once baselines are seeded).
+ */
+
+import { checkRegression, measureWithWarmup } from "./perf-measure";
+
+describe("measureWithWarmup", () => {
+  it("returns a finite non-negative median and invokes operation warmup+measure times", () => {
+    let calls = 0;
+    const median = measureWithWarmup(
+      () => {
+        calls += 1;
+      },
+      { warmupRuns: 1, measureRuns: 3 },
+    );
+
+    // 1 warmup + 3 measured iterations.
+    expect(calls).toBe(4);
+    expect(typeof median).toBe("number");
+    expect(Number.isFinite(median)).toBe(true);
+    expect(median).toBeGreaterThanOrEqual(0);
+  });
+
+  it("throws when measureRuns is 0 (would produce empty samples + undefined median)", () => {
+    expect(() =>
+      measureWithWarmup(() => undefined, { measureRuns: 0 }),
+    ).toThrow(/measureRuns must be a positive integer/);
+  });
+
+  it("throws when measureRuns is non-integer (silent footgun)", () => {
+    expect(() =>
+      measureWithWarmup(() => undefined, { measureRuns: 2.5 }),
+    ).toThrow(/measureRuns must be a positive integer/);
+  });
+});
+
+describe("checkRegression", () => {
+  let warnSpy: jest.SpyInstance;
+  let originalMode: string | undefined;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    originalMode = process.env["PERF_MODE"];
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    if (originalMode === undefined) {
+      delete process.env["PERF_MODE"];
+    } else {
+      process.env["PERF_MODE"] = originalMode;
+    }
+  });
+
+  it("warns and returns when baselineMs is undefined (no baseline yet)", () => {
+    expect(() => checkRegression("test-x", 100, undefined)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/No usable baseline for test-x/),
+    );
+  });
+
+  it("warns and returns when baselineMs is 0 (would divide by zero)", () => {
+    expect(() => checkRegression("test-x", 100, 0)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/No usable baseline for test-x/),
+    );
+  });
+
+  it("throws when regression exceeds threshold in absolute mode", () => {
+    process.env["PERF_MODE"] = "absolute";
+    // 100ms vs 50ms baseline → +100% regression, well beyond the 20% bar.
+    expect(() => checkRegression("test-x", 100, 50)).toThrow(
+      /REGRESSION DETECTED/,
+    );
+  });
+});

--- a/extension/tests/helpers/perf-measure.ts
+++ b/extension/tests/helpers/perf-measure.ts
@@ -1,0 +1,202 @@
+/**
+ * Shared performance-measurement helper.
+ *
+ * Lifts the warmup + median + baseline pattern that
+ * `tests/python-integration/performance.test.ts` uses inline so that
+ * timing-budget tests outside the python-integration suite (e.g.
+ * `chart-scalability.test.ts`, `throughput-drilldown-perf.test.ts`) can
+ * adopt the same statistically-robust pattern without duplicating it.
+ *
+ * Single-shot wall-clock checks (`expect(performance.now() - start).toBeLessThan(BUDGET)`)
+ * are flake-prone on shared CI runners and on local machines under preflight load:
+ * a single JIT-cold render or GC pause can overshoot the budget by an order of
+ * magnitude even when the typical render is well within it (issue #348).
+ *
+ * The mitigation pattern, mirrored here:
+ *   1. Run `warmupRuns` discarded iterations to warm the JIT and module caches.
+ *   2. Run `measureRuns` timed iterations.
+ *   3. Take the median to absorb any single-shot outliers.
+ *   4. Optionally compare against a committed baseline and warn / fail on
+ *      regression (gated by the `PERF_MODE` env var; default `trend` only logs).
+ *
+ * The test still asserts an absolute outer ceiling on the median —
+ * the spec ceilings (`< 1000ms` for chart-render, `< 250ms` for the
+ * throughput drill-down) are preserved verbatim, just applied to the
+ * median rather than a single sample.
+ */
+
+import * as path from "path";
+import { pathExists, readJsonFile } from "./fs-test-utils";
+
+/** Shape of the committed `extension/tests/fixtures/perf-baselines.json`. */
+export interface PerfBaselines {
+  metrics?: Record<string, number>;
+  [key: string]: unknown;
+}
+
+/** Optional iteration hooks for `measureWithWarmup`. */
+export interface MeasureWithWarmupOptions {
+  /** Discarded JIT-warm-up iterations before timing starts. Default: 2. */
+  warmupRuns?: number;
+  /** Timed iterations whose median is returned. Default: 3. */
+  measureRuns?: number;
+  /** Runs before each iteration (warmup AND measured). */
+  beforeEach?: () => void;
+  /** Runs after each iteration (warmup AND measured). */
+  afterEach?: () => void;
+}
+
+type GcGlobal = typeof globalThis & { gc?: () => void };
+
+/**
+ * Resolve the canonical baselines path relative to this helper. Centralised
+ * so callers do not duplicate `path.join(__dirname, "..", "fixtures", ...)`
+ * boilerplate and accidentally diverge.
+ */
+export const PERF_BASELINES_PATH = path.join(
+  __dirname,
+  "..",
+  "fixtures",
+  "perf-baselines.json",
+);
+
+/**
+ * Run `operation` `warmupRuns` times to warm the JIT and module caches,
+ * then `measureRuns` more times capturing wall-clock per iteration, and
+ * return the median elapsed milliseconds.
+ *
+ * `beforeEach` / `afterEach` run for both warmup and measured iterations
+ * — pass them when each iteration must start from a clean DOM / closed
+ * panel / etc. so subsequent iterations measure the same shape of work.
+ *
+ * If `--expose-gc` is in effect (`node --expose-gc`), an explicit GC
+ * runs between warmup and the first measured iteration, and after each
+ * measured iteration, so heap pressure from previous iterations does
+ * not bleed into the next sample.
+ */
+export function measureWithWarmup(
+  operation: () => void,
+  options: MeasureWithWarmupOptions = {},
+): number {
+  const warmupRuns = options.warmupRuns ?? 2;
+  const measureRuns = options.measureRuns ?? 3;
+
+  // Reject configurations that would return `undefined` through the
+  // `: number` return type. `measureRuns < 1` produces an empty samples
+  // array; `warmupRuns < 0` is nonsensical. Integer-only — fractional
+  // counts are silent footguns.
+  if (!Number.isInteger(measureRuns) || measureRuns < 1) {
+    throw new Error(
+      `measureWithWarmup: measureRuns must be a positive integer, got ${measureRuns}`,
+    );
+  }
+  if (!Number.isInteger(warmupRuns) || warmupRuns < 0) {
+    throw new Error(
+      `measureWithWarmup: warmupRuns must be a non-negative integer, got ${warmupRuns}`,
+    );
+  }
+
+  for (let i = 0; i < warmupRuns; i++) {
+    options.beforeEach?.();
+    operation();
+    options.afterEach?.();
+  }
+
+  const gcGlobal = globalThis as GcGlobal;
+  if (gcGlobal.gc) gcGlobal.gc();
+
+  const samples: number[] = [];
+  for (let i = 0; i < measureRuns; i++) {
+    options.beforeEach?.();
+    const start = performance.now();
+    operation();
+    const end = performance.now();
+    samples.push(end - start);
+    options.afterEach?.();
+    if (gcGlobal.gc) gcGlobal.gc();
+  }
+
+  samples.sort((a, b) => a - b);
+  // Median: for measureRuns=3, this returns samples[1] (the middle value).
+  // The non-null assertion is safe because measureRuns >= 1 by construction.
+  return samples[Math.floor(samples.length / 2)]!;
+}
+
+/**
+ * Compare an actual measurement against a committed baseline and log /
+ * throw based on the `PERF_MODE` env var.
+ *
+ * Modes:
+ *   - `trend` (default): only logs. Used in CI by default so flake fixes
+ *     can land before the canonical baseline is recorded.
+ *   - `absolute`: throws when the regression exceeds 20% over baseline.
+ *     Promote to `absolute` once a stable baseline has been seeded via
+ *     `pnpm run perf:update-baseline` and committed under the approved
+ *     `chore(perf): update baselines [baseline-update]` path.
+ *
+ * If `baselineMs` is undefined (no committed baseline yet), this just
+ * logs a "recording" line so the next baseline-update run can capture
+ * the value — it never trips the test.
+ */
+export function checkRegression(
+  testName: string,
+  actualMs: number,
+  baselineMs: number | undefined,
+): void {
+  const regressionThreshold = 0.2;
+  const mode = process.env["PERF_MODE"] ?? "trend";
+
+  // `baselineMs <= 0` is treated as missing too: the regression ratio
+  // `(actual - baseline) / baseline` would divide by zero (or invert
+  // sign on a negative baseline), producing `Infinity` / nonsense
+  // comparisons. A zero is plausible — a freshly-recorded baseline
+  // rounded to 0 ms by the update script for a sub-millisecond
+  // operation — so guard rather than assume positive.
+  if (baselineMs === undefined || baselineMs <= 0) {
+    console.warn(
+      `[PERF] No usable baseline for ${testName}, recording: ${actualMs.toFixed(2)}ms`,
+    );
+    return;
+  }
+
+  const regression = (actualMs - baselineMs) / baselineMs;
+  const message = `[PERF] ${testName}: ${actualMs.toFixed(2)}ms vs baseline ${baselineMs.toFixed(2)}ms (${(regression * 100).toFixed(1)}% change)`;
+
+  if (regression > regressionThreshold) {
+    if (mode === "absolute") {
+      throw new Error(`${message} - REGRESSION DETECTED`);
+    }
+    console.warn(`${message} - WARNING`);
+    return;
+  }
+  console.log(message);
+}
+
+/**
+ * Load the committed baselines file, returning `{}` when it does not
+ * exist yet — the helper stays usable in trend-mode bootstrap before
+ * baselines are first seeded.
+ */
+export function loadPerfBaselines(
+  baselinesPath: string = PERF_BASELINES_PATH,
+): PerfBaselines {
+  if (!pathExists(baselinesPath)) return {};
+  return readJsonFile<PerfBaselines>(baselinesPath);
+}
+
+/**
+ * Look up a single baseline metric by key.
+ *
+ * Uses `Object.entries` + `find` rather than direct bracket access to keep
+ * eslint-plugin-security's `detect-object-injection` rule satisfied —
+ * matches the `getMetricBaseline` shape in
+ * `tests/python-integration/performance.test.ts`.
+ */
+export function getMetricBaseline(
+  baselines: PerfBaselines,
+  key: string,
+): number | undefined {
+  return Object.entries(baselines.metrics ?? {}).find(
+    ([candidateKey]) => candidateKey === key,
+  )?.[1];
+}

--- a/extension/tests/modules/drilldown/throughput-drilldown-perf.test.ts
+++ b/extension/tests/modules/drilldown/throughput-drilldown-perf.test.ts
@@ -25,6 +25,12 @@ import {
 } from "../../../ui/modules/shared/detail-panel";
 import type { Rollup } from "../../../ui/dataset-loader";
 import type { PrRecord } from "../../../ui/schemas/rollup.schema";
+import {
+  checkRegression,
+  getMetricBaseline,
+  loadPerfBaselines,
+  measureWithWarmup,
+} from "../../helpers/perf-measure";
 
 const PERF_BUDGET_MS = 250;
 
@@ -80,6 +86,13 @@ describe("throughput-drilldown perf (feature 060 SC-001)", () => {
     document.body.innerHTML = "";
   });
 
+  // The previous single-shot `t1 - t0` measurement against a 250 ms hard
+  // ceiling tripped on routine variance — observed locally at 251.8 ms
+  // (issue #348). Warmup + median absorbs single-digit-ms jitter and a
+  // first-iteration JIT-cold blip without loosening the literal SC-001
+  // ceiling. The no-network invariant (the load-bearing SC-001 contract)
+  // is asserted across ALL warmup AND measured iterations because the
+  // fetch / XHR spies are installed outside `measureWithWarmup`.
   it("opens the panel with 500 rows under the SC-001 wall-clock budget and without any network RPC", () => {
     const rollups = [make500PrRollup()];
     const container = mountChart(rollups);
@@ -97,6 +110,9 @@ describe("throughput-drilldown perf (feature 060 SC-001)", () => {
     });
 
     // Spy for every network surface the render path could in principle use.
+    // Spies are installed outside the timed loop so the no-network
+    // invariant covers warmup runs too — any RPC at any point fails the
+    // test.
     const fetchSpy = jest.fn();
     const originalFetch = globalThis.fetch;
     Object.defineProperty(globalThis, "fetch", {
@@ -107,11 +123,28 @@ describe("throughput-drilldown perf (feature 060 SC-001)", () => {
     const xhrOpenSpy = jest.spyOn(XMLHttpRequest.prototype, "open");
 
     try {
-      const t0 = performance.now();
+      const median = measureWithWarmup(
+        () => {
+          firstBar(container).dispatchEvent(
+            new MouseEvent("click", { bubbles: true, cancelable: true }),
+          );
+        },
+        {
+          afterEach: () => {
+            // Reset to closed-panel state so the next iteration measures
+            // the same shape of work (open from scratch).
+            if (isDetailPanelOpen()) {
+              dismissDetailPanel("explicit-close-button");
+            }
+          },
+        },
+      );
+
+      // Re-open once after measurement so we can assert the panel state
+      // on a known iteration. This activation is not timed.
       firstBar(container).dispatchEvent(
         new MouseEvent("click", { bubbles: true, cancelable: true }),
       );
-      const t1 = performance.now();
 
       expect(isDetailPanelOpen()).toBe(true);
       const prSection = document.getElementById("pr-detail");
@@ -119,10 +152,23 @@ describe("throughput-drilldown perf (feature 060 SC-001)", () => {
       const rows = prSection!.querySelectorAll("ol > li");
       expect(rows.length).toBe(500);
 
-      const elapsed = t1 - t0;
-      expect(elapsed).toBeLessThan(PERF_BUDGET_MS);
+      expect(median).toBeLessThan(PERF_BUDGET_MS);
       expect(fetchSpy).not.toHaveBeenCalled();
       expect(xhrOpenSpy).not.toHaveBeenCalled();
+
+      const baseline = getMetricBaseline(
+        loadPerfBaselines(),
+        "drilldown_500pr_open_ms",
+      );
+      checkRegression("drilldown-500pr-open", median, baseline);
+      console.log(
+        JSON.stringify({
+          test: "drilldown_500pr_open",
+          duration_ms: median,
+          budget_ms: PERF_BUDGET_MS,
+          baseline_ms: baseline ?? "N/A",
+        }),
+      );
     } finally {
       Object.defineProperty(globalThis, "fetch", {
         configurable: true,

--- a/extension/tests/unit/chart-scalability.test.ts
+++ b/extension/tests/unit/chart-scalability.test.ts
@@ -24,6 +24,12 @@ import { DatasetLoader } from "../../ui/dataset-loader";
 import type { Rollup } from "../../ui/dataset-loader";
 import type { ManifestSchema } from "../../ui/types";
 import { pathExists, readJsonFile } from "../helpers/fs-test-utils";
+import {
+  checkRegression,
+  getMetricBaseline,
+  loadPerfBaselines,
+  measureWithWarmup,
+} from "../helpers/perf-measure";
 
 type RealDataManifest = ManifestSchema & {
   coverage: { total_prs: number; date_range: { min: string; max: string } };
@@ -65,14 +71,36 @@ describe("Throughput Chart Scalability", () => {
     document.body.removeChild(container);
   });
 
+  // The previous single-shot `performance.now()` check tripped on rare
+  // CI cold-render outliers (issue #348 — the same job rendered 156
+  // weeks in 56-77 ms in T028/T029/T031 but spiked to 1087 ms once on
+  // the first throughput render). Warmup + median absorbs that single-
+  // shot outlier without loosening the literal 1000 ms ceiling required
+  // by FR-010 / QG-28; the regression check additionally captures any
+  // sustained slowdown against the committed baseline.
   it("T027: renders 156 weeks in < 1000ms", () => {
     const rollups = createRollups(156);
-    const start = performance.now();
-    renderThroughputChart(container, rollups);
-    const elapsed = performance.now() - start;
+    const median = measureWithWarmup(
+      () => renderThroughputChart(container, rollups),
+      { beforeEach: () => (container.innerHTML = "") },
+    );
 
-    expect(elapsed).toBeLessThan(1000);
+    expect(median).toBeLessThan(1000);
     expect(container.innerHTML).not.toBe("");
+
+    const baseline = getMetricBaseline(
+      loadPerfBaselines(),
+      "156wk_throughput_render_ms",
+    );
+    checkRegression("156wk-throughput-render", median, baseline);
+    console.log(
+      JSON.stringify({
+        test: "156wk_throughput_render",
+        duration_ms: median,
+        budget_ms: 1000,
+        baseline_ms: baseline ?? "N/A",
+      }),
+    );
   });
 
   it("T029: caps DOM bar elements at MAX_THROUGHPUT_POINTS (104)", () => {
@@ -130,14 +158,30 @@ describe("Cycle Time Chart Scalability", () => {
     document.body.removeChild(container);
   });
 
+  // Warmup + median for the same reason as T027 — see the comment there.
   it("T028: renders 156 weeks in < 1000ms", () => {
     const rollups = createRollups(156);
-    const start = performance.now();
-    renderCycleTimeTrend(container, rollups);
-    const elapsed = performance.now() - start;
+    const median = measureWithWarmup(
+      () => renderCycleTimeTrend(container, rollups),
+      { beforeEach: () => (container.innerHTML = "") },
+    );
 
-    expect(elapsed).toBeLessThan(1000);
+    expect(median).toBeLessThan(1000);
     expect(container.innerHTML).not.toBe("");
+
+    const baseline = getMetricBaseline(
+      loadPerfBaselines(),
+      "156wk_cycle_time_render_ms",
+    );
+    checkRegression("156wk-cycle-time-render", median, baseline);
+    console.log(
+      JSON.stringify({
+        test: "156wk_cycle_time_render",
+        duration_ms: median,
+        budget_ms: 1000,
+        baseline_ms: baseline ?? "N/A",
+      }),
+    );
   });
 
   it("T030: caps DOM dot elements at MAX_CYCLE_TIME_POINTS per metric", () => {


### PR DESCRIPTION
## Summary

- Replaces single-shot `expect(elapsed).toBeLessThan(BUDGET)` in two flake-prone timing tests (`chart-scalability.test.ts` T027 / T028 and `throughput-drilldown-perf.test.ts`) with the warmup + median + committed-baseline pattern already used by `tests/python-integration/performance.test.ts`.
- The literal spec ceilings — `< 1000ms` (FR-010 / QG-28) and `< 250ms` (SC-001) — are preserved verbatim; they now apply to the median of 3 measured iterations after 2 warmup iterations rather than to a single sample.
- Lifts the harness into a shared helper (`extension/tests/helpers/perf-measure.ts`) with focused unit tests that lock the validation guards a Codex stop-time review surfaced (reject `measureRuns < 1` / non-integer; treat `baselineMs <= 0` as missing to avoid `Infinity`/divide-by-zero).

## Why

Issue #348 documents two flakes in this branch's CI / preflight history:

1. **Chart render — CI run [25050691991](https://github.com/oddessentials/ado-git-repo-insights/actions/runs/25050691991/job/73377893619)**: `T027: renders 156 weeks in < 1000ms` overshoot (1087.38 ms vs 1000 ms ceiling) on the first throughput render in a fresh worker. The same job rendered 156 weeks in 56–77 ms in T028 / T029 / T031 — a one-shot JIT-cold / GC blip on the first render, not a sustained slowdown.
2. **Drill-down panel — local preflight**: `throughput-drilldown perf (SC-001)` overshoot (251.81 ms vs 250 ms ceiling) under coverage instrumentation. Local Windows medians sit at 150–160 ms with `--coverage`, only ~1.5× headroom; routine single-digit-ms variance trips the assertion.

Median-of-3 with 2 discarded warmup runs absorbs both failure shapes (the JIT-cold first render is among the warmups, not the measurements; the median of 3 is robust to a single outlier) without weakening the original contract — the same `< 1000ms` and `< 250ms` ceilings still gate, just on a more deterministic statistic.

## Files

- `extension/tests/helpers/perf-measure.ts` — new shared helper (`measureWithWarmup`, `checkRegression`, `loadPerfBaselines`, `getMetricBaseline`).
- `extension/tests/helpers/perf-measure.test.ts` — 6 focused unit tests locking the helper contract and the Codex-flagged guards (positive-integer `measureRuns`, non-positive `baselineMs` treated as missing, absolute-mode regression-throw at the 20 % threshold).
- `extension/tests/unit/chart-scalability.test.ts` — T027 and T028 converted; `expect(median).toBeLessThan(1000)` against the same literal ceiling.
- `extension/tests/modules/drilldown/throughput-drilldown-perf.test.ts` — SC-001 test converted; fetch / XHR spies installed outside the measurement loop so the no-network invariant covers all warmup + measured iterations; final activation post-loop for assertion only.
- `extension/scripts/update-perf-baseline.ts` — test-pattern broadened (cross-OS shell-quoting on the `|` regex), mapping table extended for the three new keys, mapping variable renamed `key` → `metricName` so the high-entropy literal does not match gitleaks's `generic-api-key` rule.
- `.test-floor-contract.json` — extension floor bumped 3056 → 3062 to match the 6 new helper tests.

## Out of scope by design

- **`extension/tests/fixtures/perf-baselines.json` is intentionally untouched.** Trend-mode bootstrap: the helper logs `"No usable baseline for X, recording: Yms"` until canonical CI medians are seeded via the approved `chore(perf): update baselines [baseline-update]` path. Mixing baseline-edit ceremony into the flake fix would muddle the integrity-guard contract (see `.github/scripts/check-baseline-integrity.js`). Follow-up: once this PR's CI run produces stable medians on `ubuntu-latest`, seed the three new keys (`156wk_throughput_render_ms`, `156wk_cycle_time_render_ms`, `drilldown_500pr_open_ms`) in a separate baseline-update commit on `main`.
- Specs (024 FR-010 / QG-28 and 060 SC-001) unchanged — the literal ceilings still hold.
- No production code, schema, fixture, doc, or CI workflow edits.

## Test plan

- [x] Targeted Jest: `pnpm exec jest --testPathPatterns="perf-measure|chart-scalability|throughput-drilldown-perf" --runInBand --no-coverage` — 34/34 pass.
- [x] Same with `--coverage --ci` (mimics preflight conditions) — 34/34 pass.
- [x] 5 stability iterations on the converted tests — all green; medians stable (T027 ~25–30 ms, T028 ~42 ms, drilldown ~37 ms).
- [x] Full extension Jest suite — 3062 tests across 144 suites, all pass.
- [x] TypeScript build / test type check — clean.
- [x] ESLint production / tests — clean.
- [x] Prettier — clean.
- [x] gitleaks at HEAD — `no leaks found`.
- [x] Test-floor contract — Python (2364) and extension (3062) match canonical collectors.
- [x] `python scripts/run_pr_preflight.py` (authoritative local PR gate) at amended HEAD — `[OK] Local PR preflight passed`.
- [x] argv-probe verified the cross-OS shell-quoted `--testPathPatterns=...|...|...` token survives shell parsing as a single argument.

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Sloppy Claude