### PR TITLE
fix: comments drill-down + density-panel UX polish

### DIFF
--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 3062,
+    "min_collected": 3066,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 3066,
+    "min_collected": 3077,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -5147,6 +5147,7 @@ var PRInsightsDashboard = (() => {
                 appendText(span, "\u2014");
               } else {
                 span.setAttribute("data-partial", "false");
+                span.setAttribute("data-zero", value === 0 ? "true" : "false");
                 li.setAttribute(`data-${key}`, String(value));
                 appendText(span, String(value));
               }

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -11711,23 +11711,39 @@ var PRInsightsDashboard = (() => {
     }
     row.parentElement?.removeChild(row);
   }
-  function ensureCommentsAuthorDensityContainer() {
-    const existing = document.getElementById("comments-author-density");
-    if (existing) return existing;
-    const commentsTrendRow = document.querySelector(
-      '[data-comments-trend-row="true"]'
+  function ensureCommentsDensityGrid() {
+    const existing = document.querySelector(
+      '[data-comments-density-grid="true"]'
     );
-    let anchorRow = commentsTrendRow;
+    if (existing) return existing;
+    const trendRow = document.querySelector('[data-comments-trend-row="true"]');
+    let anchorRow = trendRow;
     if (!anchorRow) {
       const cycleDist = document.getElementById("cycle-distribution");
       anchorRow = cycleDist?.closest(".charts-row") ?? null;
     }
     if (!anchorRow || !anchorRow.parentElement) return null;
-    const row = document.createElement("div");
-    row.className = "charts-row";
-    row.setAttribute("data-comments-author-density-row", "true");
+    const grid = document.createElement("div");
+    grid.className = "charts-row comments-density-grid";
+    grid.setAttribute("data-comments-density-grid", "true");
+    anchorRow.parentElement.insertBefore(grid, anchorRow.nextSibling);
+    return grid;
+  }
+  function removeCommentsDensityGridIfEmpty() {
+    const grid = document.querySelector('[data-comments-density-grid="true"]');
+    if (!grid) return;
+    if (grid.children.length === 0) {
+      grid.parentElement?.removeChild(grid);
+    }
+  }
+  function ensureCommentsAuthorDensityContainer() {
+    const existing = document.getElementById("comments-author-density");
+    if (existing) return existing;
+    const grid = ensureCommentsDensityGrid();
+    if (!grid) return null;
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
+    containerCell.setAttribute("data-comments-author-density-row", "true");
     const heading = document.createElement("h3");
     heading.textContent = "Comments by Author";
     attachChartInfoIcon(
@@ -11740,8 +11756,7 @@ var PRInsightsDashboard = (() => {
     chart.id = "comments-author-density";
     chart.className = "chart";
     containerCell.appendChild(chart);
-    row.appendChild(containerCell);
-    anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+    grid.appendChild(containerCell);
     return chart;
   }
   function removeCommentsAuthorDensityContainer() {
@@ -11754,27 +11769,16 @@ var PRInsightsDashboard = (() => {
       detachChartInfoIcon(heading);
     }
     row.parentElement?.removeChild(row);
+    removeCommentsDensityGridIfEmpty();
   }
   function ensureCommentsRepositoryDensityContainer() {
     const existing = document.getElementById("comments-repository-density");
     if (existing) return existing;
-    const perAuthorRow = document.querySelector(
-      '[data-comments-author-density-row="true"]'
-    );
-    let anchorRow = perAuthorRow;
-    if (!anchorRow) {
-      anchorRow = document.querySelector('[data-comments-trend-row="true"]');
-    }
-    if (!anchorRow) {
-      const cycleDist = document.getElementById("cycle-distribution");
-      anchorRow = cycleDist?.closest(".charts-row") ?? null;
-    }
-    if (!anchorRow || !anchorRow.parentElement) return null;
-    const row = document.createElement("div");
-    row.className = "charts-row";
-    row.setAttribute("data-comments-repository-density-row", "true");
+    const grid = ensureCommentsDensityGrid();
+    if (!grid) return null;
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
+    containerCell.setAttribute("data-comments-repository-density-row", "true");
     const heading = document.createElement("h3");
     heading.textContent = "Comments by Repository";
     attachChartInfoIcon(
@@ -11787,8 +11791,7 @@ var PRInsightsDashboard = (() => {
     chart.id = "comments-repository-density";
     chart.className = "chart";
     containerCell.appendChild(chart);
-    row.appendChild(containerCell);
-    anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+    grid.appendChild(containerCell);
     return chart;
   }
   function removeCommentsRepositoryDensityContainer() {
@@ -11801,32 +11804,16 @@ var PRInsightsDashboard = (() => {
       detachChartInfoIcon(heading);
     }
     row.parentElement?.removeChild(row);
+    removeCommentsDensityGridIfEmpty();
   }
   function ensureCommentsReviewerDensityContainer() {
     const existing = document.getElementById("comments-reviewer-density");
     if (existing) return existing;
-    const perRepoRow = document.querySelector(
-      '[data-comments-repository-density-row="true"]'
-    );
-    let anchorRow = perRepoRow;
-    if (!anchorRow) {
-      anchorRow = document.querySelector(
-        '[data-comments-author-density-row="true"]'
-      );
-    }
-    if (!anchorRow) {
-      anchorRow = document.querySelector('[data-comments-trend-row="true"]');
-    }
-    if (!anchorRow) {
-      const cycleDist = document.getElementById("cycle-distribution");
-      anchorRow = cycleDist?.closest(".charts-row") ?? null;
-    }
-    if (!anchorRow || !anchorRow.parentElement) return null;
-    const row = document.createElement("div");
-    row.className = "charts-row";
-    row.setAttribute("data-comments-reviewer-density-row", "true");
+    const grid = ensureCommentsDensityGrid();
+    if (!grid) return null;
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
+    containerCell.setAttribute("data-comments-reviewer-density-row", "true");
     const heading = document.createElement("h3");
     heading.textContent = "Comments by Reviewer";
     attachChartInfoIcon(
@@ -11839,8 +11826,7 @@ var PRInsightsDashboard = (() => {
     chart.id = "comments-reviewer-density";
     chart.className = "chart";
     containerCell.appendChild(chart);
-    row.appendChild(containerCell);
-    anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+    grid.appendChild(containerCell);
     return chart;
   }
   function removeCommentsReviewerDensityContainer() {
@@ -11853,6 +11839,7 @@ var PRInsightsDashboard = (() => {
       detachChartInfoIcon(heading);
     }
     row.parentElement?.removeChild(row);
+    removeCommentsDensityGridIfEmpty();
   }
   function toArtifactLoadResult(loaderResult, artifactPath) {
     if (!loaderResult) {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -3502,6 +3502,19 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     opacity: 0.7;
 }
 
+/* Issue #337: zero-vs-many tonal weight on comments-metrics.
+ * Numeric zero cells render at reduced opacity so the visual contrast
+ * between "no work" and "any work" is faster to scan than reading every
+ * digit on every row.  Mutually exclusive with the
+ * ``data-partial="true"`` rule above (a span never carries both attrs)
+ * — partial italic + tertiary color keeps partial visually distinct
+ * from zero per INV-10.  Numeric ``0`` is preserved as the rendered
+ * glyph (no em-dash swap) since the partial sentinel already owns the
+ * em-dash. */
+.detail-panel-pr-list--with-comments .comments-metric[data-zero="true"] {
+    opacity: 0.45;
+}
+
 .detail-panel-pr-list--with-comments .comments-metric--unresolved {
     font-weight: 600;
 }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -734,6 +734,36 @@ input[type="search"]::placeholder {
     gap: 20px;
 }
 
+/* Issue #357 — comments-density panels share a single 2-up sub-grid so
+ * the per-author / per-repo / per-reviewer panels read as a coherent
+ * group rather than a four-row vertical wall.  The trend chart remains
+ * full-width on its own ``.charts-row`` above this wrapper (timeseries
+ * vs cross-section reading order), so the wrapper itself is a sibling
+ * of the trend row, NOT its parent.
+ *
+ * The wrapper carries the base ``.charts-row`` class so it inherits the
+ * 20px gap + grid baseline.  This rule overrides ONLY
+ * ``grid-template-columns`` to lock 2-up (instead of the parent's
+ * ``auto-fit, minmax(400px, 1fr)`` which would expand to 3-up at wide
+ * viewports — explicitly out of scope per the issue's "2-up reads
+ * better than 3-up cramped" verdict).  The narrow-viewport fallback
+ * below collapses to 1-up around the same breakpoint the rest of the
+ * dashboard uses for column collapse.
+ *
+ * With three children in 2 columns, the third (reviewer) lands in the
+ * bottom-left cell; the bottom-right is empty.  This is intentional —
+ * spanning reviewer would compress per-row scan-density at the only
+ * width where 2-up is actively useful. */
+.charts-row.comments-density-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 700px) {
+    .charts-row.comments-density-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
 .summary-cards {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -3318,6 +3318,26 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     text-align: right;
 }
 
+/* Issue #338: visually subordinate the Unresolved header cell.
+ * Unresolved is a subset of Threads (INV-09: active_thread_count <=
+ * thread_count), so the column should weigh visually less than its
+ * parent rather than equal to it.  Two non-geometric tweaks recover
+ * the subset relation without removing the dedicated sortable column
+ * (the verdict on #338 explicitly preserved sort affordance):
+ *   - lighter header weight (500 vs the parent header's 600)
+ *   - slight content indent via padding-right so the right-aligned
+ *     label pulls inward from the column's right edge
+ * Track widths are unchanged — the geometric Playwright guard
+ * (button rect within cell rect ±0.5px) still holds because padding
+ * affects content placement inside the cell box, not the cell box
+ * itself.  Width narrowing was deliberately deferred (would require
+ * relaxing the Ubuntu fallback metric buffer locked at :3267-3307). */
+.detail-panel-pr-list-header-cell--unresolved {
+    font-weight: 500;
+    padding-right: 8px;
+    color: var(--text-tertiary, var(--text-secondary));
+}
+
 .detail-panel-pr-list-header-sort {
     appearance: none;
     background: transparent;
@@ -3515,8 +3535,15 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     opacity: 0.45;
 }
 
+/* Issue #338: visually subordinate the Unresolved data column.
+ * The previous ``font-weight: 600`` rule made Unresolved BOLDER than
+ * Threads, the opposite of the subset relation (INV-09).  Replaced
+ * with a muted color + slight right-edge indent so the per-row
+ * Unresolved value reads as "child of Threads" rather than peer.
+ * Sort affordance and column position unchanged. */
 .detail-panel-pr-list--with-comments .comments-metric--unresolved {
-    font-weight: 600;
+    color: var(--text-secondary);
+    padding-right: 8px;
 }
 
 /* Issue #331 / C2 + C3 — in-panel coverage notice.

--- a/extension/tests/dashboard/comments-author-density-dashboard-lifecycle.test.ts
+++ b/extension/tests/dashboard/comments-author-density-dashboard-lifecycle.test.ts
@@ -65,26 +65,47 @@ const dashboardSrc = _fs.readFileSync(dashboardSrcPath, "utf-8");
 // cannot silently drift.
 // ---------------------------------------------------------------------------
 
-function ensureCommentsAuthorDensityContainerContract(): HTMLElement | null {
-  const existing = document.getElementById("comments-author-density");
+function ensureCommentsDensityGridContract(): HTMLElement | null {
+  const existing = document.querySelector<HTMLElement>(
+    '[data-comments-density-grid="true"]',
+  );
   if (existing) return existing;
 
-  const commentsTrendRow = document.querySelector(
-    '[data-comments-trend-row="true"]',
-  );
-  let anchorRow: Element | null = commentsTrendRow;
+  const trendRow = document.querySelector('[data-comments-trend-row="true"]');
+  let anchorRow: Element | null = trendRow;
   if (!anchorRow) {
     const cycleDist = document.getElementById("cycle-distribution");
     anchorRow = cycleDist?.closest(".charts-row") ?? null;
   }
   if (!anchorRow || !anchorRow.parentElement) return null;
 
-  const row = document.createElement("div");
-  row.className = "charts-row";
-  row.setAttribute("data-comments-author-density-row", "true");
+  const grid = document.createElement("div");
+  grid.className = "charts-row comments-density-grid";
+  grid.setAttribute("data-comments-density-grid", "true");
+
+  anchorRow.parentElement.insertBefore(grid, anchorRow.nextSibling);
+
+  return grid;
+}
+
+function removeCommentsDensityGridIfEmptyContract(): void {
+  const grid = document.querySelector('[data-comments-density-grid="true"]');
+  if (!grid) return;
+  if (grid.children.length === 0) {
+    grid.parentElement?.removeChild(grid);
+  }
+}
+
+function ensureCommentsAuthorDensityContainerContract(): HTMLElement | null {
+  const existing = document.getElementById("comments-author-density");
+  if (existing) return existing;
+
+  const grid = ensureCommentsDensityGridContract();
+  if (!grid) return null;
 
   const containerCell = document.createElement("div");
   containerCell.className = "chart-container";
+  containerCell.setAttribute("data-comments-author-density-row", "true");
 
   const heading = document.createElement("h3");
   heading.textContent = "Comments by Author";
@@ -95,9 +116,7 @@ function ensureCommentsAuthorDensityContainerContract(): HTMLElement | null {
   chart.className = "chart";
 
   containerCell.appendChild(chart);
-  row.appendChild(containerCell);
-
-  anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+  grid.appendChild(containerCell);
 
   return chart;
 }
@@ -108,6 +127,7 @@ function removeCommentsAuthorDensityContainerContract(): void {
   );
   if (!row) return;
   row.parentElement?.removeChild(row);
+  removeCommentsDensityGridIfEmptyContract();
 }
 
 // ---------------------------------------------------------------------------
@@ -234,7 +254,7 @@ const NO_FILTERS: FilterState = {
 // ===========================================================================
 
 describe("comments-author-density dashboard lifecycle — source-parse contract", () => {
-  it("ensureCommentsAuthorDensityContainer in dashboard.ts implements check-first idempotency + 333 anchor preference", () => {
+  it("ensureCommentsAuthorDensityContainer in dashboard.ts implements check-first idempotency + density-grid mount (issue #357)", () => {
     const helperStart = dashboardSrc.indexOf(
       "function ensureCommentsAuthorDensityContainer(",
     );
@@ -244,34 +264,38 @@ describe("comments-author-density dashboard lifecycle — source-parse contract"
 
     // Check-first idempotency: the helper queries the existing leaf BEFORE
     // building any new DOM. Without this, scenario (d) would fail (a
-    // second render would insert a duplicate row).
+    // second render would insert a duplicate panel.
     expect(helperBody).toContain(
       'document.getElementById("comments-author-density")',
     );
     expect(helperBody).toMatch(/if \(existing\) return existing;/);
 
-    // 333 anchor preference + cycle-distribution fallback. The
-    // production anchor logic is what places the 334 row BELOW the 333
-    // chart per FR-4-01 in the typical capability-on render order.
-    expect(helperBody).toContain('[data-comments-trend-row="true"]');
-    expect(helperBody).toContain(
-      'document.getElementById("cycle-distribution")',
-    );
-    expect(helperBody).toContain('.closest(".charts-row")');
+    // Issue #357: the helper now mounts the panel as a child of the
+    // shared comments-density-grid wrapper instead of inserting a
+    // new ``.charts-row`` sibling.  The wrapper-creation logic +
+    // anchor preference are locked by ensureCommentsDensityGrid's
+    // own source-parse contract in
+    // comments-density-subgrid-layout.test.ts; here we only assert
+    // the helper delegates to it.
+    expect(helperBody).toContain("ensureCommentsDensityGrid()");
+    expect(helperBody).toMatch(/if \(!grid\) return null;/);
 
-    // Row markers used by the cleanup helper and by scenarios (a)-(d).
-    expect(helperBody).toContain('row.className = "charts-row"');
+    // Container markers used by the cleanup helper, lifecycle scenarios
+    // (a)-(d), and dashboard parity gates.  The data-attribute moved
+    // from the old outer ``.charts-row`` element to the
+    // ``.chart-container`` cell — selector-by-attribute callers
+    // continue to find the panel because the attribute is still
+    // present on the same logical element.
+    expect(helperBody).toContain('containerCell.className = "chart-container"');
     expect(helperBody).toContain(
-      'row.setAttribute("data-comments-author-density-row", "true")',
+      'containerCell.setAttribute("data-comments-author-density-row", "true")',
     );
     expect(helperBody).toContain('chart.id = "comments-author-density"');
 
-    // Insertion ordering: the new row sits immediately after the anchor
-    // row's next sibling so it lands BELOW the 333 chart (or below
-    // cycle-distribution when 333 is not mounted).
-    expect(helperBody).toContain(
-      "anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling)",
-    );
+    // Insertion is now an appendChild on the wrapper rather than an
+    // insertBefore on a sibling — children fill the 2-up grid in
+    // call order (author, repo, reviewer).
+    expect(helperBody).toContain("grid.appendChild(containerCell)");
   });
 
   it("ensureCommentsAuthorDensityContainer mounts the heading", () => {
@@ -289,7 +313,7 @@ describe("comments-author-density dashboard lifecycle — source-parse contract"
     expect(helperBody).toContain('heading.textContent = "Comments by Author"');
   });
 
-  it("removeCommentsAuthorDensityContainer in dashboard.ts targets the data-attribute selector", () => {
+  it("removeCommentsAuthorDensityContainer targets the data-attribute selector and trims the empty wrapper (issue #357)", () => {
     const helperStart = dashboardSrc.indexOf(
       "function removeCommentsAuthorDensityContainer(",
     );
@@ -299,6 +323,10 @@ describe("comments-author-density dashboard lifecycle — source-parse contract"
     expect(helperBody).toContain('[data-comments-author-density-row="true"]');
     expect(helperBody).toMatch(/if \(!row\) return;/);
     expect(helperBody).toContain("row.parentElement?.removeChild(row)");
+    // Issue #357: cleanup must ALSO trim the wrapper when the panel
+    // was the last density child — otherwise the empty wrapper
+    // lingers as a visible gap and inflates ``.charts-row`` counts.
+    expect(helperBody).toContain("removeCommentsDensityGridIfEmpty()");
   });
 
   it("dashboard refresh path calls both helpers behind the capability gate", () => {
@@ -448,16 +476,25 @@ describe("comments-author-density dashboard lifecycle — four scenarios (T027)"
       document.querySelectorAll('[data-comments-author-density-row="true"] h3'),
     ).toHaveLength(1);
 
-    // Total `.charts-row` count is now 4 (row-1 + row-2 + 333 row + 334 row).
+    // Total `.charts-row` count is now 4 (row-1 + row-2 + 333 row +
+    // density-grid wrapper).  Issue #357: the per-author panel + the
+    // future per-repo / per-reviewer panels share a single
+    // ``.charts-row.comments-density-grid`` wrapper, so the count is
+    // independent of how many density panels are mounted (as long as
+    // at least one is).
     expect(document.querySelectorAll(".charts-row").length).toBe(4);
 
-    // The 334 row sits IMMEDIATELY AFTER the 333 row (FR-4-01: per-author
-    // breakdown sits below the weekly trend chart).
+    // Issue #357: the density-grid wrapper sits IMMEDIATELY AFTER
+    // the 333 trend row (FR-4-01 + #357 acceptance — trend stays
+    // full-width above the density grid).  The author panel itself
+    // is the FIRST CHILD of the wrapper.
     const trendRow = document.querySelector('[data-comments-trend-row="true"]');
     expect(trendRow).not.toBeNull();
-    expect(trendRow!.nextElementSibling).not.toBeNull();
+    const wrapper = trendRow!.nextElementSibling;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.getAttribute("data-comments-density-grid")).toBe("true");
     expect(
-      trendRow!.nextElementSibling?.getAttribute(
+      wrapper?.firstElementChild?.getAttribute(
         "data-comments-author-density-row",
       ),
     ).toBe("true");

--- a/extension/tests/dashboard/comments-density-subgrid-layout.test.ts
+++ b/extension/tests/dashboard/comments-density-subgrid-layout.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Comments-Density Sub-Grid Layout Tests (Issue #357).
+ *
+ * Verifies the dashboard-layer wrapper helpers
+ * (``ensureCommentsDensityGrid`` /
+ * ``removeCommentsDensityGridIfEmpty``) and the cross-helper lifecycle
+ * invariants when all three density panels (per-author 334, per-repo
+ * 335, per-reviewer 336) share the same
+ * ``[data-comments-density-grid="true"]`` wrapper:
+ *
+ *   - Wrapper absent under initial capability-off (SC-1-03 byte-identity
+ *     contract still holds; the wrapper is not mounted unless at least
+ *     one density panel ensures it).
+ *   - Wrapper created on first density-panel mount; subsequent panels
+ *     reuse the existing wrapper (idempotency).
+ *   - Wrapper persists across partial removals (still hosts children).
+ *   - Wrapper removed when its last density-panel child is detached.
+ *   - on→off→on cycles cleanly recreate the wrapper.
+ *   - Trend row (333) stays full-width as the wrapper's preceding
+ *     sibling — issue #357 acceptance ("trend full-width above the
+ *     density grid").
+ *
+ * Same source-parse-contract pattern as the per-panel lifecycle tests:
+ * test-side mirrors of the wrapper helpers are locked to production
+ * via ``dashboardSrc.indexOf`` + ``expect(helperBody).toContain(...)``.
+ *
+ * @module tests/dashboard/comments-density-subgrid-layout.test.ts
+ */
+
+import * as _fsOriginal from "fs";
+
+function _loadFs(): typeof _fsOriginal {
+  return _fsOriginal;
+}
+
+const _fs = _loadFs();
+
+import { resolve } from "path";
+
+const dashboardSrcPath = resolve(__dirname, "../../ui/dashboard.ts");
+const dashboardSrc = _fs.readFileSync(dashboardSrcPath, "utf-8");
+
+// ---------------------------------------------------------------------------
+// Test-side mirrors — locked to production via the source-parse contract
+// describe block below.
+// ---------------------------------------------------------------------------
+
+function ensureCommentsDensityGridContract(): HTMLElement | null {
+  const existing = document.querySelector<HTMLElement>(
+    '[data-comments-density-grid="true"]',
+  );
+  if (existing) return existing;
+
+  const trendRow = document.querySelector('[data-comments-trend-row="true"]');
+  let anchorRow: Element | null = trendRow;
+  if (!anchorRow) {
+    const cycleDist = document.getElementById("cycle-distribution");
+    anchorRow = cycleDist?.closest(".charts-row") ?? null;
+  }
+  if (!anchorRow || !anchorRow.parentElement) return null;
+
+  const grid = document.createElement("div");
+  grid.className = "charts-row comments-density-grid";
+  grid.setAttribute("data-comments-density-grid", "true");
+
+  anchorRow.parentElement.insertBefore(grid, anchorRow.nextSibling);
+
+  return grid;
+}
+
+function removeCommentsDensityGridIfEmptyContract(): void {
+  const grid = document.querySelector('[data-comments-density-grid="true"]');
+  if (!grid) return;
+  if (grid.children.length === 0) {
+    grid.parentElement?.removeChild(grid);
+  }
+}
+
+function appendDensityChildContract(
+  grid: HTMLElement,
+  dataAttr: string,
+  chartId: string,
+  headingText: string,
+): HTMLElement {
+  const cell = document.createElement("div");
+  cell.className = "chart-container";
+  cell.setAttribute(dataAttr, "true");
+  const heading = document.createElement("h3");
+  heading.textContent = headingText;
+  cell.appendChild(heading);
+  const chart = document.createElement("div");
+  chart.id = chartId;
+  chart.className = "chart";
+  cell.appendChild(chart);
+  grid.appendChild(cell);
+  return cell;
+}
+
+function detachDensityChild(dataAttr: string): void {
+  const row = document.querySelector(`[${dataAttr}="true"]`);
+  row?.parentElement?.removeChild(row);
+  removeCommentsDensityGridIfEmptyContract();
+}
+
+// ---------------------------------------------------------------------------
+// Pre-feature Metrics-tab baseline.  Mirrors the static markup the
+// dashboard's ``init()`` builds before any density panel is mounted.
+// ---------------------------------------------------------------------------
+
+const PRE_FEATURE_METRICS_HTML = `
+  <section id="tab-metrics">
+    <div class="charts-row" data-pre-feature-row="row-1">
+      <div class="chart-container">
+        <h3>PR Throughput Over Time</h3>
+        <div id="throughput-chart" class="chart"></div>
+      </div>
+      <div class="chart-container">
+        <h3>Cycle Time Trend</h3>
+        <div id="cycle-time-trend" class="chart"></div>
+      </div>
+    </div>
+    <div class="charts-row" data-pre-feature-row="row-2">
+      <div class="chart-container">
+        <h3 id="reviewer-activity-label">Reviewer Activity</h3>
+        <div id="reviewer-activity" class="chart"></div>
+      </div>
+      <div class="chart-container">
+        <h3>Cycle Time Distribution</h3>
+        <div id="cycle-distribution" class="chart"></div>
+      </div>
+    </div>
+  </section>
+`;
+
+function mountPreFeatureBaseline(): void {
+  document.body.innerHTML = PRE_FEATURE_METRICS_HTML;
+}
+
+function mount333Row(): HTMLElement {
+  const cycleDist = document.getElementById("cycle-distribution");
+  const anchorRow = cycleDist?.closest(".charts-row");
+  if (!anchorRow || !anchorRow.parentElement) {
+    throw new Error("baseline missing cycle-distribution anchor");
+  }
+  const row = document.createElement("div");
+  row.className = "charts-row";
+  row.setAttribute("data-comments-trend-row", "true");
+  const containerCell = document.createElement("div");
+  containerCell.className = "chart-container";
+  const heading = document.createElement("h3");
+  heading.textContent = "Comments Trend";
+  containerCell.appendChild(heading);
+  const chart = document.createElement("div");
+  chart.id = "comments-trend";
+  chart.className = "chart";
+  containerCell.appendChild(chart);
+  row.appendChild(containerCell);
+  anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+  return chart;
+}
+
+// ===========================================================================
+// Source-parse contract — locks the test-side mirrors to dashboard.ts.
+// ===========================================================================
+
+describe("comments-density-grid wrapper — source-parse contract (issue #357)", () => {
+  it("ensureCommentsDensityGrid implements check-first idempotency + trend anchor preference", () => {
+    const helperStart = dashboardSrc.indexOf(
+      "function ensureCommentsDensityGrid(",
+    );
+    expect(helperStart).toBeGreaterThan(-1);
+
+    const helperBody = dashboardSrc.slice(helperStart, helperStart + 2000);
+
+    // Check-first idempotency: subsequent mounts find the existing
+    // wrapper instead of inserting a duplicate.
+    expect(helperBody).toContain('[data-comments-density-grid="true"]');
+    expect(helperBody).toMatch(/if \(existing\) return existing;/);
+
+    // Anchor preference: trend row primary, cycle-distribution fallback.
+    // The wrapper sits IMMEDIATELY AFTER the chosen anchor — issue #357
+    // acceptance ("trend full-width above the density grid").
+    expect(helperBody).toContain('[data-comments-trend-row="true"]');
+    expect(helperBody).toContain(
+      'document.getElementById("cycle-distribution")',
+    );
+    expect(helperBody).toContain('.closest(".charts-row")');
+
+    // Wrapper markers used by the cleanup helper, by per-panel ensure
+    // helpers, and by dashboard parity gates that look for the wrapper
+    // by attribute.
+    expect(helperBody).toContain(
+      'grid.className = "charts-row comments-density-grid"',
+    );
+    expect(helperBody).toContain(
+      'grid.setAttribute("data-comments-density-grid", "true")',
+    );
+
+    // Insertion ordering: wrapper sits after the anchor's next sibling
+    // (i.e., directly below the trend row when trend is mounted).
+    expect(helperBody).toContain(
+      "anchorRow.parentElement.insertBefore(grid, anchorRow.nextSibling)",
+    );
+  });
+
+  it("removeCommentsDensityGridIfEmpty trims the wrapper only when child count is zero", () => {
+    const helperStart = dashboardSrc.indexOf(
+      "function removeCommentsDensityGridIfEmpty(",
+    );
+    expect(helperStart).toBeGreaterThan(-1);
+
+    const helperBody = dashboardSrc.slice(helperStart, helperStart + 800);
+
+    // Targets the wrapper by attribute and bails when absent (no-op
+    // under capability-off / repeated capability-off renders).
+    expect(helperBody).toContain('[data-comments-density-grid="true"]');
+    expect(helperBody).toMatch(/if \(!grid\) return;/);
+
+    // Child-count guard: wrapper survives partial removals so the
+    // remaining density panels stay mounted.  Locks the
+    // ``children.length === 0`` predicate so any future refactor that
+    // unconditionally removes the wrapper trips this contract.
+    expect(helperBody).toContain("grid.children.length === 0");
+    expect(helperBody).toContain("grid.parentElement?.removeChild(grid)");
+  });
+
+  it("each density panel's ensure helper delegates to ensureCommentsDensityGrid", () => {
+    // Locks the cross-helper invariant: per-author / per-repo /
+    // per-reviewer all funnel through ensureCommentsDensityGrid so the
+    // wrapper is the single anchor decision (issue #357 — collapses
+    // the previous fallback chains 333/334/335/cycle-dist into one).
+    expect(dashboardSrc).toContain(
+      "function ensureCommentsAuthorDensityContainer(",
+    );
+    expect(dashboardSrc).toContain(
+      "function ensureCommentsRepositoryDensityContainer(",
+    );
+    expect(dashboardSrc).toContain(
+      "function ensureCommentsReviewerDensityContainer(",
+    );
+    // Each helper body must contain a call to ensureCommentsDensityGrid.
+    // Counted via global match: minimum 3 invocations (one per density
+    // panel) plus any extras inside the helper itself if added later.
+    const matches = dashboardSrc.match(/ensureCommentsDensityGrid\(\)/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("each density panel's remove helper trims the wrapper via removeCommentsDensityGridIfEmpty", () => {
+    // Locks the cross-helper invariant: the wrapper cleanup is shared,
+    // so removing the LAST density panel deterministically removes the
+    // wrapper too — independent of which panel is last to leave.
+    expect(dashboardSrc).toContain(
+      "function removeCommentsAuthorDensityContainer(",
+    );
+    expect(dashboardSrc).toContain(
+      "function removeCommentsRepositoryDensityContainer(",
+    );
+    expect(dashboardSrc).toContain(
+      "function removeCommentsReviewerDensityContainer(",
+    );
+    const matches = dashboardSrc.match(/removeCommentsDensityGridIfEmpty\(\)/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ===========================================================================
+// Lifecycle scenarios for the wrapper itself.
+// ===========================================================================
+
+describe("comments-density-grid wrapper — lifecycle scenarios (issue #357)", () => {
+  beforeEach(() => {
+    mountPreFeatureBaseline();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("(a) initial capability-off does not mount the wrapper", () => {
+    // No density panel ensures the wrapper, so it never appears.  The
+    // 2 pre-feature ``.charts-row`` rows are the entire metrics tab.
+    expect(
+      document.querySelector('[data-comments-density-grid="true"]'),
+    ).toBeNull();
+    expect(document.querySelectorAll(".charts-row").length).toBe(2);
+  });
+
+  it("first density-panel ensure creates the wrapper exactly once; subsequent ensures reuse it", () => {
+    mount333Row();
+
+    // First call creates the wrapper.
+    const grid1 = ensureCommentsDensityGridContract();
+    expect(grid1).not.toBeNull();
+    expect(
+      document.querySelectorAll('[data-comments-density-grid="true"]').length,
+    ).toBe(1);
+    expect(grid1?.classList.contains("charts-row")).toBe(true);
+    expect(grid1?.classList.contains("comments-density-grid")).toBe(true);
+
+    // Second call returns the same element (idempotency).
+    const grid2 = ensureCommentsDensityGridContract();
+    expect(grid2).toBe(grid1);
+    expect(
+      document.querySelectorAll('[data-comments-density-grid="true"]').length,
+    ).toBe(1);
+  });
+
+  it("wrapper sits IMMEDIATELY AFTER the trend row (full-width trend stays above the 2-up grid)", () => {
+    mount333Row();
+    ensureCommentsDensityGridContract();
+
+    const trendRow = document.querySelector('[data-comments-trend-row="true"]');
+    expect(trendRow).not.toBeNull();
+    const wrapper = trendRow!.nextElementSibling;
+    expect(wrapper?.getAttribute("data-comments-density-grid")).toBe("true");
+  });
+
+  it("falls back to cycle-distribution row when the trend row is not mounted", () => {
+    // 333 row absent — wrapper falls back to anchoring on the static
+    // cycle-distribution chart's parent row (last pre-feature row).
+    const grid = ensureCommentsDensityGridContract();
+    expect(grid).not.toBeNull();
+    const lastPreFeatureRow = document.querySelector(
+      '[data-pre-feature-row="row-2"]',
+    );
+    expect(lastPreFeatureRow!.nextElementSibling).toBe(grid);
+  });
+
+  it("hosts all three density panels as siblings within the wrapper, in author → repo → reviewer order", () => {
+    mount333Row();
+    const grid = ensureCommentsDensityGridContract();
+    expect(grid).not.toBeNull();
+
+    appendDensityChildContract(
+      grid!,
+      "data-comments-author-density-row",
+      "comments-author-density",
+      "Comments by Author",
+    );
+    appendDensityChildContract(
+      grid!,
+      "data-comments-repository-density-row",
+      "comments-repository-density",
+      "Comments by Repository",
+    );
+    appendDensityChildContract(
+      grid!,
+      "data-comments-reviewer-density-row",
+      "comments-reviewer-density",
+      "Comments by Reviewer",
+    );
+
+    expect(grid!.children).toHaveLength(3);
+    expect(
+      grid!.children[0]?.getAttribute("data-comments-author-density-row"),
+    ).toBe("true");
+    expect(
+      grid!.children[1]?.getAttribute("data-comments-repository-density-row"),
+    ).toBe("true");
+    expect(
+      grid!.children[2]?.getAttribute("data-comments-reviewer-density-row"),
+    ).toBe("true");
+
+    // Wrapper still counts as ONE ``.charts-row`` regardless of how
+    // many density panels live inside it.
+    expect(document.querySelectorAll(".charts-row").length).toBe(4);
+  });
+
+  it("wrapper persists across partial removals — only trimmed when child count drops to zero", () => {
+    mount333Row();
+    const grid = ensureCommentsDensityGridContract();
+    appendDensityChildContract(
+      grid!,
+      "data-comments-author-density-row",
+      "comments-author-density",
+      "Comments by Author",
+    );
+    appendDensityChildContract(
+      grid!,
+      "data-comments-repository-density-row",
+      "comments-repository-density",
+      "Comments by Repository",
+    );
+
+    // Remove repo first — wrapper still has author, must NOT trim.
+    detachDensityChild("data-comments-repository-density-row");
+    expect(
+      document.querySelector('[data-comments-density-grid="true"]'),
+    ).not.toBeNull();
+    expect(grid!.children).toHaveLength(1);
+
+    // Remove the last child — wrapper is now trimmed.
+    detachDensityChild("data-comments-author-density-row");
+    expect(
+      document.querySelector('[data-comments-density-grid="true"]'),
+    ).toBeNull();
+  });
+
+  it("on→off→on cycles cleanly recreate the wrapper", () => {
+    mount333Row();
+    const grid1 = ensureCommentsDensityGridContract();
+    appendDensityChildContract(
+      grid1!,
+      "data-comments-author-density-row",
+      "comments-author-density",
+      "Comments by Author",
+    );
+
+    // capability-off: detach the only child → wrapper trimmed.
+    detachDensityChild("data-comments-author-density-row");
+    expect(
+      document.querySelector('[data-comments-density-grid="true"]'),
+    ).toBeNull();
+
+    // capability-on again: ensure recreates the wrapper as a fresh
+    // element (the prior reference is dead).
+    const grid2 = ensureCommentsDensityGridContract();
+    expect(grid2).not.toBeNull();
+    expect(grid2).not.toBe(grid1);
+    expect(
+      document.querySelectorAll('[data-comments-density-grid="true"]').length,
+    ).toBe(1);
+  });
+});

--- a/extension/tests/dashboard/comments-repository-density-lifecycle.test.ts
+++ b/extension/tests/dashboard/comments-repository-density-lifecycle.test.ts
@@ -78,29 +78,47 @@ const dashboardSrc = _fs.readFileSync(dashboardSrcPath, "utf-8");
 // heading text, anchor selector) will surface as a scenario failure.
 // ---------------------------------------------------------------------------
 
-function ensureCommentsRepositoryDensityContainerContract(): HTMLElement | null {
-  const existing = document.getElementById("comments-repository-density");
+function ensureCommentsDensityGridContract(): HTMLElement | null {
+  const existing = document.querySelector<HTMLElement>(
+    '[data-comments-density-grid="true"]',
+  );
   if (existing) return existing;
 
-  const perAuthorRow = document.querySelector(
-    '[data-comments-author-density-row="true"]',
-  );
-  let anchorRow: Element | null = perAuthorRow;
-  if (!anchorRow) {
-    anchorRow = document.querySelector('[data-comments-trend-row="true"]');
-  }
+  const trendRow = document.querySelector('[data-comments-trend-row="true"]');
+  let anchorRow: Element | null = trendRow;
   if (!anchorRow) {
     const cycleDist = document.getElementById("cycle-distribution");
     anchorRow = cycleDist?.closest(".charts-row") ?? null;
   }
   if (!anchorRow || !anchorRow.parentElement) return null;
 
-  const row = document.createElement("div");
-  row.className = "charts-row";
-  row.setAttribute("data-comments-repository-density-row", "true");
+  const grid = document.createElement("div");
+  grid.className = "charts-row comments-density-grid";
+  grid.setAttribute("data-comments-density-grid", "true");
+
+  anchorRow.parentElement.insertBefore(grid, anchorRow.nextSibling);
+
+  return grid;
+}
+
+function removeCommentsDensityGridIfEmptyContract(): void {
+  const grid = document.querySelector('[data-comments-density-grid="true"]');
+  if (!grid) return;
+  if (grid.children.length === 0) {
+    grid.parentElement?.removeChild(grid);
+  }
+}
+
+function ensureCommentsRepositoryDensityContainerContract(): HTMLElement | null {
+  const existing = document.getElementById("comments-repository-density");
+  if (existing) return existing;
+
+  const grid = ensureCommentsDensityGridContract();
+  if (!grid) return null;
 
   const containerCell = document.createElement("div");
   containerCell.className = "chart-container";
+  containerCell.setAttribute("data-comments-repository-density-row", "true");
 
   const heading = document.createElement("h3");
   heading.textContent = "Comments by Repository";
@@ -111,9 +129,7 @@ function ensureCommentsRepositoryDensityContainerContract(): HTMLElement | null 
   chart.className = "chart";
 
   containerCell.appendChild(chart);
-  row.appendChild(containerCell);
-
-  anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+  grid.appendChild(containerCell);
 
   return chart;
 }
@@ -124,6 +140,7 @@ function removeCommentsRepositoryDensityContainerContract(): void {
   );
   if (!row) return;
   row.parentElement?.removeChild(row);
+  removeCommentsDensityGridIfEmptyContract();
 }
 
 // ---------------------------------------------------------------------------
@@ -194,21 +211,22 @@ function mount333Row(): HTMLElement {
   return chart;
 }
 
-// Insert a synthetic 334 per-author row immediately after the 333 row.
-// In production the 334 helper anchors on the 333 row; this mirror does
-// the same so the 335 row can anchor on the 334 row per CL-10.  Tests
-// (b), (c), (d) need both 333 + 334 rows mounted to exercise the 335
-// anchor-and-insert path correctly.
+// Insert a synthetic 334 per-author panel as the FIRST child of the
+// shared comments-density-grid wrapper (issue #357 reshape).  In the
+// pre-#357 world the 334 row was a sibling row inserted below 333; in
+// the new world it is the wrapper's first child.  Tests (b), (c), (d)
+// need a mounted 334 panel so the 335 anchor + insertion path can be
+// exercised: the 335 helper appends its own panel to the same wrapper
+// so 335 lands as the wrapper's SECOND child (sibling of 334 within
+// the grid, not within the metrics tab).
 function mount334Row(): HTMLElement {
-  const trendRow = document.querySelector('[data-comments-trend-row="true"]');
-  if (!trendRow || !trendRow.parentElement) {
-    throw new Error("333 row must be mounted before 334 row");
+  const grid = ensureCommentsDensityGridContract();
+  if (!grid) {
+    throw new Error("density grid not mountable (333 row missing?)");
   }
-  const row = document.createElement("div");
-  row.className = "charts-row";
-  row.setAttribute("data-comments-author-density-row", "true");
   const containerCell = document.createElement("div");
   containerCell.className = "chart-container";
+  containerCell.setAttribute("data-comments-author-density-row", "true");
   const heading = document.createElement("h3");
   heading.textContent = "Comments by Author";
   containerCell.appendChild(heading);
@@ -216,8 +234,7 @@ function mount334Row(): HTMLElement {
   chart.id = "comments-author-density";
   chart.className = "chart";
   containerCell.appendChild(chart);
-  row.appendChild(containerCell);
-  trendRow.parentElement.insertBefore(row, trendRow.nextSibling);
+  grid.appendChild(containerCell);
   return chart;
 }
 
@@ -279,7 +296,7 @@ const NO_FILTERS: FilterState = {
 // ===========================================================================
 
 describe("comments-repository-density dashboard lifecycle — source-parse contract", () => {
-  it("ensureCommentsRepositoryDensityContainer in dashboard.ts implements check-first idempotency + CL-10 (per-author) anchor preference", () => {
+  it("ensureCommentsRepositoryDensityContainer in dashboard.ts implements check-first idempotency + density-grid mount (issue #357)", () => {
     const helperStart = dashboardSrc.indexOf(
       "function ensureCommentsRepositoryDensityContainer(",
     );
@@ -289,36 +306,38 @@ describe("comments-repository-density dashboard lifecycle — source-parse contr
 
     // Check-first idempotency: the helper queries the existing leaf
     // BEFORE building any new DOM.  Without this, scenario (d) would
-    // fail (a second render would insert a duplicate row).
+    // fail (a second render would insert a duplicate panel).
     expect(helperBody).toContain(
       'document.getElementById("comments-repository-density")',
     );
     expect(helperBody).toMatch(/if \(existing\) return existing;/);
 
-    // CL-10 anchor: 334 per-author row primary, 333 trend row fallback,
-    // cycle-distribution baseline.  This locks the production anchor
-    // chain so any refactor that drops or reorders the fallbacks
-    // surfaces here.  scenario (c) verifies the resulting position,
-    // but the contract here verifies the lookup PREFERENCE is intact.
-    expect(helperBody).toContain('[data-comments-author-density-row="true"]');
-    expect(helperBody).toContain('[data-comments-trend-row="true"]');
-    expect(helperBody).toContain(
-      'document.getElementById("cycle-distribution")',
-    );
-    expect(helperBody).toContain('.closest(".charts-row")');
+    // Issue #357: the per-author / per-repo / per-reviewer panels share
+    // a single comments-density-grid wrapper.  The pre-#357 fallback
+    // chain (334 → 333 → cycle-distribution) collapsed into the
+    // wrapper helper itself, locked by ensureCommentsDensityGrid's
+    // own source-parse contract in
+    // comments-density-subgrid-layout.test.ts; here we only assert
+    // this helper delegates to it.
+    expect(helperBody).toContain("ensureCommentsDensityGrid()");
+    expect(helperBody).toMatch(/if \(!grid\) return null;/);
 
-    // Row markers used by the cleanup helper and by scenarios (a)-(d).
-    expect(helperBody).toContain('row.className = "charts-row"');
+    // Container markers used by the cleanup helper, lifecycle scenarios
+    // (a)-(d), and dashboard parity gates.  The data-attribute moved
+    // from the old outer ``.charts-row`` element to the
+    // ``.chart-container`` cell — selector-by-attribute callers
+    // continue to find the panel because the attribute is still
+    // present on the same logical element.
+    expect(helperBody).toContain('containerCell.className = "chart-container"');
     expect(helperBody).toContain(
-      'row.setAttribute("data-comments-repository-density-row", "true")',
+      'containerCell.setAttribute("data-comments-repository-density-row", "true")',
     );
     expect(helperBody).toContain('chart.id = "comments-repository-density"');
 
-    // Insertion ordering: the new row sits immediately after the anchor
-    // row's next sibling so it lands BELOW the per-author row per CL-10.
-    expect(helperBody).toContain(
-      "anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling)",
-    );
+    // Insertion is now an appendChild on the wrapper rather than an
+    // insertBefore on a sibling — children fill the 2-up grid in
+    // call order (author → repo → reviewer).
+    expect(helperBody).toContain("grid.appendChild(containerCell)");
   });
 
   it("ensureCommentsRepositoryDensityContainer mounts the heading", () => {
@@ -338,7 +357,7 @@ describe("comments-repository-density dashboard lifecycle — source-parse contr
     );
   });
 
-  it("removeCommentsRepositoryDensityContainer in dashboard.ts targets the data-attribute selector", () => {
+  it("removeCommentsRepositoryDensityContainer targets the data-attribute selector and trims the empty wrapper (issue #357)", () => {
     const helperStart = dashboardSrc.indexOf(
       "function removeCommentsRepositoryDensityContainer(",
     );
@@ -350,6 +369,9 @@ describe("comments-repository-density dashboard lifecycle — source-parse contr
     );
     expect(helperBody).toMatch(/if \(!row\) return;/);
     expect(helperBody).toContain("row.parentElement?.removeChild(row)");
+    // Issue #357: cleanup must ALSO trim the wrapper when the panel
+    // was the last density child.
+    expect(helperBody).toContain("removeCommentsDensityGridIfEmpty()");
   });
 
   it("dashboard refresh path calls both helpers behind the capability gate", () => {
@@ -459,14 +481,19 @@ describe("comments-repository-density dashboard lifecycle — four scenarios (T0
     expect(
       document.querySelectorAll(".comments-repository-density-row").length,
     ).toBe(5);
-    // 2 pre-feature rows + 333 row + 334 row + 335 row = 5
-    expect(document.querySelectorAll(".charts-row").length).toBe(5);
+    // Issue #357: 2 pre-feature rows + 333 trend row + density-grid
+    // wrapper (containing author + repo) = 4.  The wrapper counts as
+    // a single ``.charts-row`` regardless of how many density panels
+    // it hosts.
+    expect(document.querySelectorAll(".charts-row").length).toBe(4);
 
     // Step 2: capability-off reload runs only the remove helper.
     removeCommentsRepositoryDensityContainerContract();
 
-    // Cleanup: per-repo row gone, but the 333 + 334 rows stay (each
-    // owned by its own remove helper, not by this one).
+    // Cleanup: per-repo row gone, but the 333 trend row and the
+    // density-grid wrapper (still hosting the author panel) survive
+    // because the wrapper is only trimmed when its child count
+    // drops to zero.
     expect(document.getElementById("comments-repository-density")).toBeNull();
     expect(
       document.querySelector('[data-comments-repository-density-row="true"]'),
@@ -476,7 +503,7 @@ describe("comments-repository-density dashboard lifecycle — four scenarios (T0
         '[data-comments-repository-density-row="true"] h3',
       ),
     ).toHaveLength(0);
-    // 333 + 334 rows still present.
+    // 333 row + density-grid wrapper (with author) still present.
     expect(
       document.querySelectorAll('[data-comments-trend-row="true"]').length,
     ).toBe(1);
@@ -484,7 +511,10 @@ describe("comments-repository-density dashboard lifecycle — four scenarios (T0
       document.querySelectorAll('[data-comments-author-density-row="true"]')
         .length,
     ).toBe(1);
-    // 2 pre-feature rows + 333 row + 334 row = 4
+    expect(
+      document.querySelectorAll('[data-comments-density-grid="true"]').length,
+    ).toBe(1);
+    // 2 pre-feature rows + 333 row + density-grid (with author) = 4.
     expect(document.querySelectorAll(".charts-row").length).toBe(4);
     expect(metricsTabHtml()).toBe(baselineWith333And334);
   });
@@ -522,16 +552,22 @@ describe("comments-repository-density dashboard lifecycle — four scenarios (T0
       ),
     ).toHaveLength(1);
 
-    // Total `.charts-row` count is now 5 (row-1 + row-2 + 333 + 334 + 335).
-    expect(document.querySelectorAll(".charts-row").length).toBe(5);
+    // Issue #357: 2 pre-feature rows + 333 trend row + density-grid
+    // wrapper (now hosting author + repo as children) = 4.
+    expect(document.querySelectorAll(".charts-row").length).toBe(4);
 
-    // CL-10 anchor: the 335 row sits IMMEDIATELY AFTER the 334 row
-    // (per-repo breakdown is mounted below the per-author row in the
-    // capability-on render order).
+    // CL-10 ordering inside the density-grid wrapper: the per-repo
+    // panel sits IMMEDIATELY AFTER the per-author panel (siblings
+    // within the wrapper, not within the metrics tab).  This keeps
+    // the original "repo follows author" reading order even though
+    // they now share a parent.
     const perAuthorRow = document.querySelector(
       '[data-comments-author-density-row="true"]',
     );
     expect(perAuthorRow).not.toBeNull();
+    expect(
+      perAuthorRow!.parentElement?.getAttribute("data-comments-density-grid"),
+    ).toBe("true");
     expect(perAuthorRow!.nextElementSibling).not.toBeNull();
     expect(
       perAuthorRow!.nextElementSibling?.getAttribute(
@@ -613,6 +649,8 @@ describe("comments-repository-density dashboard lifecycle — four scenarios (T0
         '[data-comments-repository-density-row="true"] h3',
       ).length,
     ).toBe(1);
-    expect(document.querySelectorAll(".charts-row").length).toBe(5);
+    // Issue #357: 2 pre-feature + 333 + density-grid = 4 (wrapper
+    // counts as one row regardless of how many density panels it hosts).
+    expect(document.querySelectorAll(".charts-row").length).toBe(4);
   });
 });

--- a/extension/tests/dashboard/comments-reviewer-density-lifecycle.test.ts
+++ b/extension/tests/dashboard/comments-reviewer-density-lifecycle.test.ts
@@ -75,34 +75,47 @@ const dashboardSrc = _fs.readFileSync(dashboardSrcPath, "utf-8");
 // heading text, anchor selector) will surface as a scenario failure.
 // ---------------------------------------------------------------------------
 
-function ensureCommentsReviewerDensityContainerContract(): HTMLElement | null {
-  const existing = document.getElementById("comments-reviewer-density");
+function ensureCommentsDensityGridContract(): HTMLElement | null {
+  const existing = document.querySelector<HTMLElement>(
+    '[data-comments-density-grid="true"]',
+  );
   if (existing) return existing;
 
-  const perRepoRow = document.querySelector(
-    '[data-comments-repository-density-row="true"]',
-  );
-  let anchorRow: Element | null = perRepoRow;
-  if (!anchorRow) {
-    anchorRow = document.querySelector(
-      '[data-comments-author-density-row="true"]',
-    );
-  }
-  if (!anchorRow) {
-    anchorRow = document.querySelector('[data-comments-trend-row="true"]');
-  }
+  const trendRow = document.querySelector('[data-comments-trend-row="true"]');
+  let anchorRow: Element | null = trendRow;
   if (!anchorRow) {
     const cycleDist = document.getElementById("cycle-distribution");
     anchorRow = cycleDist?.closest(".charts-row") ?? null;
   }
   if (!anchorRow || !anchorRow.parentElement) return null;
 
-  const row = document.createElement("div");
-  row.className = "charts-row";
-  row.setAttribute("data-comments-reviewer-density-row", "true");
+  const grid = document.createElement("div");
+  grid.className = "charts-row comments-density-grid";
+  grid.setAttribute("data-comments-density-grid", "true");
+
+  anchorRow.parentElement.insertBefore(grid, anchorRow.nextSibling);
+
+  return grid;
+}
+
+function removeCommentsDensityGridIfEmptyContract(): void {
+  const grid = document.querySelector('[data-comments-density-grid="true"]');
+  if (!grid) return;
+  if (grid.children.length === 0) {
+    grid.parentElement?.removeChild(grid);
+  }
+}
+
+function ensureCommentsReviewerDensityContainerContract(): HTMLElement | null {
+  const existing = document.getElementById("comments-reviewer-density");
+  if (existing) return existing;
+
+  const grid = ensureCommentsDensityGridContract();
+  if (!grid) return null;
 
   const containerCell = document.createElement("div");
   containerCell.className = "chart-container";
+  containerCell.setAttribute("data-comments-reviewer-density-row", "true");
 
   const heading = document.createElement("h3");
   heading.textContent = "Comments by Reviewer";
@@ -113,9 +126,7 @@ function ensureCommentsReviewerDensityContainerContract(): HTMLElement | null {
   chart.className = "chart";
 
   containerCell.appendChild(chart);
-  row.appendChild(containerCell);
-
-  anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+  grid.appendChild(containerCell);
 
   return chart;
 }
@@ -126,6 +137,7 @@ function removeCommentsReviewerDensityContainerContract(): void {
   );
   if (!row) return;
   row.parentElement?.removeChild(row);
+  removeCommentsDensityGridIfEmptyContract();
 }
 
 // ---------------------------------------------------------------------------
@@ -198,20 +210,20 @@ function mount333Row(): HTMLElement {
   return chart;
 }
 
-// Insert a synthetic 334 per-author row immediately after the 333 row.
-// In production the 334 helper anchors on the 333 row; this mirror does
-// the same so the 335 row can anchor on the 334 row, and the 336 row
-// can anchor on the 335 row per CL-11.
+// Insert a synthetic 334 per-author panel as the FIRST child of the
+// shared comments-density-grid wrapper (issue #357 reshape).  In the
+// pre-#357 world the 334 row was a sibling row inserted below 333; in
+// the new world it is the wrapper's first child.  Tests (b), (c), (d)
+// need a mounted 334 panel so the 335 + 336 panels can be appended
+// to the same wrapper as siblings within the grid.
 function mount334Row(): HTMLElement {
-  const trendRow = document.querySelector('[data-comments-trend-row="true"]');
-  if (!trendRow || !trendRow.parentElement) {
-    throw new Error("333 row must be mounted before 334 row");
+  const grid = ensureCommentsDensityGridContract();
+  if (!grid) {
+    throw new Error("density grid not mountable (333 row missing?)");
   }
-  const row = document.createElement("div");
-  row.className = "charts-row";
-  row.setAttribute("data-comments-author-density-row", "true");
   const containerCell = document.createElement("div");
   containerCell.className = "chart-container";
+  containerCell.setAttribute("data-comments-author-density-row", "true");
   const heading = document.createElement("h3");
   heading.textContent = "Comments by Author";
   containerCell.appendChild(heading);
@@ -219,28 +231,23 @@ function mount334Row(): HTMLElement {
   chart.id = "comments-author-density";
   chart.className = "chart";
   containerCell.appendChild(chart);
-  row.appendChild(containerCell);
-  trendRow.parentElement.insertBefore(row, trendRow.nextSibling);
+  grid.appendChild(containerCell);
   return chart;
 }
 
-// Insert a synthetic 335 per-repo row immediately after the 334 row.
-// Mirrors the dashboard's capability-on render order so the 336 row
-// can anchor on the 335 row per CL-11.  Tests (b), (c), (d) need 333
-// + 334 + 335 rows mounted to exercise the 336 anchor-and-insert path
-// correctly.
+// Insert a synthetic 335 per-repo panel as the SECOND child of the
+// comments-density-grid wrapper (issue #357 reshape).  Tests (b), (c),
+// (d) for the 336 helper need mounted 333 + 334 + 335 so the
+// reviewer-density panel lands as the wrapper's THIRD child within the
+// 2-up grid.
 function mount335Row(): HTMLElement {
-  const perAuthorRow = document.querySelector(
-    '[data-comments-author-density-row="true"]',
-  );
-  if (!perAuthorRow || !perAuthorRow.parentElement) {
-    throw new Error("334 row must be mounted before 335 row");
+  const grid = ensureCommentsDensityGridContract();
+  if (!grid) {
+    throw new Error("density grid not mountable (333 row missing?)");
   }
-  const row = document.createElement("div");
-  row.className = "charts-row";
-  row.setAttribute("data-comments-repository-density-row", "true");
   const containerCell = document.createElement("div");
   containerCell.className = "chart-container";
+  containerCell.setAttribute("data-comments-repository-density-row", "true");
   const heading = document.createElement("h3");
   heading.textContent = "Comments by Repository";
   containerCell.appendChild(heading);
@@ -248,8 +255,7 @@ function mount335Row(): HTMLElement {
   chart.id = "comments-repository-density";
   chart.className = "chart";
   containerCell.appendChild(chart);
-  row.appendChild(containerCell);
-  perAuthorRow.parentElement.insertBefore(row, perAuthorRow.nextSibling);
+  grid.appendChild(containerCell);
   return chart;
 }
 
@@ -314,7 +320,7 @@ const NO_FILTERS: FilterState = {
 // ===========================================================================
 
 describe("comments-reviewer-density dashboard lifecycle — source-parse contract", () => {
-  it("ensureCommentsReviewerDensityContainer in dashboard.ts implements check-first idempotency + CL-11 (per-repo) anchor preference", () => {
+  it("ensureCommentsReviewerDensityContainer in dashboard.ts implements check-first idempotency + density-grid mount (issue #357)", () => {
     const helperStart = dashboardSrc.indexOf(
       "function ensureCommentsReviewerDensityContainer(",
     );
@@ -324,40 +330,38 @@ describe("comments-reviewer-density dashboard lifecycle — source-parse contrac
 
     // Check-first idempotency: the helper queries the existing leaf
     // BEFORE building any new DOM.  Without this, scenario (d) would
-    // fail (a second render would insert a duplicate row).
+    // fail (a second render would insert a duplicate panel).
     expect(helperBody).toContain(
       'document.getElementById("comments-reviewer-density")',
     );
     expect(helperBody).toMatch(/if \(existing\) return existing;/);
 
-    // CL-11 anchor: 335 per-repo row primary, 334 per-author row
-    // fallback, 333 trend row fallback, cycle-distribution baseline.
-    // This locks the production anchor chain so any refactor that
-    // drops or reorders the fallbacks surfaces here.  Scenario (c)
-    // verifies the resulting position, but the contract here verifies
-    // the lookup PREFERENCE is intact.
-    expect(helperBody).toContain(
-      '[data-comments-repository-density-row="true"]',
-    );
-    expect(helperBody).toContain('[data-comments-author-density-row="true"]');
-    expect(helperBody).toContain('[data-comments-trend-row="true"]');
-    expect(helperBody).toContain(
-      'document.getElementById("cycle-distribution")',
-    );
-    expect(helperBody).toContain('.closest(".charts-row")');
+    // Issue #357: the per-author / per-repo / per-reviewer panels share
+    // a single comments-density-grid wrapper.  The pre-#357 fallback
+    // chain (335 → 334 → 333 → cycle-distribution) collapsed into the
+    // wrapper helper itself, locked by ensureCommentsDensityGrid's
+    // own source-parse contract in
+    // comments-density-subgrid-layout.test.ts; here we only assert
+    // this helper delegates to it.
+    expect(helperBody).toContain("ensureCommentsDensityGrid()");
+    expect(helperBody).toMatch(/if \(!grid\) return null;/);
 
-    // Row markers used by the cleanup helper and by scenarios (a)-(d).
-    expect(helperBody).toContain('row.className = "charts-row"');
+    // Container markers used by the cleanup helper, lifecycle scenarios
+    // (a)-(d), and dashboard parity gates.  The data-attribute moved
+    // from the old outer ``.charts-row`` element to the
+    // ``.chart-container`` cell — selector-by-attribute callers
+    // continue to find the panel because the attribute is still
+    // present on the same logical element.
+    expect(helperBody).toContain('containerCell.className = "chart-container"');
     expect(helperBody).toContain(
-      'row.setAttribute("data-comments-reviewer-density-row", "true")',
+      'containerCell.setAttribute("data-comments-reviewer-density-row", "true")',
     );
     expect(helperBody).toContain('chart.id = "comments-reviewer-density"');
 
-    // Insertion ordering: the new row sits immediately after the anchor
-    // row's next sibling so it lands BELOW the per-repo row per CL-11.
-    expect(helperBody).toContain(
-      "anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling)",
-    );
+    // Insertion is now an appendChild on the wrapper rather than an
+    // insertBefore on a sibling — children fill the 2-up grid in
+    // call order (author → repo → reviewer).
+    expect(helperBody).toContain("grid.appendChild(containerCell)");
   });
 
   it("ensureCommentsReviewerDensityContainer mounts the heading", () => {
@@ -378,7 +382,7 @@ describe("comments-reviewer-density dashboard lifecycle — source-parse contrac
     );
   });
 
-  it("removeCommentsReviewerDensityContainer in dashboard.ts targets the data-attribute selector", () => {
+  it("removeCommentsReviewerDensityContainer targets the data-attribute selector and trims the empty wrapper (issue #357)", () => {
     const helperStart = dashboardSrc.indexOf(
       "function removeCommentsReviewerDensityContainer(",
     );
@@ -388,6 +392,9 @@ describe("comments-reviewer-density dashboard lifecycle — source-parse contrac
     expect(helperBody).toContain('[data-comments-reviewer-density-row="true"]');
     expect(helperBody).toMatch(/if \(!row\) return;/);
     expect(helperBody).toContain("row.parentElement?.removeChild(row)");
+    // Issue #357: cleanup must ALSO trim the wrapper when the panel
+    // was the last density child.
+    expect(helperBody).toContain("removeCommentsDensityGridIfEmpty()");
   });
 
   it("dashboard refresh path calls both helpers behind the capability gate", () => {
@@ -502,14 +509,19 @@ describe("comments-reviewer-density dashboard lifecycle — four scenarios (T029
     expect(
       document.querySelectorAll(".comments-reviewer-density-row").length,
     ).toBe(5);
-    // 2 pre-feature rows + 333 row + 334 row + 335 row + 336 row = 6
-    expect(document.querySelectorAll(".charts-row").length).toBe(6);
+    // Issue #357: 2 pre-feature rows + 333 trend row + density-grid
+    // wrapper (containing author + repo + reviewer) = 4.  The wrapper
+    // counts as a single ``.charts-row`` regardless of how many
+    // density panels it hosts.
+    expect(document.querySelectorAll(".charts-row").length).toBe(4);
 
     // Step 2: capability-off reload runs only the remove helper.
     removeCommentsReviewerDensityContainerContract();
 
-    // Cleanup: per-reviewer row gone, but the 333 + 334 + 335 rows
-    // stay (each owned by its own remove helper, not by this one).
+    // Cleanup: per-reviewer row gone, but the 333 trend row and the
+    // density-grid wrapper (still hosting author + repo) survive
+    // because the wrapper is only trimmed when its child count
+    // drops to zero.
     expect(document.getElementById("comments-reviewer-density")).toBeNull();
     expect(
       document.querySelector('[data-comments-reviewer-density-row="true"]'),
@@ -519,7 +531,7 @@ describe("comments-reviewer-density dashboard lifecycle — four scenarios (T029
         '[data-comments-reviewer-density-row="true"] h3',
       ),
     ).toHaveLength(0);
-    // 333 + 334 + 335 rows still present.
+    // 333 row + density-grid wrapper (with author + repo) still present.
     expect(
       document.querySelectorAll('[data-comments-trend-row="true"]').length,
     ).toBe(1);
@@ -531,8 +543,11 @@ describe("comments-reviewer-density dashboard lifecycle — four scenarios (T029
       document.querySelectorAll('[data-comments-repository-density-row="true"]')
         .length,
     ).toBe(1);
-    // 2 pre-feature rows + 333 row + 334 row + 335 row = 5
-    expect(document.querySelectorAll(".charts-row").length).toBe(5);
+    expect(
+      document.querySelectorAll('[data-comments-density-grid="true"]').length,
+    ).toBe(1);
+    // 2 pre-feature rows + 333 row + density-grid (with 2 children) = 4.
+    expect(document.querySelectorAll(".charts-row").length).toBe(4);
     expect(metricsTabHtml()).toBe(baselineWith333_334_335);
   });
 
@@ -570,17 +585,22 @@ describe("comments-reviewer-density dashboard lifecycle — four scenarios (T029
       ),
     ).toHaveLength(1);
 
-    // Total `.charts-row` count is now 6 (row-1 + row-2 + 333 + 334 +
-    // 335 + 336).
-    expect(document.querySelectorAll(".charts-row").length).toBe(6);
+    // Issue #357: 2 pre-feature rows + 333 trend row + density-grid
+    // wrapper (now hosting author + repo + reviewer as children) = 4.
+    expect(document.querySelectorAll(".charts-row").length).toBe(4);
 
-    // CL-11 anchor: the 336 row sits IMMEDIATELY AFTER the 335 row
-    // (per-reviewer breakdown is mounted below the per-repo row in
-    // the capability-on render order).
+    // CL-11 ordering inside the density-grid wrapper: the per-reviewer
+    // panel sits IMMEDIATELY AFTER the per-repo panel (siblings within
+    // the wrapper, not within the metrics tab).  This keeps the
+    // original "reviewer follows repo" reading order even though
+    // they now share a parent.
     const perRepoRow = document.querySelector(
       '[data-comments-repository-density-row="true"]',
     );
     expect(perRepoRow).not.toBeNull();
+    expect(
+      perRepoRow!.parentElement?.getAttribute("data-comments-density-grid"),
+    ).toBe("true");
     expect(perRepoRow!.nextElementSibling).not.toBeNull();
     expect(
       perRepoRow!.nextElementSibling?.getAttribute(
@@ -663,6 +683,8 @@ describe("comments-reviewer-density dashboard lifecycle — four scenarios (T029
         '[data-comments-reviewer-density-row="true"] h3',
       ).length,
     ).toBe(1);
-    expect(document.querySelectorAll(".charts-row").length).toBe(6);
+    // Issue #357: 2 pre-feature + 333 + density-grid = 4 (wrapper
+    // counts as one row regardless of how many density panels it hosts).
+    expect(document.querySelectorAll(".charts-row").length).toBe(4);
   });
 });

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -5147,6 +5147,7 @@ var PRInsightsDashboard = (() => {
                 appendText(span, "\u2014");
               } else {
                 span.setAttribute("data-partial", "false");
+                span.setAttribute("data-zero", value === 0 ? "true" : "false");
                 li.setAttribute(`data-${key}`, String(value));
                 appendText(span, String(value));
               }

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -11711,23 +11711,39 @@ var PRInsightsDashboard = (() => {
     }
     row.parentElement?.removeChild(row);
   }
-  function ensureCommentsAuthorDensityContainer() {
-    const existing = document.getElementById("comments-author-density");
-    if (existing) return existing;
-    const commentsTrendRow = document.querySelector(
-      '[data-comments-trend-row="true"]'
+  function ensureCommentsDensityGrid() {
+    const existing = document.querySelector(
+      '[data-comments-density-grid="true"]'
     );
-    let anchorRow = commentsTrendRow;
+    if (existing) return existing;
+    const trendRow = document.querySelector('[data-comments-trend-row="true"]');
+    let anchorRow = trendRow;
     if (!anchorRow) {
       const cycleDist = document.getElementById("cycle-distribution");
       anchorRow = cycleDist?.closest(".charts-row") ?? null;
     }
     if (!anchorRow || !anchorRow.parentElement) return null;
-    const row = document.createElement("div");
-    row.className = "charts-row";
-    row.setAttribute("data-comments-author-density-row", "true");
+    const grid = document.createElement("div");
+    grid.className = "charts-row comments-density-grid";
+    grid.setAttribute("data-comments-density-grid", "true");
+    anchorRow.parentElement.insertBefore(grid, anchorRow.nextSibling);
+    return grid;
+  }
+  function removeCommentsDensityGridIfEmpty() {
+    const grid = document.querySelector('[data-comments-density-grid="true"]');
+    if (!grid) return;
+    if (grid.children.length === 0) {
+      grid.parentElement?.removeChild(grid);
+    }
+  }
+  function ensureCommentsAuthorDensityContainer() {
+    const existing = document.getElementById("comments-author-density");
+    if (existing) return existing;
+    const grid = ensureCommentsDensityGrid();
+    if (!grid) return null;
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
+    containerCell.setAttribute("data-comments-author-density-row", "true");
     const heading = document.createElement("h3");
     heading.textContent = "Comments by Author";
     attachChartInfoIcon(
@@ -11740,8 +11756,7 @@ var PRInsightsDashboard = (() => {
     chart.id = "comments-author-density";
     chart.className = "chart";
     containerCell.appendChild(chart);
-    row.appendChild(containerCell);
-    anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+    grid.appendChild(containerCell);
     return chart;
   }
   function removeCommentsAuthorDensityContainer() {
@@ -11754,27 +11769,16 @@ var PRInsightsDashboard = (() => {
       detachChartInfoIcon(heading);
     }
     row.parentElement?.removeChild(row);
+    removeCommentsDensityGridIfEmpty();
   }
   function ensureCommentsRepositoryDensityContainer() {
     const existing = document.getElementById("comments-repository-density");
     if (existing) return existing;
-    const perAuthorRow = document.querySelector(
-      '[data-comments-author-density-row="true"]'
-    );
-    let anchorRow = perAuthorRow;
-    if (!anchorRow) {
-      anchorRow = document.querySelector('[data-comments-trend-row="true"]');
-    }
-    if (!anchorRow) {
-      const cycleDist = document.getElementById("cycle-distribution");
-      anchorRow = cycleDist?.closest(".charts-row") ?? null;
-    }
-    if (!anchorRow || !anchorRow.parentElement) return null;
-    const row = document.createElement("div");
-    row.className = "charts-row";
-    row.setAttribute("data-comments-repository-density-row", "true");
+    const grid = ensureCommentsDensityGrid();
+    if (!grid) return null;
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
+    containerCell.setAttribute("data-comments-repository-density-row", "true");
     const heading = document.createElement("h3");
     heading.textContent = "Comments by Repository";
     attachChartInfoIcon(
@@ -11787,8 +11791,7 @@ var PRInsightsDashboard = (() => {
     chart.id = "comments-repository-density";
     chart.className = "chart";
     containerCell.appendChild(chart);
-    row.appendChild(containerCell);
-    anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+    grid.appendChild(containerCell);
     return chart;
   }
   function removeCommentsRepositoryDensityContainer() {
@@ -11801,32 +11804,16 @@ var PRInsightsDashboard = (() => {
       detachChartInfoIcon(heading);
     }
     row.parentElement?.removeChild(row);
+    removeCommentsDensityGridIfEmpty();
   }
   function ensureCommentsReviewerDensityContainer() {
     const existing = document.getElementById("comments-reviewer-density");
     if (existing) return existing;
-    const perRepoRow = document.querySelector(
-      '[data-comments-repository-density-row="true"]'
-    );
-    let anchorRow = perRepoRow;
-    if (!anchorRow) {
-      anchorRow = document.querySelector(
-        '[data-comments-author-density-row="true"]'
-      );
-    }
-    if (!anchorRow) {
-      anchorRow = document.querySelector('[data-comments-trend-row="true"]');
-    }
-    if (!anchorRow) {
-      const cycleDist = document.getElementById("cycle-distribution");
-      anchorRow = cycleDist?.closest(".charts-row") ?? null;
-    }
-    if (!anchorRow || !anchorRow.parentElement) return null;
-    const row = document.createElement("div");
-    row.className = "charts-row";
-    row.setAttribute("data-comments-reviewer-density-row", "true");
+    const grid = ensureCommentsDensityGrid();
+    if (!grid) return null;
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
+    containerCell.setAttribute("data-comments-reviewer-density-row", "true");
     const heading = document.createElement("h3");
     heading.textContent = "Comments by Reviewer";
     attachChartInfoIcon(
@@ -11839,8 +11826,7 @@ var PRInsightsDashboard = (() => {
     chart.id = "comments-reviewer-density";
     chart.className = "chart";
     containerCell.appendChild(chart);
-    row.appendChild(containerCell);
-    anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+    grid.appendChild(containerCell);
     return chart;
   }
   function removeCommentsReviewerDensityContainer() {
@@ -11853,6 +11839,7 @@ var PRInsightsDashboard = (() => {
       detachChartInfoIcon(heading);
     }
     row.parentElement?.removeChild(row);
+    removeCommentsDensityGridIfEmpty();
   }
   function toArtifactLoadResult(loaderResult, artifactPath) {
     if (!loaderResult) {

--- a/extension/tests/fixtures/broken-docs/styles.css
+++ b/extension/tests/fixtures/broken-docs/styles.css
@@ -3502,6 +3502,19 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     opacity: 0.7;
 }
 
+/* Issue #337: zero-vs-many tonal weight on comments-metrics.
+ * Numeric zero cells render at reduced opacity so the visual contrast
+ * between "no work" and "any work" is faster to scan than reading every
+ * digit on every row.  Mutually exclusive with the
+ * ``data-partial="true"`` rule above (a span never carries both attrs)
+ * — partial italic + tertiary color keeps partial visually distinct
+ * from zero per INV-10.  Numeric ``0`` is preserved as the rendered
+ * glyph (no em-dash swap) since the partial sentinel already owns the
+ * em-dash. */
+.detail-panel-pr-list--with-comments .comments-metric[data-zero="true"] {
+    opacity: 0.45;
+}
+
 .detail-panel-pr-list--with-comments .comments-metric--unresolved {
     font-weight: 600;
 }

--- a/extension/tests/fixtures/broken-docs/styles.css
+++ b/extension/tests/fixtures/broken-docs/styles.css
@@ -734,6 +734,36 @@ input[type="search"]::placeholder {
     gap: 20px;
 }
 
+/* Issue #357 — comments-density panels share a single 2-up sub-grid so
+ * the per-author / per-repo / per-reviewer panels read as a coherent
+ * group rather than a four-row vertical wall.  The trend chart remains
+ * full-width on its own ``.charts-row`` above this wrapper (timeseries
+ * vs cross-section reading order), so the wrapper itself is a sibling
+ * of the trend row, NOT its parent.
+ *
+ * The wrapper carries the base ``.charts-row`` class so it inherits the
+ * 20px gap + grid baseline.  This rule overrides ONLY
+ * ``grid-template-columns`` to lock 2-up (instead of the parent's
+ * ``auto-fit, minmax(400px, 1fr)`` which would expand to 3-up at wide
+ * viewports — explicitly out of scope per the issue's "2-up reads
+ * better than 3-up cramped" verdict).  The narrow-viewport fallback
+ * below collapses to 1-up around the same breakpoint the rest of the
+ * dashboard uses for column collapse.
+ *
+ * With three children in 2 columns, the third (reviewer) lands in the
+ * bottom-left cell; the bottom-right is empty.  This is intentional —
+ * spanning reviewer would compress per-row scan-density at the only
+ * width where 2-up is actively useful. */
+.charts-row.comments-density-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 700px) {
+    .charts-row.comments-density-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
 .summary-cards {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/extension/tests/fixtures/broken-docs/styles.css
+++ b/extension/tests/fixtures/broken-docs/styles.css
@@ -3318,6 +3318,26 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     text-align: right;
 }
 
+/* Issue #338: visually subordinate the Unresolved header cell.
+ * Unresolved is a subset of Threads (INV-09: active_thread_count <=
+ * thread_count), so the column should weigh visually less than its
+ * parent rather than equal to it.  Two non-geometric tweaks recover
+ * the subset relation without removing the dedicated sortable column
+ * (the verdict on #338 explicitly preserved sort affordance):
+ *   - lighter header weight (500 vs the parent header's 600)
+ *   - slight content indent via padding-right so the right-aligned
+ *     label pulls inward from the column's right edge
+ * Track widths are unchanged — the geometric Playwright guard
+ * (button rect within cell rect ±0.5px) still holds because padding
+ * affects content placement inside the cell box, not the cell box
+ * itself.  Width narrowing was deliberately deferred (would require
+ * relaxing the Ubuntu fallback metric buffer locked at :3267-3307). */
+.detail-panel-pr-list-header-cell--unresolved {
+    font-weight: 500;
+    padding-right: 8px;
+    color: var(--text-tertiary, var(--text-secondary));
+}
+
 .detail-panel-pr-list-header-sort {
     appearance: none;
     background: transparent;
@@ -3515,8 +3535,15 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     opacity: 0.45;
 }
 
+/* Issue #338: visually subordinate the Unresolved data column.
+ * The previous ``font-weight: 600`` rule made Unresolved BOLDER than
+ * Threads, the opposite of the subset relation (INV-09).  Replaced
+ * with a muted color + slight right-edge indent so the per-row
+ * Unresolved value reads as "child of Threads" rather than peer.
+ * Sort affordance and column position unchanged. */
 .detail-panel-pr-list--with-comments .comments-metric--unresolved {
-    font-weight: 600;
+    color: var(--text-secondary);
+    padding-right: 8px;
 }
 
 /* Issue #331 / C2 + C3 — in-panel coverage notice.

--- a/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
+++ b/extension/tests/modules/drilldown/pr-list-comments-columns.test.ts
@@ -842,6 +842,120 @@ describe("partial sentinel rendering (FR-3-05 / INV-10)", () => {
   });
 });
 
+describe("issue #337 zero-tonal-weight contract", () => {
+  // Locks the data-zero discriminator the styles.css rule consumes
+  // (.comments-metric[data-zero="true"] → reduced opacity).  The
+  // attribute is set only on numeric rows; partial-sentinel spans are
+  // styled separately by the data-partial="true" rule.  Mutual
+  // exclusivity is what keeps partial != zero visually distinct, so
+  // both directions are asserted below.
+  it("marks data-zero='true' on every span when all three counts are zero", () => {
+    const section = makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 200,
+          threadCount: 0,
+          commentCount: 0,
+          activeThreadCount: 0,
+        }),
+      ],
+      renderedCount: 1,
+      actualFilteredCount: 1,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+    const root = openWithPrListSection(section);
+    const row = listRows(root)[0]!;
+    for (const axis of ["threads", "comments", "unresolved"] as const) {
+      const span = metricSpan(row, axis);
+      expect(span.getAttribute("data-zero")).toBe("true");
+      // Mutually exclusive with data-partial — a numeric zero must
+      // not also be flagged partial; otherwise the two muted CSS
+      // treatments would compose and partial != zero would degrade.
+      expect(span.getAttribute("data-partial")).toBe("false");
+    }
+  });
+
+  it("flags only the zero axes on a row mixing zero and non-zero counts", () => {
+    const section = makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 201,
+          threadCount: 5,
+          commentCount: 0,
+          activeThreadCount: 3,
+        }),
+      ],
+      renderedCount: 1,
+      actualFilteredCount: 1,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+    const root = openWithPrListSection(section);
+    const row = listRows(root)[0]!;
+    expect(metricSpan(row, "threads").getAttribute("data-zero")).toBe("false");
+    expect(metricSpan(row, "comments").getAttribute("data-zero")).toBe("true");
+    expect(metricSpan(row, "unresolved").getAttribute("data-zero")).toBe(
+      "false",
+    );
+  });
+
+  it("marks data-zero='false' on every span of a fully non-zero row", () => {
+    const section = makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 202,
+          threadCount: 7,
+          commentCount: 12,
+          activeThreadCount: 4,
+        }),
+      ],
+      renderedCount: 1,
+      actualFilteredCount: 1,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+    const root = openWithPrListSection(section);
+    const row = listRows(root)[0]!;
+    for (const axis of ["threads", "comments", "unresolved"] as const) {
+      expect(metricSpan(row, axis).getAttribute("data-zero")).toBe("false");
+    }
+  });
+
+  it("does NOT set data-zero on partial-sentinel spans", () => {
+    // Partial spans render as ``—`` with ``data-partial="true"`` and
+    // are styled by the [data-partial="true"] CSS rule.  A
+    // ``data-zero`` attribute on a partial span would compose two
+    // muted treatments and lie about whether the row carries a
+    // numeric zero, distinct from the missing-data sentinel.
+    const section = makePrListSection({
+      contentState: "pr-list",
+      rows: [
+        buildRow({
+          id: 203,
+          threadCount: null,
+          commentCount: null,
+          activeThreadCount: null,
+        }),
+      ],
+      renderedCount: 1,
+      actualFilteredCount: 1,
+      capValue: 500,
+      commentsMetricsAvailable: true,
+    });
+    const root = openWithPrListSection(section);
+    const row = listRows(root)[0]!;
+    for (const axis of ["threads", "comments", "unresolved"] as const) {
+      const span = metricSpan(row, axis);
+      expect(span.getAttribute("data-partial")).toBe("true");
+      expect(span.getAttribute("data-zero")).toBeNull();
+    }
+  });
+});
+
 describe("sort mechanics (FR-3-02 / FR-4-02)", () => {
   function sortSection(): PrListSection {
     return makePrListSection({

--- a/extension/ui/dashboard.ts
+++ b/extension/ui/dashboard.ts
@@ -1738,37 +1738,88 @@ function removeCommentsTrendContainer(): void {
 }
 
 /**
- * Idempotently ensure the per-author comments-density chart row exists
- * (Feature 334 US1).  Mirrors ``ensureCommentsTrendContainer`` (333 round-12
- * idempotency contract) but anchors BELOW the 333 row per FR-4-01.
+ * Idempotently ensure the comments-density sub-grid wrapper exists
+ * (Issue #357).  All three density panels (per-author 334, per-repo
+ * 335, per-reviewer 336) mount as ``.chart-container`` children of
+ * this single wrapper instead of as four sequential ``.charts-row``
+ * siblings — recovering vertical scan-density without removing any
+ * panel, capability gate, or data-attribute selector that downstream
+ * tests + parity gates depend on.
  *
- * Anchor preference: the existing comments-trend row (333) when mounted —
- * this guarantees the per-author breakdown lands immediately under the
- * weekly trend chart in the typical capability-on render order.  Fallback
- * to ``cycle-distribution`` for atypical orderings (e.g., a future render
- * path that mounts 334 before 333).  Returns ``null`` if neither anchor
- * is locatable.
+ * Anchor preference: the comments-trend row (333) when mounted, falling
+ * back to the static ``cycle-distribution`` chart row.  The wrapper
+ * sits IMMEDIATELY AFTER the chosen anchor so the trend chart stays
+ * full-width above the density grid (issue #357 acceptance: "trend
+ * full-width on its own row, density panels in a 2-up sub-grid below").
+ *
+ * Returns ``null`` when no anchor is locatable (defensive — same
+ * fallback semantics as the prior per-helper anchor chains).
  */
-function ensureCommentsAuthorDensityContainer(): HTMLElement | null {
-  const existing = document.getElementById("comments-author-density");
+function ensureCommentsDensityGrid(): HTMLElement | null {
+  const existing = document.querySelector<HTMLElement>(
+    '[data-comments-density-grid="true"]',
+  );
   if (existing) return existing;
 
-  const commentsTrendRow = document.querySelector(
-    '[data-comments-trend-row="true"]',
-  );
-  let anchorRow: Element | null = commentsTrendRow;
+  const trendRow = document.querySelector('[data-comments-trend-row="true"]');
+  let anchorRow: Element | null = trendRow;
   if (!anchorRow) {
     const cycleDist = document.getElementById("cycle-distribution");
     anchorRow = cycleDist?.closest(".charts-row") ?? null;
   }
   if (!anchorRow || !anchorRow.parentElement) return null;
 
-  const row = document.createElement("div");
-  row.className = "charts-row";
-  row.setAttribute("data-comments-author-density-row", "true");
+  const grid = document.createElement("div");
+  // Carries ``charts-row`` so it inherits the existing gap + grid
+  // baseline from styles.css; ``comments-density-grid`` overrides
+  // ``grid-template-columns`` to a fixed 2-up (with single-column
+  // fallback at narrow viewports).
+  grid.className = "charts-row comments-density-grid";
+  grid.setAttribute("data-comments-density-grid", "true");
+
+  anchorRow.parentElement.insertBefore(grid, anchorRow.nextSibling);
+
+  return grid;
+}
+
+/**
+ * Remove the comments-density sub-grid wrapper if it has no remaining
+ * density-panel children.  Called by each density panel's remove
+ * helper after the panel itself is detached so the wrapper does not
+ * linger as an empty ``.charts-row`` (which would inflate row counts
+ * and leave a visible gap above subsequent sections).  No-op when the
+ * wrapper is absent or still hosts at least one child.
+ */
+function removeCommentsDensityGridIfEmpty(): void {
+  const grid = document.querySelector('[data-comments-density-grid="true"]');
+  if (!grid) return;
+  if (grid.children.length === 0) {
+    grid.parentElement?.removeChild(grid);
+  }
+}
+
+/**
+ * Idempotently ensure the per-author comments-density chart container
+ * exists (Feature 334 US1; reshaped for issue #357).  The container
+ * is appended as a ``.chart-container`` child of the shared
+ * ``[data-comments-density-grid="true"]`` wrapper rather than as a
+ * standalone ``.charts-row`` sibling.  The
+ * ``data-comments-author-density-row="true"`` selector still
+ * resolves to the same logical element (now a ``.chart-container``)
+ * so downstream lifecycle tests and dashboard parity gates continue
+ * to find the panel by attribute.  Returns ``null`` when the wrapper
+ * cannot be created (no anchor locatable).
+ */
+function ensureCommentsAuthorDensityContainer(): HTMLElement | null {
+  const existing = document.getElementById("comments-author-density");
+  if (existing) return existing;
+
+  const grid = ensureCommentsDensityGrid();
+  if (!grid) return null;
 
   const containerCell = document.createElement("div");
   containerCell.className = "chart-container";
+  containerCell.setAttribute("data-comments-author-density-row", "true");
 
   const heading = document.createElement("h3");
   heading.textContent = "Comments by Author";
@@ -1784,18 +1835,19 @@ function ensureCommentsAuthorDensityContainer(): HTMLElement | null {
   chart.className = "chart";
 
   containerCell.appendChild(chart);
-  row.appendChild(containerCell);
-
-  anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+  grid.appendChild(containerCell);
 
   return chart;
 }
 
 /**
- * Remove the per-author comments-density chart row from the DOM if
- * present.  No-op when absent (initial capability-off; repeated
+ * Remove the per-author comments-density chart container from the DOM
+ * if present.  No-op when absent (initial capability-off; repeated
  * capability-off renders).  Active cleanup happens on the on→off
- * mid-session transition (FR-3-02).
+ * mid-session transition (FR-3-02).  When the removal leaves the
+ * shared density-grid wrapper empty, the wrapper is also removed
+ * (issue #357: keeps capability-off byte-identity at the wrapper
+ * scope).
  */
 function removeCommentsAuthorDensityContainer(): void {
   const row = document.querySelector(
@@ -1807,49 +1859,29 @@ function removeCommentsAuthorDensityContainer(): void {
     detachChartInfoIcon(heading);
   }
   row.parentElement?.removeChild(row);
+  removeCommentsDensityGridIfEmpty();
 }
 
 /**
- * Idempotently ensure the per-repo comments-density chart row exists
- * (Feature 335 US1).  Mirrors ``ensureCommentsAuthorDensityContainer``
- * (334 idempotency contract) but anchors BELOW the 334 row per CL-10.
- *
- * Anchor preference (CL-10 + defensive fallbacks):
- *   1. Per-author row (334) — the primary anchor; both charts share the
- *      same capability gate so 334's row will normally be mounted by
- *      the time the 335 render block fires (334's block runs first
- *      in renderMetricsTab).
- *   2. Comments-trend row (333) — fallback when 334's anchor is
- *      missing (rare; would mean 334's ensure helper returned null).
- *   3. ``cycle-distribution`` chart row — universal baseline anchor
- *      shared with 333 / 334 for the unusual case where neither
- *      sibling row is mounted.
- *
- * Returns ``null`` if no anchor is locatable.
+ * Idempotently ensure the per-repo comments-density chart container
+ * exists (Feature 335 US1; reshaped for issue #357).  Like the
+ * per-author helper, this is now a ``.chart-container`` child of the
+ * shared ``[data-comments-density-grid="true"]`` wrapper.  The
+ * ``data-comments-repository-density-row="true"`` selector still
+ * resolves to the same logical element so lifecycle tests and parity
+ * gates continue to find the panel by attribute.  Returns ``null``
+ * when the wrapper cannot be created.
  */
 function ensureCommentsRepositoryDensityContainer(): HTMLElement | null {
   const existing = document.getElementById("comments-repository-density");
   if (existing) return existing;
 
-  const perAuthorRow = document.querySelector(
-    '[data-comments-author-density-row="true"]',
-  );
-  let anchorRow: Element | null = perAuthorRow;
-  if (!anchorRow) {
-    anchorRow = document.querySelector('[data-comments-trend-row="true"]');
-  }
-  if (!anchorRow) {
-    const cycleDist = document.getElementById("cycle-distribution");
-    anchorRow = cycleDist?.closest(".charts-row") ?? null;
-  }
-  if (!anchorRow || !anchorRow.parentElement) return null;
-
-  const row = document.createElement("div");
-  row.className = "charts-row";
-  row.setAttribute("data-comments-repository-density-row", "true");
+  const grid = ensureCommentsDensityGrid();
+  if (!grid) return null;
 
   const containerCell = document.createElement("div");
   containerCell.className = "chart-container";
+  containerCell.setAttribute("data-comments-repository-density-row", "true");
 
   const heading = document.createElement("h3");
   heading.textContent = "Comments by Repository";
@@ -1865,18 +1897,16 @@ function ensureCommentsRepositoryDensityContainer(): HTMLElement | null {
   chart.className = "chart";
 
   containerCell.appendChild(chart);
-  row.appendChild(containerCell);
-
-  anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+  grid.appendChild(containerCell);
 
   return chart;
 }
 
 /**
- * Remove the per-repo comments-density chart row from the DOM if
- * present.  No-op when absent (initial capability-off; repeated
- * capability-off renders).  Active cleanup happens on the on→off
- * mid-session transition (FR-3-02).
+ * Remove the per-repo comments-density chart container from the DOM
+ * if present.  No-op when absent.  When the removal leaves the shared
+ * density-grid wrapper empty, the wrapper is also removed (issue
+ * #357).
  */
 function removeCommentsRepositoryDensityContainer(): void {
   const row = document.querySelector(
@@ -1888,55 +1918,29 @@ function removeCommentsRepositoryDensityContainer(): void {
     detachChartInfoIcon(heading);
   }
   row.parentElement?.removeChild(row);
+  removeCommentsDensityGridIfEmpty();
 }
 
 /**
- * Idempotently ensure the per-reviewer comments-density chart row
- * exists (Feature 336 US1).  Mirrors
- * ``ensureCommentsRepositoryDensityContainer`` (335 idempotency
- * contract) but anchors BELOW the 335 row per CL-11.
- *
- * Anchor preference (CL-11 + defensive fallbacks):
- *   1. Per-repo row (335) — primary; both charts share the capability
- *      gate so 335's row will normally be mounted by the time the 336
- *      render block fires (335's block runs first in renderMetricsTab).
- *   2. Per-author row (334) — fallback when 335's row is absent.
- *   3. Comments-trend row (333) — fallback when neither 334 nor 335 is
- *      mounted.
- *   4. ``cycle-distribution`` chart row — universal baseline anchor
- *      shared with 333 / 334 / 335 for the unusual case where no
- *      sibling row is mounted.
- *
- * Returns ``null`` if no anchor is locatable.
+ * Idempotently ensure the per-reviewer comments-density chart
+ * container exists (Feature 336 US1; reshaped for issue #357).  Like
+ * the per-author and per-repo helpers, this is now a
+ * ``.chart-container`` child of the shared
+ * ``[data-comments-density-grid="true"]`` wrapper.  The
+ * ``data-comments-reviewer-density-row="true"`` selector still
+ * resolves to the same logical element.  Returns ``null`` when the
+ * wrapper cannot be created.
  */
 function ensureCommentsReviewerDensityContainer(): HTMLElement | null {
   const existing = document.getElementById("comments-reviewer-density");
   if (existing) return existing;
 
-  const perRepoRow = document.querySelector(
-    '[data-comments-repository-density-row="true"]',
-  );
-  let anchorRow: Element | null = perRepoRow;
-  if (!anchorRow) {
-    anchorRow = document.querySelector(
-      '[data-comments-author-density-row="true"]',
-    );
-  }
-  if (!anchorRow) {
-    anchorRow = document.querySelector('[data-comments-trend-row="true"]');
-  }
-  if (!anchorRow) {
-    const cycleDist = document.getElementById("cycle-distribution");
-    anchorRow = cycleDist?.closest(".charts-row") ?? null;
-  }
-  if (!anchorRow || !anchorRow.parentElement) return null;
-
-  const row = document.createElement("div");
-  row.className = "charts-row";
-  row.setAttribute("data-comments-reviewer-density-row", "true");
+  const grid = ensureCommentsDensityGrid();
+  if (!grid) return null;
 
   const containerCell = document.createElement("div");
   containerCell.className = "chart-container";
+  containerCell.setAttribute("data-comments-reviewer-density-row", "true");
 
   const heading = document.createElement("h3");
   heading.textContent = "Comments by Reviewer";
@@ -1952,18 +1956,16 @@ function ensureCommentsReviewerDensityContainer(): HTMLElement | null {
   chart.className = "chart";
 
   containerCell.appendChild(chart);
-  row.appendChild(containerCell);
-
-  anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+  grid.appendChild(containerCell);
 
   return chart;
 }
 
 /**
- * Remove the per-reviewer comments-density chart row from the DOM if
- * present.  No-op when absent (initial capability-off; repeated
- * capability-off renders).  Active cleanup happens on the on→off
- * mid-session transition (FR-3-02).
+ * Remove the per-reviewer comments-density chart container from the
+ * DOM if present.  No-op when absent.  When the removal leaves the
+ * shared density-grid wrapper empty, the wrapper is also removed
+ * (issue #357).
  */
 function removeCommentsReviewerDensityContainer(): void {
   const row = document.querySelector(
@@ -1975,6 +1977,7 @@ function removeCommentsReviewerDensityContainer(): void {
     detachChartInfoIcon(heading);
   }
   row.parentElement?.removeChild(row);
+  removeCommentsDensityGridIfEmpty();
 }
 
 // addChartTooltips is now imported from "./modules/charts"

--- a/extension/ui/modules/shared/detail-panel.ts
+++ b/extension/ui/modules/shared/detail-panel.ts
@@ -1310,6 +1310,16 @@ function renderPrListSection(section: PrListSection): HTMLElement {
               appendText(span, "—");
             } else {
               span.setAttribute("data-partial", "false");
+              // Issue #337: muted tonal treatment for true-zero metric
+              // cells.  The ``data-zero`` marker is set only on numeric
+              // rows (partial rows carry ``data-partial="true"`` and
+              // own the em-dash glyph + tertiary-italic styling
+              // separately).  The two attribute selectors are mutually
+              // exclusive so partial != zero stays visually distinct
+              // per INV-10.  Numeric ``0`` is preserved as the rendered
+              // glyph — no em-dash swap — because the partial sentinel
+              // already owns ``—``.
+              span.setAttribute("data-zero", value === 0 ? "true" : "false");
               li.setAttribute(`data-${key}`, String(value));
               appendText(span, String(value));
             }

--- a/extension/ui/styles.css
+++ b/extension/ui/styles.css
@@ -3502,6 +3502,19 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     opacity: 0.7;
 }
 
+/* Issue #337: zero-vs-many tonal weight on comments-metrics.
+ * Numeric zero cells render at reduced opacity so the visual contrast
+ * between "no work" and "any work" is faster to scan than reading every
+ * digit on every row.  Mutually exclusive with the
+ * ``data-partial="true"`` rule above (a span never carries both attrs)
+ * — partial italic + tertiary color keeps partial visually distinct
+ * from zero per INV-10.  Numeric ``0`` is preserved as the rendered
+ * glyph (no em-dash swap) since the partial sentinel already owns the
+ * em-dash. */
+.detail-panel-pr-list--with-comments .comments-metric[data-zero="true"] {
+    opacity: 0.45;
+}
+
 .detail-panel-pr-list--with-comments .comments-metric--unresolved {
     font-weight: 600;
 }

--- a/extension/ui/styles.css
+++ b/extension/ui/styles.css
@@ -734,6 +734,36 @@ input[type="search"]::placeholder {
     gap: 20px;
 }
 
+/* Issue #357 — comments-density panels share a single 2-up sub-grid so
+ * the per-author / per-repo / per-reviewer panels read as a coherent
+ * group rather than a four-row vertical wall.  The trend chart remains
+ * full-width on its own ``.charts-row`` above this wrapper (timeseries
+ * vs cross-section reading order), so the wrapper itself is a sibling
+ * of the trend row, NOT its parent.
+ *
+ * The wrapper carries the base ``.charts-row`` class so it inherits the
+ * 20px gap + grid baseline.  This rule overrides ONLY
+ * ``grid-template-columns`` to lock 2-up (instead of the parent's
+ * ``auto-fit, minmax(400px, 1fr)`` which would expand to 3-up at wide
+ * viewports — explicitly out of scope per the issue's "2-up reads
+ * better than 3-up cramped" verdict).  The narrow-viewport fallback
+ * below collapses to 1-up around the same breakpoint the rest of the
+ * dashboard uses for column collapse.
+ *
+ * With three children in 2 columns, the third (reviewer) lands in the
+ * bottom-left cell; the bottom-right is empty.  This is intentional —
+ * spanning reviewer would compress per-row scan-density at the only
+ * width where 2-up is actively useful. */
+.charts-row.comments-density-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 700px) {
+    .charts-row.comments-density-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
 .summary-cards {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/extension/ui/styles.css
+++ b/extension/ui/styles.css
@@ -3318,6 +3318,26 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     text-align: right;
 }
 
+/* Issue #338: visually subordinate the Unresolved header cell.
+ * Unresolved is a subset of Threads (INV-09: active_thread_count <=
+ * thread_count), so the column should weigh visually less than its
+ * parent rather than equal to it.  Two non-geometric tweaks recover
+ * the subset relation without removing the dedicated sortable column
+ * (the verdict on #338 explicitly preserved sort affordance):
+ *   - lighter header weight (500 vs the parent header's 600)
+ *   - slight content indent via padding-right so the right-aligned
+ *     label pulls inward from the column's right edge
+ * Track widths are unchanged — the geometric Playwright guard
+ * (button rect within cell rect ±0.5px) still holds because padding
+ * affects content placement inside the cell box, not the cell box
+ * itself.  Width narrowing was deliberately deferred (would require
+ * relaxing the Ubuntu fallback metric buffer locked at :3267-3307). */
+.detail-panel-pr-list-header-cell--unresolved {
+    font-weight: 500;
+    padding-right: 8px;
+    color: var(--text-tertiary, var(--text-secondary));
+}
+
 .detail-panel-pr-list-header-sort {
     appearance: none;
     background: transparent;
@@ -3515,8 +3535,15 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     opacity: 0.45;
 }
 
+/* Issue #338: visually subordinate the Unresolved data column.
+ * The previous ``font-weight: 600`` rule made Unresolved BOLDER than
+ * Threads, the opposite of the subset relation (INV-09).  Replaced
+ * with a muted color + slight right-edge indent so the per-row
+ * Unresolved value reads as "child of Threads" rather than peer.
+ * Sort affordance and column position unchanged. */
 .detail-panel-pr-list--with-comments .comments-metric--unresolved {
-    font-weight: 600;
+    color: var(--text-secondary);
+    padding-right: 8px;
 }
 
 /* Issue #331 / C2 + C3 — in-panel coverage notice.

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -5147,6 +5147,7 @@ var PRInsightsDashboard = (() => {
                 appendText(span, "\u2014");
               } else {
                 span.setAttribute("data-partial", "false");
+                span.setAttribute("data-zero", value === 0 ? "true" : "false");
                 li.setAttribute(`data-${key}`, String(value));
                 appendText(span, String(value));
               }

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -11711,23 +11711,39 @@ var PRInsightsDashboard = (() => {
     }
     row.parentElement?.removeChild(row);
   }
-  function ensureCommentsAuthorDensityContainer() {
-    const existing = document.getElementById("comments-author-density");
-    if (existing) return existing;
-    const commentsTrendRow = document.querySelector(
-      '[data-comments-trend-row="true"]'
+  function ensureCommentsDensityGrid() {
+    const existing = document.querySelector(
+      '[data-comments-density-grid="true"]'
     );
-    let anchorRow = commentsTrendRow;
+    if (existing) return existing;
+    const trendRow = document.querySelector('[data-comments-trend-row="true"]');
+    let anchorRow = trendRow;
     if (!anchorRow) {
       const cycleDist = document.getElementById("cycle-distribution");
       anchorRow = cycleDist?.closest(".charts-row") ?? null;
     }
     if (!anchorRow || !anchorRow.parentElement) return null;
-    const row = document.createElement("div");
-    row.className = "charts-row";
-    row.setAttribute("data-comments-author-density-row", "true");
+    const grid = document.createElement("div");
+    grid.className = "charts-row comments-density-grid";
+    grid.setAttribute("data-comments-density-grid", "true");
+    anchorRow.parentElement.insertBefore(grid, anchorRow.nextSibling);
+    return grid;
+  }
+  function removeCommentsDensityGridIfEmpty() {
+    const grid = document.querySelector('[data-comments-density-grid="true"]');
+    if (!grid) return;
+    if (grid.children.length === 0) {
+      grid.parentElement?.removeChild(grid);
+    }
+  }
+  function ensureCommentsAuthorDensityContainer() {
+    const existing = document.getElementById("comments-author-density");
+    if (existing) return existing;
+    const grid = ensureCommentsDensityGrid();
+    if (!grid) return null;
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
+    containerCell.setAttribute("data-comments-author-density-row", "true");
     const heading = document.createElement("h3");
     heading.textContent = "Comments by Author";
     attachChartInfoIcon(
@@ -11740,8 +11756,7 @@ var PRInsightsDashboard = (() => {
     chart.id = "comments-author-density";
     chart.className = "chart";
     containerCell.appendChild(chart);
-    row.appendChild(containerCell);
-    anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+    grid.appendChild(containerCell);
     return chart;
   }
   function removeCommentsAuthorDensityContainer() {
@@ -11754,27 +11769,16 @@ var PRInsightsDashboard = (() => {
       detachChartInfoIcon(heading);
     }
     row.parentElement?.removeChild(row);
+    removeCommentsDensityGridIfEmpty();
   }
   function ensureCommentsRepositoryDensityContainer() {
     const existing = document.getElementById("comments-repository-density");
     if (existing) return existing;
-    const perAuthorRow = document.querySelector(
-      '[data-comments-author-density-row="true"]'
-    );
-    let anchorRow = perAuthorRow;
-    if (!anchorRow) {
-      anchorRow = document.querySelector('[data-comments-trend-row="true"]');
-    }
-    if (!anchorRow) {
-      const cycleDist = document.getElementById("cycle-distribution");
-      anchorRow = cycleDist?.closest(".charts-row") ?? null;
-    }
-    if (!anchorRow || !anchorRow.parentElement) return null;
-    const row = document.createElement("div");
-    row.className = "charts-row";
-    row.setAttribute("data-comments-repository-density-row", "true");
+    const grid = ensureCommentsDensityGrid();
+    if (!grid) return null;
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
+    containerCell.setAttribute("data-comments-repository-density-row", "true");
     const heading = document.createElement("h3");
     heading.textContent = "Comments by Repository";
     attachChartInfoIcon(
@@ -11787,8 +11791,7 @@ var PRInsightsDashboard = (() => {
     chart.id = "comments-repository-density";
     chart.className = "chart";
     containerCell.appendChild(chart);
-    row.appendChild(containerCell);
-    anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+    grid.appendChild(containerCell);
     return chart;
   }
   function removeCommentsRepositoryDensityContainer() {
@@ -11801,32 +11804,16 @@ var PRInsightsDashboard = (() => {
       detachChartInfoIcon(heading);
     }
     row.parentElement?.removeChild(row);
+    removeCommentsDensityGridIfEmpty();
   }
   function ensureCommentsReviewerDensityContainer() {
     const existing = document.getElementById("comments-reviewer-density");
     if (existing) return existing;
-    const perRepoRow = document.querySelector(
-      '[data-comments-repository-density-row="true"]'
-    );
-    let anchorRow = perRepoRow;
-    if (!anchorRow) {
-      anchorRow = document.querySelector(
-        '[data-comments-author-density-row="true"]'
-      );
-    }
-    if (!anchorRow) {
-      anchorRow = document.querySelector('[data-comments-trend-row="true"]');
-    }
-    if (!anchorRow) {
-      const cycleDist = document.getElementById("cycle-distribution");
-      anchorRow = cycleDist?.closest(".charts-row") ?? null;
-    }
-    if (!anchorRow || !anchorRow.parentElement) return null;
-    const row = document.createElement("div");
-    row.className = "charts-row";
-    row.setAttribute("data-comments-reviewer-density-row", "true");
+    const grid = ensureCommentsDensityGrid();
+    if (!grid) return null;
     const containerCell = document.createElement("div");
     containerCell.className = "chart-container";
+    containerCell.setAttribute("data-comments-reviewer-density-row", "true");
     const heading = document.createElement("h3");
     heading.textContent = "Comments by Reviewer";
     attachChartInfoIcon(
@@ -11839,8 +11826,7 @@ var PRInsightsDashboard = (() => {
     chart.id = "comments-reviewer-density";
     chart.className = "chart";
     containerCell.appendChild(chart);
-    row.appendChild(containerCell);
-    anchorRow.parentElement.insertBefore(row, anchorRow.nextSibling);
+    grid.appendChild(containerCell);
     return chart;
   }
   function removeCommentsReviewerDensityContainer() {
@@ -11853,6 +11839,7 @@ var PRInsightsDashboard = (() => {
       detachChartInfoIcon(heading);
     }
     row.parentElement?.removeChild(row);
+    removeCommentsDensityGridIfEmpty();
   }
   function toArtifactLoadResult(loaderResult, artifactPath) {
     if (!loaderResult) {

--- a/src/ado_git_repo_insights/ui_bundle/styles.css
+++ b/src/ado_git_repo_insights/ui_bundle/styles.css
@@ -3502,6 +3502,19 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     opacity: 0.7;
 }
 
+/* Issue #337: zero-vs-many tonal weight on comments-metrics.
+ * Numeric zero cells render at reduced opacity so the visual contrast
+ * between "no work" and "any work" is faster to scan than reading every
+ * digit on every row.  Mutually exclusive with the
+ * ``data-partial="true"`` rule above (a span never carries both attrs)
+ * — partial italic + tertiary color keeps partial visually distinct
+ * from zero per INV-10.  Numeric ``0`` is preserved as the rendered
+ * glyph (no em-dash swap) since the partial sentinel already owns the
+ * em-dash. */
+.detail-panel-pr-list--with-comments .comments-metric[data-zero="true"] {
+    opacity: 0.45;
+}
+
 .detail-panel-pr-list--with-comments .comments-metric--unresolved {
     font-weight: 600;
 }

--- a/src/ado_git_repo_insights/ui_bundle/styles.css
+++ b/src/ado_git_repo_insights/ui_bundle/styles.css
@@ -734,6 +734,36 @@ input[type="search"]::placeholder {
     gap: 20px;
 }
 
+/* Issue #357 — comments-density panels share a single 2-up sub-grid so
+ * the per-author / per-repo / per-reviewer panels read as a coherent
+ * group rather than a four-row vertical wall.  The trend chart remains
+ * full-width on its own ``.charts-row`` above this wrapper (timeseries
+ * vs cross-section reading order), so the wrapper itself is a sibling
+ * of the trend row, NOT its parent.
+ *
+ * The wrapper carries the base ``.charts-row`` class so it inherits the
+ * 20px gap + grid baseline.  This rule overrides ONLY
+ * ``grid-template-columns`` to lock 2-up (instead of the parent's
+ * ``auto-fit, minmax(400px, 1fr)`` which would expand to 3-up at wide
+ * viewports — explicitly out of scope per the issue's "2-up reads
+ * better than 3-up cramped" verdict).  The narrow-viewport fallback
+ * below collapses to 1-up around the same breakpoint the rest of the
+ * dashboard uses for column collapse.
+ *
+ * With three children in 2 columns, the third (reviewer) lands in the
+ * bottom-left cell; the bottom-right is empty.  This is intentional —
+ * spanning reviewer would compress per-row scan-density at the only
+ * width where 2-up is actively useful. */
+.charts-row.comments-density-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 700px) {
+    .charts-row.comments-density-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
 .summary-cards {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/src/ado_git_repo_insights/ui_bundle/styles.css
+++ b/src/ado_git_repo_insights/ui_bundle/styles.css
@@ -3318,6 +3318,26 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     text-align: right;
 }
 
+/* Issue #338: visually subordinate the Unresolved header cell.
+ * Unresolved is a subset of Threads (INV-09: active_thread_count <=
+ * thread_count), so the column should weigh visually less than its
+ * parent rather than equal to it.  Two non-geometric tweaks recover
+ * the subset relation without removing the dedicated sortable column
+ * (the verdict on #338 explicitly preserved sort affordance):
+ *   - lighter header weight (500 vs the parent header's 600)
+ *   - slight content indent via padding-right so the right-aligned
+ *     label pulls inward from the column's right edge
+ * Track widths are unchanged — the geometric Playwright guard
+ * (button rect within cell rect ±0.5px) still holds because padding
+ * affects content placement inside the cell box, not the cell box
+ * itself.  Width narrowing was deliberately deferred (would require
+ * relaxing the Ubuntu fallback metric buffer locked at :3267-3307). */
+.detail-panel-pr-list-header-cell--unresolved {
+    font-weight: 500;
+    padding-right: 8px;
+    color: var(--text-tertiary, var(--text-secondary));
+}
+
 .detail-panel-pr-list-header-sort {
     appearance: none;
     background: transparent;
@@ -3515,8 +3535,15 @@ g[role="button"][data-drilldown-week]:focus-visible .line-chart-dot {
     opacity: 0.45;
 }
 
+/* Issue #338: visually subordinate the Unresolved data column.
+ * The previous ``font-weight: 600`` rule made Unresolved BOLDER than
+ * Threads, the opposite of the subset relation (INV-09).  Replaced
+ * with a muted color + slight right-edge indent so the per-row
+ * Unresolved value reads as "child of Threads" rather than peer.
+ * Sort affordance and column position unchanged. */
 .detail-panel-pr-list--with-comments .comments-metric--unresolved {
-    font-weight: 600;
+    color: var(--text-secondary);
+    padding-right: 8px;
 }
 
 /* Issue #331 / C2 + C3 — in-panel coverage notice.


### PR DESCRIPTION
## Summary

- **#337 — zero-vs-many tonal weight (drill-down)**: numeric zero cells on the comments-metrics columns now carry `data-zero="true"` and render at opacity 0.45, so the visual contrast between "no work" and "any work" is fast to scan rather than requiring the eye to read every digit on every row. Mutually exclusive with the existing `[data-partial="true"]` rule, so partial != zero stays visible per INV-10. The `0` glyph is preserved (no em-dash swap — the partial sentinel already owns `—`).
- **#338 — visually subordinate Unresolved column (drill-down)**: dropped the prior `font-weight: 600` rule that made Unresolved bolder than Threads (the opposite of the INV-09 subset relation); replaced with muted `var(--text-secondary)` on the data column, lighter `font-weight: 500` on the header cell, and 8px right-edge padding on both. Sortable column and track widths preserved (the Playwright geometric guard on the cell rect is unchanged because padding affects content, not the cell box).
- **#357 — comments-density 2-up sub-grid (dashboard)**: the per-author / per-repo / per-reviewer panels now share a single `[data-comments-density-grid="true"]` wrapper that locks 2-up via `grid-template-columns: repeat(2, minmax(0, 1fr))` and collapses to single column at `max-width: 700px`. The trend chart stays full-width on its own row above. Reduces vertical sprawl from four sequential `.charts-row` rows to two without changing what panels show, what data they read, or sort/filter behavior. New `ensureCommentsDensityGrid()` + `removeCommentsDensityGridIfEmpty()` helpers; the three density ensure/remove helpers delegate to them. Every `data-comments-X-density-row` selector still resolves to the same logical element (now a `.chart-container` cell rather than the outer `.charts-row`, but the attribute moved with it).

Atomic test contract update for #357: the three lifecycle test files (`comments-author-density-dashboard-lifecycle.test.ts`, `comments-repository-density-lifecycle.test.ts`, `comments-reviewer-density-lifecycle.test.ts`) had their test-side mirrors and source-parse `describe` blocks rewritten to lock the new helper shape; new `comments-density-subgrid-layout.test.ts` covers the wrapper itself (source-parse contracts + lifecycle scenarios). Extension test floor `.test-floor-contract.json` bumped 3062 → 3077 (+4 from #337, +11 from #357).

No aggregator, schema, or contract changes. No `docs/data/` regeneration — UI shell/bundle work only; canonical sync covers `src/ado_git_repo_insights/ui_bundle/`, `docs/` shell, and `extension/tests/fixtures/broken-docs/`.

Closes #337
Closes #338
Closes #357

## Test plan

- [x] `pnpm exec jest` on touched suites: 204/204 (drilldown), 148/148 (dashboard), 34/34 (css-contract)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint` on changed TS — clean
- [x] `pnpm run build` — bundles green
- [x] `python scripts/manage_generated_artifacts.py sync --scope all --stage` — UI bundle / docs shell / broken-docs in sync
- [x] `python scripts/run_pr_preflight.py` at HEAD — green
- [x] Pre-push gate at HEAD — green (ran via \`git push\`)
- [x] CI: lint, type-check, unit, smoke (pending)
- [x] Visual smoke on dashboard with comments capability on (light + dark, desktop + ~480px container)

Co-Authored-By: Sloppy Claude <noreply@anthropic.com>