### PR TITLE
feat(354): comments-density UX polish

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -8670,14 +8670,14 @@ var PRInsightsDashboard = (() => {
   // ../ui/modules/charts/comments-trend.ts
   var MAX_COMMENTS_TREND_POINTS = 104;
   var COMMENTS_TREND_TOOLTIP = "Bars show resolved (lower) and unresolved (upper) review threads per week. The line shows total comments. Hatched bars indicate partial coverage \u2014 some PRs in the week aren't yet extracted, so totals are partial.";
-  var commentsTrendInfoIconControllers = /* @__PURE__ */ new WeakMap();
-  function attachCommentsTrendInfoIcon(heading) {
+  var chartInfoIconControllers = /* @__PURE__ */ new WeakMap();
+  function attachChartInfoIcon(heading, tooltipText, instanceId) {
     const existing = heading.querySelector(
       ".info-icon-btn"
     );
     if (existing) {
-      commentsTrendInfoIconControllers.get(existing)?.abort();
-      commentsTrendInfoIconControllers.delete(existing);
+      chartInfoIconControllers.get(existing)?.abort();
+      chartInfoIconControllers.delete(existing);
       existing.remove();
     }
     const controller = new AbortController();
@@ -8686,12 +8686,12 @@ var PRInsightsDashboard = (() => {
     btn.className = "info-icon-btn";
     btn.setAttribute("type", "button");
     btn.setAttribute("aria-label", "About this chart");
-    btn.setAttribute("data-info-tooltip", "comments-trend");
+    btn.setAttribute("data-info-tooltip", instanceId);
     btn.textContent = "\u2139";
     btn.addEventListener(
       "pointerenter",
       () => {
-        showInfoTooltip(btn, COMMENTS_TREND_TOOLTIP);
+        showInfoTooltip(btn, tooltipText);
       },
       { signal }
     );
@@ -8711,7 +8711,7 @@ var PRInsightsDashboard = (() => {
           dismissAllTooltips();
           return;
         }
-        showInfoTooltip(btn, COMMENTS_TREND_TOOLTIP);
+        showInfoTooltip(btn, tooltipText);
         requestAnimationFrame(() => {
           const dismissOnce = () => {
             dismissAllTooltips();
@@ -8722,16 +8722,22 @@ var PRInsightsDashboard = (() => {
       },
       { signal }
     );
-    commentsTrendInfoIconControllers.set(btn, controller);
+    chartInfoIconControllers.set(btn, controller);
     heading.appendChild(btn);
   }
-  function detachCommentsTrendInfoIcon(heading) {
+  function detachChartInfoIcon(heading) {
     const btn = heading.querySelector(".info-icon-btn");
     if (!btn) return;
-    commentsTrendInfoIconControllers.get(btn)?.abort();
-    commentsTrendInfoIconControllers.delete(btn);
+    chartInfoIconControllers.get(btn)?.abort();
+    chartInfoIconControllers.delete(btn);
     btn.remove();
     dismissAllTooltips();
+  }
+  function attachCommentsTrendInfoIcon(heading) {
+    attachChartInfoIcon(heading, COMMENTS_TREND_TOOLTIP, "comments-trend");
+  }
+  function detachCommentsTrendInfoIcon(heading) {
+    detachChartInfoIcon(heading);
   }
   var MAX_VISIBLE_LABELS2 = 16;
   var CHART_HEIGHT_PX = 200;
@@ -8746,7 +8752,7 @@ var PRInsightsDashboard = (() => {
       renderNoData(
         container,
         "Comments trend is not yet filterable",
-        "Clear repo / team / author / reviewer filters to view weekly comment activity. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+        "Clear repo / team / author / reviewer filters to view weekly comment activity. Per-dimension comment breakdowns are coming soon."
       );
       return;
     }
@@ -8989,7 +8995,7 @@ var PRInsightsDashboard = (() => {
       renderNoData(
         container,
         "Comments density is not yet filterable",
-        "Clear repo / team / author / reviewer filters to view per-author review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+        "Clear repo / team / author / reviewer filters to view per-author review-conversation totals. Per-dimension comment breakdowns are coming soon."
       );
       return;
     }
@@ -9047,7 +9053,7 @@ var PRInsightsDashboard = (() => {
       case "thread_count":
         return "Threads";
       case "active_thread_count":
-        return "Active threads";
+        return "Unresolved threads";
     }
   }
   function renderSortControls(activeMetric) {
@@ -9061,14 +9067,14 @@ var PRInsightsDashboard = (() => {
   }
   function renderTable(rows) {
     const rowsHtml = rows.map((row) => renderRow(row)).join("");
-    return `<div class="comments-author-density-table" role="table" aria-label="Per-author comment density"><div class="comments-author-density-thead" role="row"><div role="columnheader">Author</div><div role="columnheader" class="comments-author-density-numeric">Threads</div><div role="columnheader" class="comments-author-density-numeric">Active threads</div><div role="columnheader" class="comments-author-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+    return `<div class="comments-author-density-table" role="table" aria-label="Per-author comments"><div class="comments-author-density-thead" role="row"><div role="columnheader">Author</div><div role="columnheader" class="comments-author-density-numeric">Threads</div><div role="columnheader" class="comments-author-density-numeric">Comments</div><div role="columnheader" class="comments-author-density-numeric">Unresolved</div></div>${rowsHtml}</div>`;
   }
   function renderRow(row) {
     const partialClass = row.coverage_partial ? " coverage-partial" : "";
     const partialAttr = row.coverage_partial ? ' data-coverage-partial="true"' : "";
     const partialNote = row.coverage_partial ? " (partial coverage)" : "";
-    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
-    return `<div class="comments-author-density-row${partialClass}" role="row" data-author-key="${escapeHtml(row.authorKey)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-author-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.comment_count.toLocaleString()} comments, ${row.active_thread_count.toLocaleString()} unresolved threads${partialNote}`;
+    return `<div class="comments-author-density-row${partialClass}" role="row" data-author-key="${escapeHtml(row.authorKey)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-author-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div></div>`;
   }
 
   // ../ui/modules/charts/comments-repository-density.ts
@@ -9195,7 +9201,7 @@ var PRInsightsDashboard = (() => {
       renderNoData(
         container,
         "Comments density is not yet filterable",
-        "Clear repo / team / author / reviewer filters to view per-repo review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+        "Clear repo / team / author / reviewer filters to view per-repo review-conversation totals. Per-dimension comment breakdowns are coming soon."
       );
       return;
     }
@@ -9256,7 +9262,7 @@ var PRInsightsDashboard = (() => {
       case "thread_count":
         return "Threads";
       case "active_thread_count":
-        return "Active threads";
+        return "Unresolved threads";
     }
   }
   function renderSortControls2(activeMetric) {
@@ -9270,14 +9276,14 @@ var PRInsightsDashboard = (() => {
   }
   function renderTable2(rows) {
     const rowsHtml = rows.map((row) => renderRow2(row)).join("");
-    return `<div class="comments-repository-density-table" role="table" aria-label="Per-repository comment density"><div class="comments-repository-density-thead" role="row"><div role="columnheader">Repository</div><div role="columnheader" class="comments-repository-density-numeric">Threads</div><div role="columnheader" class="comments-repository-density-numeric">Active threads</div><div role="columnheader" class="comments-repository-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+    return `<div class="comments-repository-density-table" role="table" aria-label="Per-repository comments"><div class="comments-repository-density-thead" role="row"><div role="columnheader">Repository</div><div role="columnheader" class="comments-repository-density-numeric">Threads</div><div role="columnheader" class="comments-repository-density-numeric">Comments</div><div role="columnheader" class="comments-repository-density-numeric">Unresolved</div></div>${rowsHtml}</div>`;
   }
   function renderRow2(row) {
     const partialClass = row.coverage_partial ? " coverage-partial" : "";
     const partialAttr = row.coverage_partial ? ' data-coverage-partial="true"' : "";
     const partialNote = row.coverage_partial ? " (partial coverage)" : "";
-    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
-    return `<div class="comments-repository-density-row${partialClass}" role="row" data-repository-id="${escapeHtml(row.repositoryId)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-repository-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.comment_count.toLocaleString()} comments, ${row.active_thread_count.toLocaleString()} unresolved threads${partialNote}`;
+    return `<div class="comments-repository-density-row${partialClass}" role="row" data-repository-id="${escapeHtml(row.repositoryId)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-repository-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div></div>`;
   }
 
   // ../ui/modules/charts/comments-reviewer-density.ts
@@ -9409,7 +9415,7 @@ var PRInsightsDashboard = (() => {
       renderNoData(
         container,
         "Comments density is not yet filterable",
-        "Clear repo / team / author / reviewer filters to view per-reviewer review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+        "Clear repo / team / author / reviewer filters to view per-reviewer review-conversation totals. Per-dimension comment breakdowns are coming soon."
       );
       return;
     }
@@ -9470,7 +9476,7 @@ var PRInsightsDashboard = (() => {
       case "thread_count":
         return "Threads";
       case "active_thread_count":
-        return "Active threads";
+        return "Unresolved threads";
     }
   }
   function renderSortControls3(activeMetric) {
@@ -9484,15 +9490,15 @@ var PRInsightsDashboard = (() => {
   }
   function renderTable3(rows) {
     const rowsHtml = rows.map((row) => renderRow3(row)).join("");
-    return `<div class="comments-reviewer-density-table" role="table" aria-label="Per-reviewer comment density"><div class="comments-reviewer-density-thead" role="row"><div role="columnheader">Reviewer</div><div role="columnheader" class="comments-reviewer-density-numeric">Threads</div><div role="columnheader" class="comments-reviewer-density-numeric">Active threads</div><div role="columnheader" class="comments-reviewer-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+    return `<div class="comments-reviewer-density-table" role="table" aria-label="Per-reviewer comments"><div class="comments-reviewer-density-thead" role="row"><div role="columnheader">Reviewer</div><div role="columnheader" class="comments-reviewer-density-numeric">Threads</div><div role="columnheader" class="comments-reviewer-density-numeric">Comments</div><div role="columnheader" class="comments-reviewer-density-numeric">Unresolved</div></div>${rowsHtml}</div>`;
   }
   function renderRow3(row) {
     const partialClass = row.coverage_partial ? " coverage-partial" : "";
     const partialAttr = row.coverage_partial ? ' data-coverage-partial="true"' : "";
     const partialTitle = row.coverage_partial ? ` title="${escapeHtml("This week's comments extraction is partial; reviewer activity may be incomplete")}"` : "";
     const partialNote = row.coverage_partial ? " (partial week coverage; reviewer activity may be incomplete this week)" : "";
-    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
-    return `<div class="comments-reviewer-density-row${partialClass}" role="row" data-reviewer-key="${escapeHtml(row.reviewerKey)}"${partialAttr}${partialTitle} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-reviewer-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.comment_count.toLocaleString()} comments, ${row.active_thread_count.toLocaleString()} unresolved threads${partialNote}`;
+    return `<div class="comments-reviewer-density-row${partialClass}" role="row" data-reviewer-key="${escapeHtml(row.reviewerKey)}"${partialAttr}${partialTitle} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-reviewer-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div></div>`;
   }
 
   // ../ui/modules/filter-constraint-resolver.ts
@@ -10837,6 +10843,9 @@ var PRInsightsDashboard = (() => {
   var lastEffectiveState = null;
   var SETTINGS_KEY_PROJECT = "pr-insights-source-project";
   var SETTINGS_KEY_PIPELINE = "pr-insights-pipeline-id";
+  var COMMENTS_AUTHOR_DENSITY_TOOLTIP = "Each row shows one author's review-conversation totals across the selected range. Threads = review threads on PRs the author opened; Unresolved threads = the subset still in the Active state. Comments = every comment posted on those threads. Hatched rows mean some weeks in this author's range are partially extracted.";
+  var COMMENTS_REPOSITORY_DENSITY_TOOLTIP = "Each row shows one repository's review-conversation totals across the selected range. Threads = review threads on PRs in this repository; Unresolved threads = the subset still in the Active state. Comments = every comment posted on those threads. Hatched rows mean some weeks in this repository's range are partially extracted.";
+  var COMMENTS_REVIEWER_DENSITY_TOOLTIP = "Each row shows one reviewer's commenting activity across the selected range. Threads = review threads this reviewer commented in. A thread with multiple commenters contributes one to each, so the total of this column may exceed total threads on the trend chart above. Unresolved threads = the subset still in the Active state. Comments = every comment posted by this reviewer on those threads.";
   var cachedDataService = null;
   async function getDataService() {
     if (!cachedDataService) {
@@ -11719,7 +11728,12 @@ var PRInsightsDashboard = (() => {
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
     const heading = document.createElement("h3");
-    heading.textContent = "Comment Density by Author";
+    heading.textContent = "Comments by Author";
+    attachChartInfoIcon(
+      heading,
+      COMMENTS_AUTHOR_DENSITY_TOOLTIP,
+      "comments-author-density"
+    );
     containerCell.appendChild(heading);
     const chart = document.createElement("div");
     chart.id = "comments-author-density";
@@ -11734,6 +11748,10 @@ var PRInsightsDashboard = (() => {
       '[data-comments-author-density-row="true"]'
     );
     if (!row) return;
+    const heading = row.querySelector("h3");
+    if (heading instanceof HTMLElement) {
+      detachChartInfoIcon(heading);
+    }
     row.parentElement?.removeChild(row);
   }
   function ensureCommentsRepositoryDensityContainer() {
@@ -11757,7 +11775,12 @@ var PRInsightsDashboard = (() => {
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
     const heading = document.createElement("h3");
-    heading.textContent = "Comment Density by Repository";
+    heading.textContent = "Comments by Repository";
+    attachChartInfoIcon(
+      heading,
+      COMMENTS_REPOSITORY_DENSITY_TOOLTIP,
+      "comments-repository-density"
+    );
     containerCell.appendChild(heading);
     const chart = document.createElement("div");
     chart.id = "comments-repository-density";
@@ -11772,6 +11795,10 @@ var PRInsightsDashboard = (() => {
       '[data-comments-repository-density-row="true"]'
     );
     if (!row) return;
+    const heading = row.querySelector("h3");
+    if (heading instanceof HTMLElement) {
+      detachChartInfoIcon(heading);
+    }
     row.parentElement?.removeChild(row);
   }
   function ensureCommentsReviewerDensityContainer() {
@@ -11800,7 +11827,12 @@ var PRInsightsDashboard = (() => {
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
     const heading = document.createElement("h3");
-    heading.textContent = "Comment Density by Reviewer";
+    heading.textContent = "Comments by Reviewer";
+    attachChartInfoIcon(
+      heading,
+      COMMENTS_REVIEWER_DENSITY_TOOLTIP,
+      "comments-reviewer-density"
+    );
     containerCell.appendChild(heading);
     const chart = document.createElement("div");
     chart.id = "comments-reviewer-density";
@@ -11815,6 +11847,10 @@ var PRInsightsDashboard = (() => {
       '[data-comments-reviewer-density-row="true"]'
     );
     if (!row) return;
+    const heading = row.querySelector("h3");
+    if (heading instanceof HTMLElement) {
+      detachChartInfoIcon(heading);
+    }
     row.parentElement?.removeChild(row);
   }
   function toArtifactLoadResult(loaderResult, artifactPath) {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -3854,8 +3854,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-author-density-sort-btn {
-    border: 1px solid var(--border-color, #d0d7de);
-    background: var(--bg-secondary, #f6f8fa);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text-primary, inherit);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -3865,14 +3865,14 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-author-density-sort-btn:focus-visible {
-    outline: 2px solid var(--primary, #0969da);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
 .comments-author-density-sort-btn.is-active {
-    background: var(--primary, #0969da);
-    color: var(--bg-primary, #ffffff);
-    border-color: var(--primary, #0969da);
+    background: var(--primary);
+    color: var(--bg-primary);
+    border-color: var(--primary);
 }
 
 .comments-author-density-table {
@@ -3893,9 +3893,9 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--text-secondary, #57606a);
+    color: var(--text-secondary);
     padding: 0.25rem 0;
-    border-bottom: 1px solid var(--border-color, #d0d7de);
+    border-bottom: 1px solid var(--border);
 }
 
 .comments-author-density-row > [role="cell"] {
@@ -3918,11 +3918,11 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
  * (FR-4-03).  Shares the .coverage-partial class hook with 333 so the
  * convention stays visually consistent across the two surfaces. */
 .comments-author-density-row.coverage-partial > [role="cell"] {
-    color: var(--text-tertiary, #6e7781);
+    color: var(--text-tertiary);
     background-image: repeating-linear-gradient(
         45deg,
-        rgba(110, 119, 129, 0.08) 0,
-        rgba(110, 119, 129, 0.08) 4px,
+        rgba(110, 119, 129, 0.18) 0,
+        rgba(110, 119, 129, 0.18) 4px,
         transparent 4px,
         transparent 8px
     );
@@ -3947,8 +3947,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-repository-density-sort-btn {
-    border: 1px solid var(--border-color, #d0d7de);
-    background: var(--bg-secondary, #f6f8fa);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text-primary, inherit);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -3958,14 +3958,14 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-repository-density-sort-btn:focus-visible {
-    outline: 2px solid var(--primary, #0969da);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
 .comments-repository-density-sort-btn.is-active {
-    background: var(--primary, #0969da);
-    color: var(--bg-primary, #ffffff);
-    border-color: var(--primary, #0969da);
+    background: var(--primary);
+    color: var(--bg-primary);
+    border-color: var(--primary);
 }
 
 .comments-repository-density-table {
@@ -3986,9 +3986,9 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--text-secondary, #57606a);
+    color: var(--text-secondary);
     padding: 0.25rem 0;
-    border-bottom: 1px solid var(--border-color, #d0d7de);
+    border-bottom: 1px solid var(--border);
 }
 
 .comments-repository-density-row > [role="cell"] {
@@ -4012,11 +4012,11 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
  * the convention stays visually consistent across all three comments-
  * density surfaces. */
 .comments-repository-density-row.coverage-partial > [role="cell"] {
-    color: var(--text-tertiary, #6e7781);
+    color: var(--text-tertiary);
     background-image: repeating-linear-gradient(
         45deg,
-        rgba(110, 119, 129, 0.08) 0,
-        rgba(110, 119, 129, 0.08) 4px,
+        rgba(110, 119, 129, 0.18) 0,
+        rgba(110, 119, 129, 0.18) 4px,
         transparent 4px,
         transparent 8px
     );
@@ -4041,8 +4041,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-reviewer-density-sort-btn {
-    border: 1px solid var(--border-color, #d0d7de);
-    background: var(--bg-secondary, #f6f8fa);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text-primary, inherit);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -4052,14 +4052,14 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-reviewer-density-sort-btn:focus-visible {
-    outline: 2px solid var(--primary, #0969da);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
 .comments-reviewer-density-sort-btn.is-active {
-    background: var(--primary, #0969da);
-    color: var(--bg-primary, #ffffff);
-    border-color: var(--primary, #0969da);
+    background: var(--primary);
+    color: var(--bg-primary);
+    border-color: var(--primary);
 }
 
 .comments-reviewer-density-table {
@@ -4080,9 +4080,9 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--text-secondary, #57606a);
+    color: var(--text-secondary);
     padding: 0.25rem 0;
-    border-bottom: 1px solid var(--border-color, #d0d7de);
+    border-bottom: 1px solid var(--border);
 }
 
 .comments-reviewer-density-row > [role="cell"] {
@@ -4106,11 +4106,11 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
  * 335 so the convention stays visually consistent across all four
  * comments-density surfaces. */
 .comments-reviewer-density-row.coverage-partial > [role="cell"] {
-    color: var(--text-tertiary, #6e7781);
+    color: var(--text-tertiary);
     background-image: repeating-linear-gradient(
         45deg,
-        rgba(110, 119, 129, 0.08) 0,
-        rgba(110, 119, 129, 0.08) 4px,
+        rgba(110, 119, 129, 0.18) 0,
+        rgba(110, 119, 129, 0.18) 4px,
         transparent 4px,
         transparent 8px
     );

--- a/extension/tests/dashboard/comments-author-density-dashboard-lifecycle.test.ts
+++ b/extension/tests/dashboard/comments-author-density-dashboard-lifecycle.test.ts
@@ -87,7 +87,7 @@ function ensureCommentsAuthorDensityContainerContract(): HTMLElement | null {
   containerCell.className = "chart-container";
 
   const heading = document.createElement("h3");
-  heading.textContent = "Comment Density by Author";
+  heading.textContent = "Comments by Author";
   containerCell.appendChild(heading);
 
   const chart = document.createElement("div");
@@ -287,7 +287,7 @@ describe("comments-author-density dashboard lifecycle — source-parse contract"
     // refactor that drops or renames it fails this contract.
     expect(helperBody).toContain('document.createElement("h3")');
     expect(helperBody).toContain(
-      'heading.textContent = "Comment Density by Author"',
+      'heading.textContent = "Comments by Author"',
     );
   });
 

--- a/extension/tests/dashboard/comments-author-density-dashboard-lifecycle.test.ts
+++ b/extension/tests/dashboard/comments-author-density-dashboard-lifecycle.test.ts
@@ -286,9 +286,7 @@ describe("comments-author-density dashboard lifecycle — source-parse contract"
     // an <h3> title. The locked text is asserted here so a future
     // refactor that drops or renames it fails this contract.
     expect(helperBody).toContain('document.createElement("h3")');
-    expect(helperBody).toContain(
-      'heading.textContent = "Comments by Author"',
-    );
+    expect(helperBody).toContain('heading.textContent = "Comments by Author"');
   });
 
   it("removeCommentsAuthorDensityContainer in dashboard.ts targets the data-attribute selector", () => {

--- a/extension/tests/dashboard/comments-repository-density-lifecycle.test.ts
+++ b/extension/tests/dashboard/comments-repository-density-lifecycle.test.ts
@@ -103,7 +103,7 @@ function ensureCommentsRepositoryDensityContainerContract(): HTMLElement | null 
   containerCell.className = "chart-container";
 
   const heading = document.createElement("h3");
-  heading.textContent = "Comment Density by Repository";
+  heading.textContent = "Comments by Repository";
   containerCell.appendChild(heading);
 
   const chart = document.createElement("div");
@@ -210,7 +210,7 @@ function mount334Row(): HTMLElement {
   const containerCell = document.createElement("div");
   containerCell.className = "chart-container";
   const heading = document.createElement("h3");
-  heading.textContent = "Comment Density by Author";
+  heading.textContent = "Comments by Author";
   containerCell.appendChild(heading);
   const chart = document.createElement("div");
   chart.id = "comments-author-density";
@@ -334,7 +334,7 @@ describe("comments-repository-density dashboard lifecycle — source-parse contr
     // refactor that drops or renames it fails this contract.
     expect(helperBody).toContain('document.createElement("h3")');
     expect(helperBody).toContain(
-      'heading.textContent = "Comment Density by Repository"',
+      'heading.textContent = "Comments by Repository"',
     );
   });
 

--- a/extension/tests/dashboard/comments-reviewer-density-lifecycle.test.ts
+++ b/extension/tests/dashboard/comments-reviewer-density-lifecycle.test.ts
@@ -105,7 +105,7 @@ function ensureCommentsReviewerDensityContainerContract(): HTMLElement | null {
   containerCell.className = "chart-container";
 
   const heading = document.createElement("h3");
-  heading.textContent = "Comment Density by Reviewer";
+  heading.textContent = "Comments by Reviewer";
   containerCell.appendChild(heading);
 
   const chart = document.createElement("div");
@@ -213,7 +213,7 @@ function mount334Row(): HTMLElement {
   const containerCell = document.createElement("div");
   containerCell.className = "chart-container";
   const heading = document.createElement("h3");
-  heading.textContent = "Comment Density by Author";
+  heading.textContent = "Comments by Author";
   containerCell.appendChild(heading);
   const chart = document.createElement("div");
   chart.id = "comments-author-density";
@@ -242,7 +242,7 @@ function mount335Row(): HTMLElement {
   const containerCell = document.createElement("div");
   containerCell.className = "chart-container";
   const heading = document.createElement("h3");
-  heading.textContent = "Comment Density by Repository";
+  heading.textContent = "Comments by Repository";
   containerCell.appendChild(heading);
   const chart = document.createElement("div");
   chart.id = "comments-repository-density";
@@ -374,7 +374,7 @@ describe("comments-reviewer-density dashboard lifecycle — source-parse contrac
     // contract.
     expect(helperBody).toContain('document.createElement("h3")');
     expect(helperBody).toContain(
-      'heading.textContent = "Comment Density by Reviewer"',
+      'heading.textContent = "Comments by Reviewer"',
     );
   });
 

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -8670,14 +8670,14 @@ var PRInsightsDashboard = (() => {
   // ../ui/modules/charts/comments-trend.ts
   var MAX_COMMENTS_TREND_POINTS = 104;
   var COMMENTS_TREND_TOOLTIP = "Bars show resolved (lower) and unresolved (upper) review threads per week. The line shows total comments. Hatched bars indicate partial coverage \u2014 some PRs in the week aren't yet extracted, so totals are partial.";
-  var commentsTrendInfoIconControllers = /* @__PURE__ */ new WeakMap();
-  function attachCommentsTrendInfoIcon(heading) {
+  var chartInfoIconControllers = /* @__PURE__ */ new WeakMap();
+  function attachChartInfoIcon(heading, tooltipText, instanceId) {
     const existing = heading.querySelector(
       ".info-icon-btn"
     );
     if (existing) {
-      commentsTrendInfoIconControllers.get(existing)?.abort();
-      commentsTrendInfoIconControllers.delete(existing);
+      chartInfoIconControllers.get(existing)?.abort();
+      chartInfoIconControllers.delete(existing);
       existing.remove();
     }
     const controller = new AbortController();
@@ -8686,12 +8686,12 @@ var PRInsightsDashboard = (() => {
     btn.className = "info-icon-btn";
     btn.setAttribute("type", "button");
     btn.setAttribute("aria-label", "About this chart");
-    btn.setAttribute("data-info-tooltip", "comments-trend");
+    btn.setAttribute("data-info-tooltip", instanceId);
     btn.textContent = "\u2139";
     btn.addEventListener(
       "pointerenter",
       () => {
-        showInfoTooltip(btn, COMMENTS_TREND_TOOLTIP);
+        showInfoTooltip(btn, tooltipText);
       },
       { signal }
     );
@@ -8711,7 +8711,7 @@ var PRInsightsDashboard = (() => {
           dismissAllTooltips();
           return;
         }
-        showInfoTooltip(btn, COMMENTS_TREND_TOOLTIP);
+        showInfoTooltip(btn, tooltipText);
         requestAnimationFrame(() => {
           const dismissOnce = () => {
             dismissAllTooltips();
@@ -8722,16 +8722,22 @@ var PRInsightsDashboard = (() => {
       },
       { signal }
     );
-    commentsTrendInfoIconControllers.set(btn, controller);
+    chartInfoIconControllers.set(btn, controller);
     heading.appendChild(btn);
   }
-  function detachCommentsTrendInfoIcon(heading) {
+  function detachChartInfoIcon(heading) {
     const btn = heading.querySelector(".info-icon-btn");
     if (!btn) return;
-    commentsTrendInfoIconControllers.get(btn)?.abort();
-    commentsTrendInfoIconControllers.delete(btn);
+    chartInfoIconControllers.get(btn)?.abort();
+    chartInfoIconControllers.delete(btn);
     btn.remove();
     dismissAllTooltips();
+  }
+  function attachCommentsTrendInfoIcon(heading) {
+    attachChartInfoIcon(heading, COMMENTS_TREND_TOOLTIP, "comments-trend");
+  }
+  function detachCommentsTrendInfoIcon(heading) {
+    detachChartInfoIcon(heading);
   }
   var MAX_VISIBLE_LABELS2 = 16;
   var CHART_HEIGHT_PX = 200;
@@ -8746,7 +8752,7 @@ var PRInsightsDashboard = (() => {
       renderNoData(
         container,
         "Comments trend is not yet filterable",
-        "Clear repo / team / author / reviewer filters to view weekly comment activity. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+        "Clear repo / team / author / reviewer filters to view weekly comment activity. Per-dimension comment breakdowns are coming soon."
       );
       return;
     }
@@ -8989,7 +8995,7 @@ var PRInsightsDashboard = (() => {
       renderNoData(
         container,
         "Comments density is not yet filterable",
-        "Clear repo / team / author / reviewer filters to view per-author review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+        "Clear repo / team / author / reviewer filters to view per-author review-conversation totals. Per-dimension comment breakdowns are coming soon."
       );
       return;
     }
@@ -9047,7 +9053,7 @@ var PRInsightsDashboard = (() => {
       case "thread_count":
         return "Threads";
       case "active_thread_count":
-        return "Active threads";
+        return "Unresolved threads";
     }
   }
   function renderSortControls(activeMetric) {
@@ -9061,14 +9067,14 @@ var PRInsightsDashboard = (() => {
   }
   function renderTable(rows) {
     const rowsHtml = rows.map((row) => renderRow(row)).join("");
-    return `<div class="comments-author-density-table" role="table" aria-label="Per-author comment density"><div class="comments-author-density-thead" role="row"><div role="columnheader">Author</div><div role="columnheader" class="comments-author-density-numeric">Threads</div><div role="columnheader" class="comments-author-density-numeric">Active threads</div><div role="columnheader" class="comments-author-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+    return `<div class="comments-author-density-table" role="table" aria-label="Per-author comments"><div class="comments-author-density-thead" role="row"><div role="columnheader">Author</div><div role="columnheader" class="comments-author-density-numeric">Threads</div><div role="columnheader" class="comments-author-density-numeric">Comments</div><div role="columnheader" class="comments-author-density-numeric">Unresolved</div></div>${rowsHtml}</div>`;
   }
   function renderRow(row) {
     const partialClass = row.coverage_partial ? " coverage-partial" : "";
     const partialAttr = row.coverage_partial ? ' data-coverage-partial="true"' : "";
     const partialNote = row.coverage_partial ? " (partial coverage)" : "";
-    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
-    return `<div class="comments-author-density-row${partialClass}" role="row" data-author-key="${escapeHtml(row.authorKey)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-author-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.comment_count.toLocaleString()} comments, ${row.active_thread_count.toLocaleString()} unresolved threads${partialNote}`;
+    return `<div class="comments-author-density-row${partialClass}" role="row" data-author-key="${escapeHtml(row.authorKey)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-author-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div></div>`;
   }
 
   // ../ui/modules/charts/comments-repository-density.ts
@@ -9195,7 +9201,7 @@ var PRInsightsDashboard = (() => {
       renderNoData(
         container,
         "Comments density is not yet filterable",
-        "Clear repo / team / author / reviewer filters to view per-repo review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+        "Clear repo / team / author / reviewer filters to view per-repo review-conversation totals. Per-dimension comment breakdowns are coming soon."
       );
       return;
     }
@@ -9256,7 +9262,7 @@ var PRInsightsDashboard = (() => {
       case "thread_count":
         return "Threads";
       case "active_thread_count":
-        return "Active threads";
+        return "Unresolved threads";
     }
   }
   function renderSortControls2(activeMetric) {
@@ -9270,14 +9276,14 @@ var PRInsightsDashboard = (() => {
   }
   function renderTable2(rows) {
     const rowsHtml = rows.map((row) => renderRow2(row)).join("");
-    return `<div class="comments-repository-density-table" role="table" aria-label="Per-repository comment density"><div class="comments-repository-density-thead" role="row"><div role="columnheader">Repository</div><div role="columnheader" class="comments-repository-density-numeric">Threads</div><div role="columnheader" class="comments-repository-density-numeric">Active threads</div><div role="columnheader" class="comments-repository-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+    return `<div class="comments-repository-density-table" role="table" aria-label="Per-repository comments"><div class="comments-repository-density-thead" role="row"><div role="columnheader">Repository</div><div role="columnheader" class="comments-repository-density-numeric">Threads</div><div role="columnheader" class="comments-repository-density-numeric">Comments</div><div role="columnheader" class="comments-repository-density-numeric">Unresolved</div></div>${rowsHtml}</div>`;
   }
   function renderRow2(row) {
     const partialClass = row.coverage_partial ? " coverage-partial" : "";
     const partialAttr = row.coverage_partial ? ' data-coverage-partial="true"' : "";
     const partialNote = row.coverage_partial ? " (partial coverage)" : "";
-    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
-    return `<div class="comments-repository-density-row${partialClass}" role="row" data-repository-id="${escapeHtml(row.repositoryId)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-repository-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.comment_count.toLocaleString()} comments, ${row.active_thread_count.toLocaleString()} unresolved threads${partialNote}`;
+    return `<div class="comments-repository-density-row${partialClass}" role="row" data-repository-id="${escapeHtml(row.repositoryId)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-repository-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div></div>`;
   }
 
   // ../ui/modules/charts/comments-reviewer-density.ts
@@ -9409,7 +9415,7 @@ var PRInsightsDashboard = (() => {
       renderNoData(
         container,
         "Comments density is not yet filterable",
-        "Clear repo / team / author / reviewer filters to view per-reviewer review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+        "Clear repo / team / author / reviewer filters to view per-reviewer review-conversation totals. Per-dimension comment breakdowns are coming soon."
       );
       return;
     }
@@ -9470,7 +9476,7 @@ var PRInsightsDashboard = (() => {
       case "thread_count":
         return "Threads";
       case "active_thread_count":
-        return "Active threads";
+        return "Unresolved threads";
     }
   }
   function renderSortControls3(activeMetric) {
@@ -9484,15 +9490,15 @@ var PRInsightsDashboard = (() => {
   }
   function renderTable3(rows) {
     const rowsHtml = rows.map((row) => renderRow3(row)).join("");
-    return `<div class="comments-reviewer-density-table" role="table" aria-label="Per-reviewer comment density"><div class="comments-reviewer-density-thead" role="row"><div role="columnheader">Reviewer</div><div role="columnheader" class="comments-reviewer-density-numeric">Threads</div><div role="columnheader" class="comments-reviewer-density-numeric">Active threads</div><div role="columnheader" class="comments-reviewer-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+    return `<div class="comments-reviewer-density-table" role="table" aria-label="Per-reviewer comments"><div class="comments-reviewer-density-thead" role="row"><div role="columnheader">Reviewer</div><div role="columnheader" class="comments-reviewer-density-numeric">Threads</div><div role="columnheader" class="comments-reviewer-density-numeric">Comments</div><div role="columnheader" class="comments-reviewer-density-numeric">Unresolved</div></div>${rowsHtml}</div>`;
   }
   function renderRow3(row) {
     const partialClass = row.coverage_partial ? " coverage-partial" : "";
     const partialAttr = row.coverage_partial ? ' data-coverage-partial="true"' : "";
     const partialTitle = row.coverage_partial ? ` title="${escapeHtml("This week's comments extraction is partial; reviewer activity may be incomplete")}"` : "";
     const partialNote = row.coverage_partial ? " (partial week coverage; reviewer activity may be incomplete this week)" : "";
-    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
-    return `<div class="comments-reviewer-density-row${partialClass}" role="row" data-reviewer-key="${escapeHtml(row.reviewerKey)}"${partialAttr}${partialTitle} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-reviewer-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.comment_count.toLocaleString()} comments, ${row.active_thread_count.toLocaleString()} unresolved threads${partialNote}`;
+    return `<div class="comments-reviewer-density-row${partialClass}" role="row" data-reviewer-key="${escapeHtml(row.reviewerKey)}"${partialAttr}${partialTitle} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-reviewer-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div></div>`;
   }
 
   // ../ui/modules/filter-constraint-resolver.ts
@@ -10837,6 +10843,9 @@ var PRInsightsDashboard = (() => {
   var lastEffectiveState = null;
   var SETTINGS_KEY_PROJECT = "pr-insights-source-project";
   var SETTINGS_KEY_PIPELINE = "pr-insights-pipeline-id";
+  var COMMENTS_AUTHOR_DENSITY_TOOLTIP = "Each row shows one author's review-conversation totals across the selected range. Threads = review threads on PRs the author opened; Unresolved threads = the subset still in the Active state. Comments = every comment posted on those threads. Hatched rows mean some weeks in this author's range are partially extracted.";
+  var COMMENTS_REPOSITORY_DENSITY_TOOLTIP = "Each row shows one repository's review-conversation totals across the selected range. Threads = review threads on PRs in this repository; Unresolved threads = the subset still in the Active state. Comments = every comment posted on those threads. Hatched rows mean some weeks in this repository's range are partially extracted.";
+  var COMMENTS_REVIEWER_DENSITY_TOOLTIP = "Each row shows one reviewer's commenting activity across the selected range. Threads = review threads this reviewer commented in. A thread with multiple commenters contributes one to each, so the total of this column may exceed total threads on the trend chart above. Unresolved threads = the subset still in the Active state. Comments = every comment posted by this reviewer on those threads.";
   var cachedDataService = null;
   async function getDataService() {
     if (!cachedDataService) {
@@ -11719,7 +11728,12 @@ var PRInsightsDashboard = (() => {
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
     const heading = document.createElement("h3");
-    heading.textContent = "Comment Density by Author";
+    heading.textContent = "Comments by Author";
+    attachChartInfoIcon(
+      heading,
+      COMMENTS_AUTHOR_DENSITY_TOOLTIP,
+      "comments-author-density"
+    );
     containerCell.appendChild(heading);
     const chart = document.createElement("div");
     chart.id = "comments-author-density";
@@ -11734,6 +11748,10 @@ var PRInsightsDashboard = (() => {
       '[data-comments-author-density-row="true"]'
     );
     if (!row) return;
+    const heading = row.querySelector("h3");
+    if (heading instanceof HTMLElement) {
+      detachChartInfoIcon(heading);
+    }
     row.parentElement?.removeChild(row);
   }
   function ensureCommentsRepositoryDensityContainer() {
@@ -11757,7 +11775,12 @@ var PRInsightsDashboard = (() => {
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
     const heading = document.createElement("h3");
-    heading.textContent = "Comment Density by Repository";
+    heading.textContent = "Comments by Repository";
+    attachChartInfoIcon(
+      heading,
+      COMMENTS_REPOSITORY_DENSITY_TOOLTIP,
+      "comments-repository-density"
+    );
     containerCell.appendChild(heading);
     const chart = document.createElement("div");
     chart.id = "comments-repository-density";
@@ -11772,6 +11795,10 @@ var PRInsightsDashboard = (() => {
       '[data-comments-repository-density-row="true"]'
     );
     if (!row) return;
+    const heading = row.querySelector("h3");
+    if (heading instanceof HTMLElement) {
+      detachChartInfoIcon(heading);
+    }
     row.parentElement?.removeChild(row);
   }
   function ensureCommentsReviewerDensityContainer() {
@@ -11800,7 +11827,12 @@ var PRInsightsDashboard = (() => {
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
     const heading = document.createElement("h3");
-    heading.textContent = "Comment Density by Reviewer";
+    heading.textContent = "Comments by Reviewer";
+    attachChartInfoIcon(
+      heading,
+      COMMENTS_REVIEWER_DENSITY_TOOLTIP,
+      "comments-reviewer-density"
+    );
     containerCell.appendChild(heading);
     const chart = document.createElement("div");
     chart.id = "comments-reviewer-density";
@@ -11815,6 +11847,10 @@ var PRInsightsDashboard = (() => {
       '[data-comments-reviewer-density-row="true"]'
     );
     if (!row) return;
+    const heading = row.querySelector("h3");
+    if (heading instanceof HTMLElement) {
+      detachChartInfoIcon(heading);
+    }
     row.parentElement?.removeChild(row);
   }
   function toArtifactLoadResult(loaderResult, artifactPath) {

--- a/extension/tests/fixtures/broken-docs/styles.css
+++ b/extension/tests/fixtures/broken-docs/styles.css
@@ -3854,8 +3854,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-author-density-sort-btn {
-    border: 1px solid var(--border-color, #d0d7de);
-    background: var(--bg-secondary, #f6f8fa);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text-primary, inherit);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -3865,14 +3865,14 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-author-density-sort-btn:focus-visible {
-    outline: 2px solid var(--primary, #0969da);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
 .comments-author-density-sort-btn.is-active {
-    background: var(--primary, #0969da);
-    color: var(--bg-primary, #ffffff);
-    border-color: var(--primary, #0969da);
+    background: var(--primary);
+    color: var(--bg-primary);
+    border-color: var(--primary);
 }
 
 .comments-author-density-table {
@@ -3893,9 +3893,9 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--text-secondary, #57606a);
+    color: var(--text-secondary);
     padding: 0.25rem 0;
-    border-bottom: 1px solid var(--border-color, #d0d7de);
+    border-bottom: 1px solid var(--border);
 }
 
 .comments-author-density-row > [role="cell"] {
@@ -3918,11 +3918,11 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
  * (FR-4-03).  Shares the .coverage-partial class hook with 333 so the
  * convention stays visually consistent across the two surfaces. */
 .comments-author-density-row.coverage-partial > [role="cell"] {
-    color: var(--text-tertiary, #6e7781);
+    color: var(--text-tertiary);
     background-image: repeating-linear-gradient(
         45deg,
-        rgba(110, 119, 129, 0.08) 0,
-        rgba(110, 119, 129, 0.08) 4px,
+        rgba(110, 119, 129, 0.18) 0,
+        rgba(110, 119, 129, 0.18) 4px,
         transparent 4px,
         transparent 8px
     );
@@ -3947,8 +3947,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-repository-density-sort-btn {
-    border: 1px solid var(--border-color, #d0d7de);
-    background: var(--bg-secondary, #f6f8fa);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text-primary, inherit);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -3958,14 +3958,14 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-repository-density-sort-btn:focus-visible {
-    outline: 2px solid var(--primary, #0969da);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
 .comments-repository-density-sort-btn.is-active {
-    background: var(--primary, #0969da);
-    color: var(--bg-primary, #ffffff);
-    border-color: var(--primary, #0969da);
+    background: var(--primary);
+    color: var(--bg-primary);
+    border-color: var(--primary);
 }
 
 .comments-repository-density-table {
@@ -3986,9 +3986,9 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--text-secondary, #57606a);
+    color: var(--text-secondary);
     padding: 0.25rem 0;
-    border-bottom: 1px solid var(--border-color, #d0d7de);
+    border-bottom: 1px solid var(--border);
 }
 
 .comments-repository-density-row > [role="cell"] {
@@ -4012,11 +4012,11 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
  * the convention stays visually consistent across all three comments-
  * density surfaces. */
 .comments-repository-density-row.coverage-partial > [role="cell"] {
-    color: var(--text-tertiary, #6e7781);
+    color: var(--text-tertiary);
     background-image: repeating-linear-gradient(
         45deg,
-        rgba(110, 119, 129, 0.08) 0,
-        rgba(110, 119, 129, 0.08) 4px,
+        rgba(110, 119, 129, 0.18) 0,
+        rgba(110, 119, 129, 0.18) 4px,
         transparent 4px,
         transparent 8px
     );
@@ -4041,8 +4041,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-reviewer-density-sort-btn {
-    border: 1px solid var(--border-color, #d0d7de);
-    background: var(--bg-secondary, #f6f8fa);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text-primary, inherit);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -4052,14 +4052,14 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-reviewer-density-sort-btn:focus-visible {
-    outline: 2px solid var(--primary, #0969da);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
 .comments-reviewer-density-sort-btn.is-active {
-    background: var(--primary, #0969da);
-    color: var(--bg-primary, #ffffff);
-    border-color: var(--primary, #0969da);
+    background: var(--primary);
+    color: var(--bg-primary);
+    border-color: var(--primary);
 }
 
 .comments-reviewer-density-table {
@@ -4080,9 +4080,9 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--text-secondary, #57606a);
+    color: var(--text-secondary);
     padding: 0.25rem 0;
-    border-bottom: 1px solid var(--border-color, #d0d7de);
+    border-bottom: 1px solid var(--border);
 }
 
 .comments-reviewer-density-row > [role="cell"] {
@@ -4106,11 +4106,11 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
  * 335 so the convention stays visually consistent across all four
  * comments-density surfaces. */
 .comments-reviewer-density-row.coverage-partial > [role="cell"] {
-    color: var(--text-tertiary, #6e7781);
+    color: var(--text-tertiary);
     background-image: repeating-linear-gradient(
         45deg,
-        rgba(110, 119, 129, 0.08) 0,
-        rgba(110, 119, 129, 0.08) 4px,
+        rgba(110, 119, 129, 0.18) 0,
+        rgba(110, 119, 129, 0.18) 4px,
         transparent 4px,
         transparent 8px
     );

--- a/extension/tests/modules/charts/comments-author-density.test.ts
+++ b/extension/tests/modules/charts/comments-author-density.test.ts
@@ -153,9 +153,10 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
     );
     expect(wideRows).toHaveLength(3);
     // 4 weeks × 5 comments = 20 per author on the wide range.
+    // Comments cell is index [1] (column order: Threads / Comments / Unresolved).
     const wideFirstCommentCell = wideRows[0]?.querySelectorAll(
       ".comments-author-density-numeric",
-    )[2];
+    )[1];
     expect(wideFirstCommentCell?.textContent).toBe("20");
 
     // Narrow to first 2 weeks → 2 × 5 = 10 per author.
@@ -169,7 +170,7 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
     expect(narrowRows).toHaveLength(3);
     const narrowFirstCommentCell = narrowRows[0]?.querySelectorAll(
       ".comments-author-density-numeric",
-    )[2];
+    )[1];
     expect(narrowFirstCommentCell?.textContent).toBe("10");
   });
 
@@ -314,7 +315,7 @@ describe("renderCommentsAuthorDensityChart (Feature 334 US1)", () => {
     );
     const ariaLabel = firstRow?.getAttribute("aria-label") ?? "";
     expect(ariaLabel).toContain("threads");
-    expect(ariaLabel).toContain("active threads");
+    expect(ariaLabel).toContain("unresolved threads");
     expect(ariaLabel).toContain("comments");
   });
 

--- a/extension/tests/modules/charts/comments-repository-density.test.ts
+++ b/extension/tests/modules/charts/comments-repository-density.test.ts
@@ -169,9 +169,10 @@ describe("renderCommentsRepositoryDensityChart (Feature 335 US1)", () => {
     );
     expect(wideRows).toHaveLength(3);
     // 4 weeks × 5 comments = 20 per repo on the wide range.
+    // Comments cell is index [1] (column order: Threads / Comments / Unresolved).
     const wideFirstCommentCell = wideRows[0]?.querySelectorAll(
       ".comments-repository-density-numeric",
-    )[2];
+    )[1];
     expect(wideFirstCommentCell?.textContent).toBe("20");
 
     // Narrow to first 2 weeks → 2 × 5 = 10 per repo.
@@ -185,7 +186,7 @@ describe("renderCommentsRepositoryDensityChart (Feature 335 US1)", () => {
     expect(narrowRows).toHaveLength(3);
     const narrowFirstCommentCell = narrowRows[0]?.querySelectorAll(
       ".comments-repository-density-numeric",
-    )[2];
+    )[1];
     expect(narrowFirstCommentCell?.textContent).toBe("10");
   });
 
@@ -335,7 +336,7 @@ describe("renderCommentsRepositoryDensityChart (Feature 335 US1)", () => {
     );
     const ariaLabel = firstRow?.getAttribute("aria-label") ?? "";
     expect(ariaLabel).toContain("threads");
-    expect(ariaLabel).toContain("active threads");
+    expect(ariaLabel).toContain("unresolved threads");
     expect(ariaLabel).toContain("comments");
   });
 

--- a/extension/tests/modules/charts/comments-reviewer-density.test.ts
+++ b/extension/tests/modules/charts/comments-reviewer-density.test.ts
@@ -197,9 +197,10 @@ describe("renderCommentsReviewerDensityChart (Feature 336 US1)", () => {
     );
     expect(wideRows).toHaveLength(3);
     // 4 weeks × 5 comments = 20 per reviewer on the wide range.
+    // Comments cell is index [1] (column order: Threads / Comments / Unresolved).
     const wideFirstCommentCell = wideRows[0]?.querySelectorAll(
       ".comments-reviewer-density-numeric",
-    )[2];
+    )[1];
     expect(wideFirstCommentCell?.textContent).toBe("20");
 
     // Narrow to first 2 weeks → 2 × 5 = 10 per reviewer.
@@ -213,7 +214,7 @@ describe("renderCommentsReviewerDensityChart (Feature 336 US1)", () => {
     expect(narrowRows).toHaveLength(3);
     const narrowFirstCommentCell = narrowRows[0]?.querySelectorAll(
       ".comments-reviewer-density-numeric",
-    )[2];
+    )[1];
     expect(narrowFirstCommentCell?.textContent).toBe("10");
   });
 
@@ -431,7 +432,7 @@ describe("renderCommentsReviewerDensityChart (Feature 336 US1)", () => {
     );
     const ariaLabel = firstRow?.getAttribute("aria-label") ?? "";
     expect(ariaLabel).toContain("threads");
-    expect(ariaLabel).toContain("active threads");
+    expect(ariaLabel).toContain("unresolved threads");
     expect(ariaLabel).toContain("comments");
 
     // NOTE: this slice does NOT assert keyboard activation (Enter /
@@ -634,14 +635,14 @@ describe("renderCommentsReviewerDensityChart (Feature 336 US1)", () => {
     ).toBe(SENTINEL_LABEL);
 
     // Numeric cells reflect the cross-week sum (column order in
-    // ``renderTable``: Threads, Active threads, Comments).
+    // ``renderTable``: Threads, Comments, Unresolved).
     const numericCells = sentinelRow.querySelectorAll<HTMLElement>(
       ".comments-reviewer-density-numeric",
     );
     expect(numericCells).toHaveLength(3);
     expect(numericCells[0]!.textContent).toBe("3"); // thread_count = 2 + 1
-    expect(numericCells[1]!.textContent).toBe("1"); // active_thread_count = 1 + 0
-    expect(numericCells[2]!.textContent).toBe("9"); // comment_count = 5 + 4
+    expect(numericCells[1]!.textContent).toBe("9"); // comment_count = 5 + 4
+    expect(numericCells[2]!.textContent).toBe("1"); // active_thread_count = 1 + 0
   });
 
   it("(T030-b) sentinel participates in sort across all 3 metrics — distinct positions per metric", () => {

--- a/extension/ui/dashboard.ts
+++ b/extension/ui/dashboard.ts
@@ -53,6 +53,8 @@ import {
   renderCommentsTrendChart as renderCommentsTrendChartModule,
   attachCommentsTrendInfoIcon,
   detachCommentsTrendInfoIcon,
+  attachChartInfoIcon,
+  detachChartInfoIcon,
   renderCommentsAuthorDensityChart as renderCommentsAuthorDensityChartModule,
   renderCommentsRepositoryDensityChart as renderCommentsRepositoryDensityChartModule,
   renderCommentsReviewerDensityChart as renderCommentsReviewerDensityChartModule,
@@ -165,6 +167,30 @@ let lastEffectiveState: EffectiveState | null = null;
 // Settings keys for extension data storage (must match settings.js)
 const SETTINGS_KEY_PROJECT = "pr-insights-source-project";
 const SETTINGS_KEY_PIPELINE = "pr-insights-pipeline-id";
+
+// Plain-language explanatory copy surfaced by the chart-level info-icon on
+// the three comments-density panels. Defines Threads / Comments / Unresolved
+// in user-facing terms; the per-reviewer copy additionally clarifies that
+// reviewer thread counts can sum higher than the trend chart's thread total
+// because a thread with multiple commenters contributes one to each reviewer.
+const COMMENTS_AUTHOR_DENSITY_TOOLTIP =
+  "Each row shows one author's review-conversation totals across the selected range. " +
+  "Threads = review threads on PRs the author opened; Unresolved threads = the subset still in the Active state. " +
+  "Comments = every comment posted on those threads. " +
+  "Hatched rows mean some weeks in this author's range are partially extracted.";
+
+const COMMENTS_REPOSITORY_DENSITY_TOOLTIP =
+  "Each row shows one repository's review-conversation totals across the selected range. " +
+  "Threads = review threads on PRs in this repository; Unresolved threads = the subset still in the Active state. " +
+  "Comments = every comment posted on those threads. " +
+  "Hatched rows mean some weeks in this repository's range are partially extracted.";
+
+const COMMENTS_REVIEWER_DENSITY_TOOLTIP =
+  "Each row shows one reviewer's commenting activity across the selected range. " +
+  "Threads = review threads this reviewer commented in. " +
+  "A thread with multiple commenters contributes one to each, so the total of this column may exceed total threads on the trend chart above. " +
+  "Unresolved threads = the subset still in the Active state. " +
+  "Comments = every comment posted by this reviewer on those threads.";
 
 // Cached data service — resolved once per session (matches settings.ts pattern)
 let cachedDataService: Awaited<
@@ -1745,7 +1771,12 @@ function ensureCommentsAuthorDensityContainer(): HTMLElement | null {
   containerCell.className = "chart-container";
 
   const heading = document.createElement("h3");
-  heading.textContent = "Comment Density by Author";
+  heading.textContent = "Comments by Author";
+  attachChartInfoIcon(
+    heading,
+    COMMENTS_AUTHOR_DENSITY_TOOLTIP,
+    "comments-author-density",
+  );
   containerCell.appendChild(heading);
 
   const chart = document.createElement("div");
@@ -1771,6 +1802,10 @@ function removeCommentsAuthorDensityContainer(): void {
     '[data-comments-author-density-row="true"]',
   );
   if (!row) return;
+  const heading = row.querySelector("h3");
+  if (heading instanceof HTMLElement) {
+    detachChartInfoIcon(heading);
+  }
   row.parentElement?.removeChild(row);
 }
 
@@ -1817,7 +1852,12 @@ function ensureCommentsRepositoryDensityContainer(): HTMLElement | null {
   containerCell.className = "chart-container";
 
   const heading = document.createElement("h3");
-  heading.textContent = "Comment Density by Repository";
+  heading.textContent = "Comments by Repository";
+  attachChartInfoIcon(
+    heading,
+    COMMENTS_REPOSITORY_DENSITY_TOOLTIP,
+    "comments-repository-density",
+  );
   containerCell.appendChild(heading);
 
   const chart = document.createElement("div");
@@ -1843,6 +1883,10 @@ function removeCommentsRepositoryDensityContainer(): void {
     '[data-comments-repository-density-row="true"]',
   );
   if (!row) return;
+  const heading = row.querySelector("h3");
+  if (heading instanceof HTMLElement) {
+    detachChartInfoIcon(heading);
+  }
   row.parentElement?.removeChild(row);
 }
 
@@ -1895,7 +1939,12 @@ function ensureCommentsReviewerDensityContainer(): HTMLElement | null {
   containerCell.className = "chart-container";
 
   const heading = document.createElement("h3");
-  heading.textContent = "Comment Density by Reviewer";
+  heading.textContent = "Comments by Reviewer";
+  attachChartInfoIcon(
+    heading,
+    COMMENTS_REVIEWER_DENSITY_TOOLTIP,
+    "comments-reviewer-density",
+  );
   containerCell.appendChild(heading);
 
   const chart = document.createElement("div");
@@ -1921,6 +1970,10 @@ function removeCommentsReviewerDensityContainer(): void {
     '[data-comments-reviewer-density-row="true"]',
   );
   if (!row) return;
+  const heading = row.querySelector("h3");
+  if (heading instanceof HTMLElement) {
+    detachChartInfoIcon(heading);
+  }
   row.parentElement?.removeChild(row);
 }
 

--- a/extension/ui/modules/charts/comments-author-density.ts
+++ b/extension/ui/modules/charts/comments-author-density.ts
@@ -343,7 +343,7 @@ export function renderCommentsAuthorDensityChart(
     renderNoData(
       container,
       "Comments density is not yet filterable",
-      "Clear repo / team / author / reviewer filters to view per-author review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322.",
+      "Clear repo / team / author / reviewer filters to view per-author review-conversation totals. Per-dimension comment breakdowns are coming soon.",
     );
     return;
   }
@@ -420,7 +420,7 @@ function metricLabel(metric: CommentsAuthorDensitySortMetric): string {
     case "thread_count":
       return "Threads";
     case "active_thread_count":
-      return "Active threads";
+      return "Unresolved threads";
   }
 }
 
@@ -448,7 +448,7 @@ function renderSortControls(
 
 function renderTable(rows: readonly AuthorDensityRow[]): string {
   const rowsHtml = rows.map((row) => renderRow(row)).join("");
-  return `<div class="comments-author-density-table" role="table" aria-label="Per-author comment density"><div class="comments-author-density-thead" role="row"><div role="columnheader">Author</div><div role="columnheader" class="comments-author-density-numeric">Threads</div><div role="columnheader" class="comments-author-density-numeric">Active threads</div><div role="columnheader" class="comments-author-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+  return `<div class="comments-author-density-table" role="table" aria-label="Per-author comments"><div class="comments-author-density-thead" role="row"><div role="columnheader">Author</div><div role="columnheader" class="comments-author-density-numeric">Threads</div><div role="columnheader" class="comments-author-density-numeric">Comments</div><div role="columnheader" class="comments-author-density-numeric">Unresolved</div></div>${rowsHtml}</div>`;
 }
 
 function renderRow(row: AuthorDensityRow): string {
@@ -457,6 +457,6 @@ function renderRow(row: AuthorDensityRow): string {
     ? ' data-coverage-partial="true"'
     : "";
   const partialNote = row.coverage_partial ? " (partial coverage)" : "";
-  const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
-  return `<div class="comments-author-density-row${partialClass}" role="row" data-author-key="${escapeHtml(row.authorKey)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-author-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+  const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.comment_count.toLocaleString()} comments, ${row.active_thread_count.toLocaleString()} unresolved threads${partialNote}`;
+  return `<div class="comments-author-density-row${partialClass}" role="row" data-author-key="${escapeHtml(row.authorKey)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-author-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div></div>`;
 }

--- a/extension/ui/modules/charts/comments-repository-density.ts
+++ b/extension/ui/modules/charts/comments-repository-density.ts
@@ -314,7 +314,7 @@ export function renderCommentsRepositoryDensityChart(
     renderNoData(
       container,
       "Comments density is not yet filterable",
-      "Clear repo / team / author / reviewer filters to view per-repo review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322.",
+      "Clear repo / team / author / reviewer filters to view per-repo review-conversation totals. Per-dimension comment breakdowns are coming soon.",
     );
     return;
   }
@@ -409,7 +409,7 @@ function metricLabel(metric: CommentsRepoDensitySortMetric): string {
     case "thread_count":
       return "Threads";
     case "active_thread_count":
-      return "Active threads";
+      return "Unresolved threads";
   }
 }
 
@@ -435,7 +435,7 @@ function renderSortControls(
 
 function renderTable(rows: readonly RepoDensityRow[]): string {
   const rowsHtml = rows.map((row) => renderRow(row)).join("");
-  return `<div class="comments-repository-density-table" role="table" aria-label="Per-repository comment density"><div class="comments-repository-density-thead" role="row"><div role="columnheader">Repository</div><div role="columnheader" class="comments-repository-density-numeric">Threads</div><div role="columnheader" class="comments-repository-density-numeric">Active threads</div><div role="columnheader" class="comments-repository-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+  return `<div class="comments-repository-density-table" role="table" aria-label="Per-repository comments"><div class="comments-repository-density-thead" role="row"><div role="columnheader">Repository</div><div role="columnheader" class="comments-repository-density-numeric">Threads</div><div role="columnheader" class="comments-repository-density-numeric">Comments</div><div role="columnheader" class="comments-repository-density-numeric">Unresolved</div></div>${rowsHtml}</div>`;
 }
 
 function renderRow(row: RepoDensityRow): string {
@@ -444,6 +444,6 @@ function renderRow(row: RepoDensityRow): string {
     ? ' data-coverage-partial="true"'
     : "";
   const partialNote = row.coverage_partial ? " (partial coverage)" : "";
-  const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
-  return `<div class="comments-repository-density-row${partialClass}" role="row" data-repository-id="${escapeHtml(row.repositoryId)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-repository-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+  const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.comment_count.toLocaleString()} comments, ${row.active_thread_count.toLocaleString()} unresolved threads${partialNote}`;
+  return `<div class="comments-repository-density-row${partialClass}" role="row" data-repository-id="${escapeHtml(row.repositoryId)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-repository-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div></div>`;
 }

--- a/extension/ui/modules/charts/comments-reviewer-density.ts
+++ b/extension/ui/modules/charts/comments-reviewer-density.ts
@@ -379,7 +379,7 @@ export function renderCommentsReviewerDensityChart(
     renderNoData(
       container,
       "Comments density is not yet filterable",
-      "Clear repo / team / author / reviewer filters to view per-reviewer review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322.",
+      "Clear repo / team / author / reviewer filters to view per-reviewer review-conversation totals. Per-dimension comment breakdowns are coming soon.",
     );
     return;
   }
@@ -475,7 +475,7 @@ function metricLabel(metric: CommentsReviewerDensitySortMetric): string {
     case "thread_count":
       return "Threads";
     case "active_thread_count":
-      return "Active threads";
+      return "Unresolved threads";
   }
 }
 
@@ -500,7 +500,7 @@ function renderSortControls(
 
 function renderTable(rows: readonly ReviewerDensityRow[]): string {
   const rowsHtml = rows.map((row) => renderRow(row)).join("");
-  return `<div class="comments-reviewer-density-table" role="table" aria-label="Per-reviewer comment density"><div class="comments-reviewer-density-thead" role="row"><div role="columnheader">Reviewer</div><div role="columnheader" class="comments-reviewer-density-numeric">Threads</div><div role="columnheader" class="comments-reviewer-density-numeric">Active threads</div><div role="columnheader" class="comments-reviewer-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+  return `<div class="comments-reviewer-density-table" role="table" aria-label="Per-reviewer comments"><div class="comments-reviewer-density-thead" role="row"><div role="columnheader">Reviewer</div><div role="columnheader" class="comments-reviewer-density-numeric">Threads</div><div role="columnheader" class="comments-reviewer-density-numeric">Comments</div><div role="columnheader" class="comments-reviewer-density-numeric">Unresolved</div></div>${rowsHtml}</div>`;
 }
 
 function renderRow(row: ReviewerDensityRow): string {
@@ -519,6 +519,6 @@ function renderRow(row: ReviewerDensityRow): string {
   const partialNote = row.coverage_partial
     ? " (partial week coverage; reviewer activity may be incomplete this week)"
     : "";
-  const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
-  return `<div class="comments-reviewer-density-row${partialClass}" role="row" data-reviewer-key="${escapeHtml(row.reviewerKey)}"${partialAttr}${partialTitle} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-reviewer-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+  const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.comment_count.toLocaleString()} comments, ${row.active_thread_count.toLocaleString()} unresolved threads${partialNote}`;
+  return `<div class="comments-reviewer-density-row${partialClass}" role="row" data-reviewer-key="${escapeHtml(row.reviewerKey)}"${partialAttr}${partialTitle} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-reviewer-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div></div>`;
 }

--- a/extension/ui/modules/charts/comments-trend.ts
+++ b/extension/ui/modules/charts/comments-trend.ts
@@ -54,25 +54,27 @@ export const COMMENTS_TREND_TOOLTIP =
   "some PRs in the week aren't yet extracted, so totals are partial.";
 
 /** Per-button AbortControllers to prevent listener accumulation on re-attach. */
-const commentsTrendInfoIconControllers = new WeakMap<
-  HTMLElement,
-  AbortController
->();
+const chartInfoIconControllers = new WeakMap<HTMLElement, AbortController>();
 
 /**
- * Mount the chart-level info-icon button as a child of `heading`.
+ * Mount a chart-level info-icon button as a child of `heading`, with the
+ * supplied `tooltipText` shown on hover/click. Generic version used by all
+ * comments panels (trend + 3 density). Idempotent: re-attach replaces.
  *
- * Idempotent: if the heading already carries an `.info-icon-btn`, the previous
- * controller is aborted and the button is replaced. This keeps re-mounts safe
- * across capability flips and dashboard re-renders.
+ * `instanceId` is written to `data-info-tooltip` so per-chart tests can
+ * disambiguate when multiple icons mount in the same DOM tree.
  */
-export function attachCommentsTrendInfoIcon(heading: HTMLElement): void {
+export function attachChartInfoIcon(
+  heading: HTMLElement,
+  tooltipText: string,
+  instanceId: string,
+): void {
   const existing = heading.querySelector(
     ".info-icon-btn",
   ) as HTMLElement | null;
   if (existing) {
-    commentsTrendInfoIconControllers.get(existing)?.abort();
-    commentsTrendInfoIconControllers.delete(existing);
+    chartInfoIconControllers.get(existing)?.abort();
+    chartInfoIconControllers.delete(existing);
     existing.remove();
   }
 
@@ -83,13 +85,13 @@ export function attachCommentsTrendInfoIcon(heading: HTMLElement): void {
   btn.className = "info-icon-btn";
   btn.setAttribute("type", "button");
   btn.setAttribute("aria-label", "About this chart");
-  btn.setAttribute("data-info-tooltip", "comments-trend");
+  btn.setAttribute("data-info-tooltip", instanceId);
   btn.textContent = "ℹ"; // Unicode info symbol ⓘ
 
   btn.addEventListener(
     "pointerenter",
     () => {
-      showInfoTooltip(btn, COMMENTS_TREND_TOOLTIP);
+      showInfoTooltip(btn, tooltipText);
     },
     { signal },
   );
@@ -109,7 +111,7 @@ export function attachCommentsTrendInfoIcon(heading: HTMLElement): void {
         dismissAllTooltips();
         return;
       }
-      showInfoTooltip(btn, COMMENTS_TREND_TOOLTIP);
+      showInfoTooltip(btn, tooltipText);
       requestAnimationFrame(() => {
         const dismissOnce = (): void => {
           dismissAllTooltips();
@@ -121,29 +123,40 @@ export function attachCommentsTrendInfoIcon(heading: HTMLElement): void {
     { signal },
   );
 
-  commentsTrendInfoIconControllers.set(btn, controller);
+  chartInfoIconControllers.set(btn, controller);
   heading.appendChild(btn);
 }
 
 /**
- * Remove the chart-level info-icon button from `heading` and abort its
- * listeners. Also dismisses any open info-tooltip — the tooltip is
- * document-rooted (positioned via `position: fixed` on document.body by
- * `tooltip-manager.ts::showInfoTooltip`), so removing the button alone
- * leaves the tooltip stranded with no anchoring element. No-op when the
- * heading carries no button AND no tooltip is open.
+ * Remove a chart-level info-icon button from `heading` and abort its
+ * listeners. Also dismisses any open info-tooltip — document-rooted
+ * tooltips would otherwise outlive the anchor button on capability flips.
+ * No-op when the heading carries no button AND no tooltip is open.
  */
-export function detachCommentsTrendInfoIcon(heading: HTMLElement): void {
+export function detachChartInfoIcon(heading: HTMLElement): void {
   const btn = heading.querySelector(".info-icon-btn") as HTMLElement | null;
   if (!btn) return;
-  commentsTrendInfoIconControllers.get(btn)?.abort();
-  commentsTrendInfoIconControllers.delete(btn);
+  chartInfoIconControllers.get(btn)?.abort();
+  chartInfoIconControllers.delete(btn);
   btn.remove();
-  // The button is gone — drop any open tooltip so it cannot survive the
-  // heading's teardown and render against an orphaned position. Uses the
-  // canonical tooltip-manager helper so the scroll/resize dismiss listener
-  // is also released.
   dismissAllTooltips();
+}
+
+/**
+ * Mount the comments-trend chart-level info-icon. Thin wrapper around
+ * `attachChartInfoIcon` preserving the original (heading)-only signature
+ * for the dashboard's trend ensure helper and existing tests.
+ */
+export function attachCommentsTrendInfoIcon(heading: HTMLElement): void {
+  attachChartInfoIcon(heading, COMMENTS_TREND_TOOLTIP, "comments-trend");
+}
+
+/**
+ * Remove the comments-trend chart-level info-icon. Thin wrapper around
+ * `detachChartInfoIcon` preserving the original (heading)-only signature.
+ */
+export function detachCommentsTrendInfoIcon(heading: HTMLElement): void {
+  detachChartInfoIcon(heading);
 }
 
 /** Maximum visible week labels before thinning kicks in. */
@@ -207,7 +220,7 @@ export function renderCommentsTrendChart(
     renderNoData(
       container,
       "Comments trend is not yet filterable",
-      "Clear repo / team / author / reviewer filters to view weekly comment activity. Per-dimension comments breakdowns are tracked under follow-up issue #322.",
+      "Clear repo / team / author / reviewer filters to view weekly comment activity. Per-dimension comment breakdowns are coming soon.",
     );
     return;
   }

--- a/extension/ui/styles.css
+++ b/extension/ui/styles.css
@@ -3854,8 +3854,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-author-density-sort-btn {
-    border: 1px solid var(--border-color, #d0d7de);
-    background: var(--bg-secondary, #f6f8fa);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text-primary, inherit);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -3865,14 +3865,14 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-author-density-sort-btn:focus-visible {
-    outline: 2px solid var(--primary, #0969da);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
 .comments-author-density-sort-btn.is-active {
-    background: var(--primary, #0969da);
-    color: var(--bg-primary, #ffffff);
-    border-color: var(--primary, #0969da);
+    background: var(--primary);
+    color: var(--bg-primary);
+    border-color: var(--primary);
 }
 
 .comments-author-density-table {
@@ -3893,9 +3893,9 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--text-secondary, #57606a);
+    color: var(--text-secondary);
     padding: 0.25rem 0;
-    border-bottom: 1px solid var(--border-color, #d0d7de);
+    border-bottom: 1px solid var(--border);
 }
 
 .comments-author-density-row > [role="cell"] {
@@ -3918,11 +3918,11 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
  * (FR-4-03).  Shares the .coverage-partial class hook with 333 so the
  * convention stays visually consistent across the two surfaces. */
 .comments-author-density-row.coverage-partial > [role="cell"] {
-    color: var(--text-tertiary, #6e7781);
+    color: var(--text-tertiary);
     background-image: repeating-linear-gradient(
         45deg,
-        rgba(110, 119, 129, 0.08) 0,
-        rgba(110, 119, 129, 0.08) 4px,
+        rgba(110, 119, 129, 0.18) 0,
+        rgba(110, 119, 129, 0.18) 4px,
         transparent 4px,
         transparent 8px
     );
@@ -3947,8 +3947,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-repository-density-sort-btn {
-    border: 1px solid var(--border-color, #d0d7de);
-    background: var(--bg-secondary, #f6f8fa);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text-primary, inherit);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -3958,14 +3958,14 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-repository-density-sort-btn:focus-visible {
-    outline: 2px solid var(--primary, #0969da);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
 .comments-repository-density-sort-btn.is-active {
-    background: var(--primary, #0969da);
-    color: var(--bg-primary, #ffffff);
-    border-color: var(--primary, #0969da);
+    background: var(--primary);
+    color: var(--bg-primary);
+    border-color: var(--primary);
 }
 
 .comments-repository-density-table {
@@ -3986,9 +3986,9 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--text-secondary, #57606a);
+    color: var(--text-secondary);
     padding: 0.25rem 0;
-    border-bottom: 1px solid var(--border-color, #d0d7de);
+    border-bottom: 1px solid var(--border);
 }
 
 .comments-repository-density-row > [role="cell"] {
@@ -4012,11 +4012,11 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
  * the convention stays visually consistent across all three comments-
  * density surfaces. */
 .comments-repository-density-row.coverage-partial > [role="cell"] {
-    color: var(--text-tertiary, #6e7781);
+    color: var(--text-tertiary);
     background-image: repeating-linear-gradient(
         45deg,
-        rgba(110, 119, 129, 0.08) 0,
-        rgba(110, 119, 129, 0.08) 4px,
+        rgba(110, 119, 129, 0.18) 0,
+        rgba(110, 119, 129, 0.18) 4px,
         transparent 4px,
         transparent 8px
     );
@@ -4041,8 +4041,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-reviewer-density-sort-btn {
-    border: 1px solid var(--border-color, #d0d7de);
-    background: var(--bg-secondary, #f6f8fa);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text-primary, inherit);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -4052,14 +4052,14 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-reviewer-density-sort-btn:focus-visible {
-    outline: 2px solid var(--primary, #0969da);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
 .comments-reviewer-density-sort-btn.is-active {
-    background: var(--primary, #0969da);
-    color: var(--bg-primary, #ffffff);
-    border-color: var(--primary, #0969da);
+    background: var(--primary);
+    color: var(--bg-primary);
+    border-color: var(--primary);
 }
 
 .comments-reviewer-density-table {
@@ -4080,9 +4080,9 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--text-secondary, #57606a);
+    color: var(--text-secondary);
     padding: 0.25rem 0;
-    border-bottom: 1px solid var(--border-color, #d0d7de);
+    border-bottom: 1px solid var(--border);
 }
 
 .comments-reviewer-density-row > [role="cell"] {
@@ -4106,11 +4106,11 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
  * 335 so the convention stays visually consistent across all four
  * comments-density surfaces. */
 .comments-reviewer-density-row.coverage-partial > [role="cell"] {
-    color: var(--text-tertiary, #6e7781);
+    color: var(--text-tertiary);
     background-image: repeating-linear-gradient(
         45deg,
-        rgba(110, 119, 129, 0.08) 0,
-        rgba(110, 119, 129, 0.08) 4px,
+        rgba(110, 119, 129, 0.18) 0,
+        rgba(110, 119, 129, 0.18) 4px,
         transparent 4px,
         transparent 8px
     );

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -8670,14 +8670,14 @@ var PRInsightsDashboard = (() => {
   // ../ui/modules/charts/comments-trend.ts
   var MAX_COMMENTS_TREND_POINTS = 104;
   var COMMENTS_TREND_TOOLTIP = "Bars show resolved (lower) and unresolved (upper) review threads per week. The line shows total comments. Hatched bars indicate partial coverage \u2014 some PRs in the week aren't yet extracted, so totals are partial.";
-  var commentsTrendInfoIconControllers = /* @__PURE__ */ new WeakMap();
-  function attachCommentsTrendInfoIcon(heading) {
+  var chartInfoIconControllers = /* @__PURE__ */ new WeakMap();
+  function attachChartInfoIcon(heading, tooltipText, instanceId) {
     const existing = heading.querySelector(
       ".info-icon-btn"
     );
     if (existing) {
-      commentsTrendInfoIconControllers.get(existing)?.abort();
-      commentsTrendInfoIconControllers.delete(existing);
+      chartInfoIconControllers.get(existing)?.abort();
+      chartInfoIconControllers.delete(existing);
       existing.remove();
     }
     const controller = new AbortController();
@@ -8686,12 +8686,12 @@ var PRInsightsDashboard = (() => {
     btn.className = "info-icon-btn";
     btn.setAttribute("type", "button");
     btn.setAttribute("aria-label", "About this chart");
-    btn.setAttribute("data-info-tooltip", "comments-trend");
+    btn.setAttribute("data-info-tooltip", instanceId);
     btn.textContent = "\u2139";
     btn.addEventListener(
       "pointerenter",
       () => {
-        showInfoTooltip(btn, COMMENTS_TREND_TOOLTIP);
+        showInfoTooltip(btn, tooltipText);
       },
       { signal }
     );
@@ -8711,7 +8711,7 @@ var PRInsightsDashboard = (() => {
           dismissAllTooltips();
           return;
         }
-        showInfoTooltip(btn, COMMENTS_TREND_TOOLTIP);
+        showInfoTooltip(btn, tooltipText);
         requestAnimationFrame(() => {
           const dismissOnce = () => {
             dismissAllTooltips();
@@ -8722,16 +8722,22 @@ var PRInsightsDashboard = (() => {
       },
       { signal }
     );
-    commentsTrendInfoIconControllers.set(btn, controller);
+    chartInfoIconControllers.set(btn, controller);
     heading.appendChild(btn);
   }
-  function detachCommentsTrendInfoIcon(heading) {
+  function detachChartInfoIcon(heading) {
     const btn = heading.querySelector(".info-icon-btn");
     if (!btn) return;
-    commentsTrendInfoIconControllers.get(btn)?.abort();
-    commentsTrendInfoIconControllers.delete(btn);
+    chartInfoIconControllers.get(btn)?.abort();
+    chartInfoIconControllers.delete(btn);
     btn.remove();
     dismissAllTooltips();
+  }
+  function attachCommentsTrendInfoIcon(heading) {
+    attachChartInfoIcon(heading, COMMENTS_TREND_TOOLTIP, "comments-trend");
+  }
+  function detachCommentsTrendInfoIcon(heading) {
+    detachChartInfoIcon(heading);
   }
   var MAX_VISIBLE_LABELS2 = 16;
   var CHART_HEIGHT_PX = 200;
@@ -8746,7 +8752,7 @@ var PRInsightsDashboard = (() => {
       renderNoData(
         container,
         "Comments trend is not yet filterable",
-        "Clear repo / team / author / reviewer filters to view weekly comment activity. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+        "Clear repo / team / author / reviewer filters to view weekly comment activity. Per-dimension comment breakdowns are coming soon."
       );
       return;
     }
@@ -8989,7 +8995,7 @@ var PRInsightsDashboard = (() => {
       renderNoData(
         container,
         "Comments density is not yet filterable",
-        "Clear repo / team / author / reviewer filters to view per-author review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+        "Clear repo / team / author / reviewer filters to view per-author review-conversation totals. Per-dimension comment breakdowns are coming soon."
       );
       return;
     }
@@ -9047,7 +9053,7 @@ var PRInsightsDashboard = (() => {
       case "thread_count":
         return "Threads";
       case "active_thread_count":
-        return "Active threads";
+        return "Unresolved threads";
     }
   }
   function renderSortControls(activeMetric) {
@@ -9061,14 +9067,14 @@ var PRInsightsDashboard = (() => {
   }
   function renderTable(rows) {
     const rowsHtml = rows.map((row) => renderRow(row)).join("");
-    return `<div class="comments-author-density-table" role="table" aria-label="Per-author comment density"><div class="comments-author-density-thead" role="row"><div role="columnheader">Author</div><div role="columnheader" class="comments-author-density-numeric">Threads</div><div role="columnheader" class="comments-author-density-numeric">Active threads</div><div role="columnheader" class="comments-author-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+    return `<div class="comments-author-density-table" role="table" aria-label="Per-author comments"><div class="comments-author-density-thead" role="row"><div role="columnheader">Author</div><div role="columnheader" class="comments-author-density-numeric">Threads</div><div role="columnheader" class="comments-author-density-numeric">Comments</div><div role="columnheader" class="comments-author-density-numeric">Unresolved</div></div>${rowsHtml}</div>`;
   }
   function renderRow(row) {
     const partialClass = row.coverage_partial ? " coverage-partial" : "";
     const partialAttr = row.coverage_partial ? ' data-coverage-partial="true"' : "";
     const partialNote = row.coverage_partial ? " (partial coverage)" : "";
-    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
-    return `<div class="comments-author-density-row${partialClass}" role="row" data-author-key="${escapeHtml(row.authorKey)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-author-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.comment_count.toLocaleString()} comments, ${row.active_thread_count.toLocaleString()} unresolved threads${partialNote}`;
+    return `<div class="comments-author-density-row${partialClass}" role="row" data-author-key="${escapeHtml(row.authorKey)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-author-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div><div class="comments-author-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div></div>`;
   }
 
   // ../ui/modules/charts/comments-repository-density.ts
@@ -9195,7 +9201,7 @@ var PRInsightsDashboard = (() => {
       renderNoData(
         container,
         "Comments density is not yet filterable",
-        "Clear repo / team / author / reviewer filters to view per-repo review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+        "Clear repo / team / author / reviewer filters to view per-repo review-conversation totals. Per-dimension comment breakdowns are coming soon."
       );
       return;
     }
@@ -9256,7 +9262,7 @@ var PRInsightsDashboard = (() => {
       case "thread_count":
         return "Threads";
       case "active_thread_count":
-        return "Active threads";
+        return "Unresolved threads";
     }
   }
   function renderSortControls2(activeMetric) {
@@ -9270,14 +9276,14 @@ var PRInsightsDashboard = (() => {
   }
   function renderTable2(rows) {
     const rowsHtml = rows.map((row) => renderRow2(row)).join("");
-    return `<div class="comments-repository-density-table" role="table" aria-label="Per-repository comment density"><div class="comments-repository-density-thead" role="row"><div role="columnheader">Repository</div><div role="columnheader" class="comments-repository-density-numeric">Threads</div><div role="columnheader" class="comments-repository-density-numeric">Active threads</div><div role="columnheader" class="comments-repository-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+    return `<div class="comments-repository-density-table" role="table" aria-label="Per-repository comments"><div class="comments-repository-density-thead" role="row"><div role="columnheader">Repository</div><div role="columnheader" class="comments-repository-density-numeric">Threads</div><div role="columnheader" class="comments-repository-density-numeric">Comments</div><div role="columnheader" class="comments-repository-density-numeric">Unresolved</div></div>${rowsHtml}</div>`;
   }
   function renderRow2(row) {
     const partialClass = row.coverage_partial ? " coverage-partial" : "";
     const partialAttr = row.coverage_partial ? ' data-coverage-partial="true"' : "";
     const partialNote = row.coverage_partial ? " (partial coverage)" : "";
-    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
-    return `<div class="comments-repository-density-row${partialClass}" role="row" data-repository-id="${escapeHtml(row.repositoryId)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-repository-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.comment_count.toLocaleString()} comments, ${row.active_thread_count.toLocaleString()} unresolved threads${partialNote}`;
+    return `<div class="comments-repository-density-row${partialClass}" role="row" data-repository-id="${escapeHtml(row.repositoryId)}"${partialAttr} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-repository-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div><div class="comments-repository-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div></div>`;
   }
 
   // ../ui/modules/charts/comments-reviewer-density.ts
@@ -9409,7 +9415,7 @@ var PRInsightsDashboard = (() => {
       renderNoData(
         container,
         "Comments density is not yet filterable",
-        "Clear repo / team / author / reviewer filters to view per-reviewer review-conversation totals. Per-dimension comments breakdowns are tracked under follow-up issue #322."
+        "Clear repo / team / author / reviewer filters to view per-reviewer review-conversation totals. Per-dimension comment breakdowns are coming soon."
       );
       return;
     }
@@ -9470,7 +9476,7 @@ var PRInsightsDashboard = (() => {
       case "thread_count":
         return "Threads";
       case "active_thread_count":
-        return "Active threads";
+        return "Unresolved threads";
     }
   }
   function renderSortControls3(activeMetric) {
@@ -9484,15 +9490,15 @@ var PRInsightsDashboard = (() => {
   }
   function renderTable3(rows) {
     const rowsHtml = rows.map((row) => renderRow3(row)).join("");
-    return `<div class="comments-reviewer-density-table" role="table" aria-label="Per-reviewer comment density"><div class="comments-reviewer-density-thead" role="row"><div role="columnheader">Reviewer</div><div role="columnheader" class="comments-reviewer-density-numeric">Threads</div><div role="columnheader" class="comments-reviewer-density-numeric">Active threads</div><div role="columnheader" class="comments-reviewer-density-numeric">Comments</div></div>${rowsHtml}</div>`;
+    return `<div class="comments-reviewer-density-table" role="table" aria-label="Per-reviewer comments"><div class="comments-reviewer-density-thead" role="row"><div role="columnheader">Reviewer</div><div role="columnheader" class="comments-reviewer-density-numeric">Threads</div><div role="columnheader" class="comments-reviewer-density-numeric">Comments</div><div role="columnheader" class="comments-reviewer-density-numeric">Unresolved</div></div>${rowsHtml}</div>`;
   }
   function renderRow3(row) {
     const partialClass = row.coverage_partial ? " coverage-partial" : "";
     const partialAttr = row.coverage_partial ? ' data-coverage-partial="true"' : "";
     const partialTitle = row.coverage_partial ? ` title="${escapeHtml("This week's comments extraction is partial; reviewer activity may be incomplete")}"` : "";
     const partialNote = row.coverage_partial ? " (partial week coverage; reviewer activity may be incomplete this week)" : "";
-    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.active_thread_count.toLocaleString()} active threads, ${row.comment_count.toLocaleString()} comments${partialNote}`;
-    return `<div class="comments-reviewer-density-row${partialClass}" role="row" data-reviewer-key="${escapeHtml(row.reviewerKey)}"${partialAttr}${partialTitle} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-reviewer-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div></div>`;
+    const ariaLabel = `${row.displayName}: ${row.thread_count.toLocaleString()} threads, ${row.comment_count.toLocaleString()} comments, ${row.active_thread_count.toLocaleString()} unresolved threads${partialNote}`;
+    return `<div class="comments-reviewer-density-row${partialClass}" role="row" data-reviewer-key="${escapeHtml(row.reviewerKey)}"${partialAttr}${partialTitle} aria-label="${escapeHtml(ariaLabel)}"><div class="comments-reviewer-density-name" role="cell">${escapeHtml(row.displayName)}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.thread_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.comment_count.toLocaleString())}</div><div class="comments-reviewer-density-numeric" role="cell">${escapeHtml(row.active_thread_count.toLocaleString())}</div></div>`;
   }
 
   // ../ui/modules/filter-constraint-resolver.ts
@@ -10837,6 +10843,9 @@ var PRInsightsDashboard = (() => {
   var lastEffectiveState = null;
   var SETTINGS_KEY_PROJECT = "pr-insights-source-project";
   var SETTINGS_KEY_PIPELINE = "pr-insights-pipeline-id";
+  var COMMENTS_AUTHOR_DENSITY_TOOLTIP = "Each row shows one author's review-conversation totals across the selected range. Threads = review threads on PRs the author opened; Unresolved threads = the subset still in the Active state. Comments = every comment posted on those threads. Hatched rows mean some weeks in this author's range are partially extracted.";
+  var COMMENTS_REPOSITORY_DENSITY_TOOLTIP = "Each row shows one repository's review-conversation totals across the selected range. Threads = review threads on PRs in this repository; Unresolved threads = the subset still in the Active state. Comments = every comment posted on those threads. Hatched rows mean some weeks in this repository's range are partially extracted.";
+  var COMMENTS_REVIEWER_DENSITY_TOOLTIP = "Each row shows one reviewer's commenting activity across the selected range. Threads = review threads this reviewer commented in. A thread with multiple commenters contributes one to each, so the total of this column may exceed total threads on the trend chart above. Unresolved threads = the subset still in the Active state. Comments = every comment posted by this reviewer on those threads.";
   var cachedDataService = null;
   async function getDataService() {
     if (!cachedDataService) {
@@ -11719,7 +11728,12 @@ var PRInsightsDashboard = (() => {
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
     const heading = document.createElement("h3");
-    heading.textContent = "Comment Density by Author";
+    heading.textContent = "Comments by Author";
+    attachChartInfoIcon(
+      heading,
+      COMMENTS_AUTHOR_DENSITY_TOOLTIP,
+      "comments-author-density"
+    );
     containerCell.appendChild(heading);
     const chart = document.createElement("div");
     chart.id = "comments-author-density";
@@ -11734,6 +11748,10 @@ var PRInsightsDashboard = (() => {
       '[data-comments-author-density-row="true"]'
     );
     if (!row) return;
+    const heading = row.querySelector("h3");
+    if (heading instanceof HTMLElement) {
+      detachChartInfoIcon(heading);
+    }
     row.parentElement?.removeChild(row);
   }
   function ensureCommentsRepositoryDensityContainer() {
@@ -11757,7 +11775,12 @@ var PRInsightsDashboard = (() => {
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
     const heading = document.createElement("h3");
-    heading.textContent = "Comment Density by Repository";
+    heading.textContent = "Comments by Repository";
+    attachChartInfoIcon(
+      heading,
+      COMMENTS_REPOSITORY_DENSITY_TOOLTIP,
+      "comments-repository-density"
+    );
     containerCell.appendChild(heading);
     const chart = document.createElement("div");
     chart.id = "comments-repository-density";
@@ -11772,6 +11795,10 @@ var PRInsightsDashboard = (() => {
       '[data-comments-repository-density-row="true"]'
     );
     if (!row) return;
+    const heading = row.querySelector("h3");
+    if (heading instanceof HTMLElement) {
+      detachChartInfoIcon(heading);
+    }
     row.parentElement?.removeChild(row);
   }
   function ensureCommentsReviewerDensityContainer() {
@@ -11800,7 +11827,12 @@ var PRInsightsDashboard = (() => {
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
     const heading = document.createElement("h3");
-    heading.textContent = "Comment Density by Reviewer";
+    heading.textContent = "Comments by Reviewer";
+    attachChartInfoIcon(
+      heading,
+      COMMENTS_REVIEWER_DENSITY_TOOLTIP,
+      "comments-reviewer-density"
+    );
     containerCell.appendChild(heading);
     const chart = document.createElement("div");
     chart.id = "comments-reviewer-density";
@@ -11815,6 +11847,10 @@ var PRInsightsDashboard = (() => {
       '[data-comments-reviewer-density-row="true"]'
     );
     if (!row) return;
+    const heading = row.querySelector("h3");
+    if (heading instanceof HTMLElement) {
+      detachChartInfoIcon(heading);
+    }
     row.parentElement?.removeChild(row);
   }
   function toArtifactLoadResult(loaderResult, artifactPath) {

--- a/src/ado_git_repo_insights/ui_bundle/styles.css
+++ b/src/ado_git_repo_insights/ui_bundle/styles.css
@@ -3854,8 +3854,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-author-density-sort-btn {
-    border: 1px solid var(--border-color, #d0d7de);
-    background: var(--bg-secondary, #f6f8fa);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text-primary, inherit);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -3865,14 +3865,14 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-author-density-sort-btn:focus-visible {
-    outline: 2px solid var(--primary, #0969da);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
 .comments-author-density-sort-btn.is-active {
-    background: var(--primary, #0969da);
-    color: var(--bg-primary, #ffffff);
-    border-color: var(--primary, #0969da);
+    background: var(--primary);
+    color: var(--bg-primary);
+    border-color: var(--primary);
 }
 
 .comments-author-density-table {
@@ -3893,9 +3893,9 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--text-secondary, #57606a);
+    color: var(--text-secondary);
     padding: 0.25rem 0;
-    border-bottom: 1px solid var(--border-color, #d0d7de);
+    border-bottom: 1px solid var(--border);
 }
 
 .comments-author-density-row > [role="cell"] {
@@ -3918,11 +3918,11 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
  * (FR-4-03).  Shares the .coverage-partial class hook with 333 so the
  * convention stays visually consistent across the two surfaces. */
 .comments-author-density-row.coverage-partial > [role="cell"] {
-    color: var(--text-tertiary, #6e7781);
+    color: var(--text-tertiary);
     background-image: repeating-linear-gradient(
         45deg,
-        rgba(110, 119, 129, 0.08) 0,
-        rgba(110, 119, 129, 0.08) 4px,
+        rgba(110, 119, 129, 0.18) 0,
+        rgba(110, 119, 129, 0.18) 4px,
         transparent 4px,
         transparent 8px
     );
@@ -3947,8 +3947,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-repository-density-sort-btn {
-    border: 1px solid var(--border-color, #d0d7de);
-    background: var(--bg-secondary, #f6f8fa);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text-primary, inherit);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -3958,14 +3958,14 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-repository-density-sort-btn:focus-visible {
-    outline: 2px solid var(--primary, #0969da);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
 .comments-repository-density-sort-btn.is-active {
-    background: var(--primary, #0969da);
-    color: var(--bg-primary, #ffffff);
-    border-color: var(--primary, #0969da);
+    background: var(--primary);
+    color: var(--bg-primary);
+    border-color: var(--primary);
 }
 
 .comments-repository-density-table {
@@ -3986,9 +3986,9 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--text-secondary, #57606a);
+    color: var(--text-secondary);
     padding: 0.25rem 0;
-    border-bottom: 1px solid var(--border-color, #d0d7de);
+    border-bottom: 1px solid var(--border);
 }
 
 .comments-repository-density-row > [role="cell"] {
@@ -4012,11 +4012,11 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
  * the convention stays visually consistent across all three comments-
  * density surfaces. */
 .comments-repository-density-row.coverage-partial > [role="cell"] {
-    color: var(--text-tertiary, #6e7781);
+    color: var(--text-tertiary);
     background-image: repeating-linear-gradient(
         45deg,
-        rgba(110, 119, 129, 0.08) 0,
-        rgba(110, 119, 129, 0.08) 4px,
+        rgba(110, 119, 129, 0.18) 0,
+        rgba(110, 119, 129, 0.18) 4px,
         transparent 4px,
         transparent 8px
     );
@@ -4041,8 +4041,8 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-reviewer-density-sort-btn {
-    border: 1px solid var(--border-color, #d0d7de);
-    background: var(--bg-secondary, #f6f8fa);
+    border: 1px solid var(--border);
+    background: var(--bg-secondary);
     color: var(--text-primary, inherit);
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
@@ -4052,14 +4052,14 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
 }
 
 .comments-reviewer-density-sort-btn:focus-visible {
-    outline: 2px solid var(--primary, #0969da);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
 .comments-reviewer-density-sort-btn.is-active {
-    background: var(--primary, #0969da);
-    color: var(--bg-primary, #ffffff);
-    border-color: var(--primary, #0969da);
+    background: var(--primary);
+    color: var(--bg-primary);
+    border-color: var(--primary);
 }
 
 .comments-reviewer-density-table {
@@ -4080,9 +4080,9 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--text-secondary, #57606a);
+    color: var(--text-secondary);
     padding: 0.25rem 0;
-    border-bottom: 1px solid var(--border-color, #d0d7de);
+    border-bottom: 1px solid var(--border);
 }
 
 .comments-reviewer-density-row > [role="cell"] {
@@ -4106,11 +4106,11 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
  * 335 so the convention stays visually consistent across all four
  * comments-density surfaces. */
 .comments-reviewer-density-row.coverage-partial > [role="cell"] {
-    color: var(--text-tertiary, #6e7781);
+    color: var(--text-tertiary);
     background-image: repeating-linear-gradient(
         45deg,
-        rgba(110, 119, 129, 0.08) 0,
-        rgba(110, 119, 129, 0.08) 4px,
+        rgba(110, 119, 129, 0.18) 0,
+        rgba(110, 119, 129, 0.18) 4px,
         transparent 4px,
         transparent 8px
     );


### PR DESCRIPTION
## Summary

- Aligns comments-density panel terminology with the trend chart and drill-down: "Active threads" → "Unresolved threads" everywhere user-facing on the three density panels (sort labels, column headers, ARIA labels).
- Adds panel-level info-icons defining Threads / Unresolved threads / Comments on the three density panels (only the trend chart had one). Reviewer-panel info-icon copy explicitly clarifies the per-reviewer multi-count semantic — a thread with multiple commenters contributes one to each, so the column total can exceed total threads on the trend chart above.
- Heading rename: "Comment Density by X" → "Comments by X". Density column order aligned to the drill-down panel: Threads / Comments / Unresolved (was Threads / Active threads / Comments).
- Removes the internal `issue #322` reference from user-visible empty-state copy across all four panels.
- CSS: renames non-canonical `--border-color` to canonical `--border` and drops hex Primer fallbacks in the density-panel sort-pill rules; bumps partial-coverage hatch alpha 0.08 → 0.18 so the qualifier reads at parity with the trend-bar treatment.

Generic `attachChartInfoIcon` extracted from `comments-trend.ts` (minimal-diff parameterization). `attachCommentsTrendInfoIcon` kept as a thin wrapper so existing tests and dashboard call site are unchanged.

No aggregator, schema, or contract changes. Layout reorganization deferred to #357 (intentional — keeps copy/semantics review separate from structural). System-comment counting semantics deferred to #356. Demo sentinel dominance deferred to #355.

## Test plan

- [x] `pnpm exec tsc --noEmit` — no errors
- [x] `pnpm test` — 145 suites / 3038 tests pass
- [x] `python scripts/run_pr_preflight.py` — exit 0 (green)
- [x] `manage_generated_artifacts.py sync --scope all` — `ui_bundle/`, `docs/`, `extension/tests/fixtures/broken-docs/` in sync with source
- [x] CI: lint, type-check, unit, smoke
- [x] Visual check on dashboard with comments capability on (light + dark mode)

Closes #354