### PR TITLE
fix(task)!: BREAKING TASK CHANGE: bump Major to 3 (cache recovery)

### DIFF
--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 3199,
+    "min_collected": 3205,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ variables:
     - group: ado-insights-secrets # Contains PAT_SECRET
 
 steps:
-    - task: ExtractPullRequests@2
+    - task: ExtractPullRequests@3
       inputs:
           organization: "MyOrg"
           projects: "Project1,Project2"

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -6999,11 +6999,11 @@ var PRInsightsDashboard = (() => {
   // ../ui/modules/ml/setup-guides.ts
   var yamlStore = /* @__PURE__ */ new Map();
   var delegatedContainers = /* @__PURE__ */ new WeakSet();
-  var PREDICTIONS_YAML = `- task: ExtractPullRequests@2
+  var PREDICTIONS_YAML = `- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enablePredictions: true`;
-  var INSIGHTS_YAML = `- task: ExtractPullRequests@2
+  var INSIGHTS_YAML = `- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enableInsights: true

--- a/docs/operations/runbook.md
+++ b/docs/operations/runbook.md
@@ -247,7 +247,7 @@ After backfill, row counts should be non-decreasing. Compare `run_summary.json` 
 ### Pipeline Broken
 
 1. Check extension is installed in organization
-2. Verify task name: `ExtractPullRequests@2`
+2. Verify task name: `ExtractPullRequests@3`
 3. Test with minimal pipeline configuration
 4. Check agent connectivity to marketplace
 

--- a/docs/reference/task-reference.md
+++ b/docs/reference/task-reference.md
@@ -1,6 +1,6 @@
 # Task Input Reference
 
-Complete reference for the `ExtractPullRequests@2` Azure DevOps pipeline task.
+Complete reference for the `ExtractPullRequests@3` Azure DevOps pipeline task.
 
 ---
 
@@ -8,7 +8,7 @@ Complete reference for the `ExtractPullRequests@2` Azure DevOps pipeline task.
 
 | Property | Value |
 |----------|-------|
-| **Task name** | `ExtractPullRequests@2` |
+| **Task name** | `ExtractPullRequests@3` |
 | **Friendly name** | Extract Pull Request Metrics |
 | **Publisher** | OddEssentials |
 
@@ -113,7 +113,7 @@ End date defaults to yesterday to avoid incomplete data — PRs closed today may
 
 **Include today's data:**
 ```yaml
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     organization: 'MyOrg'
     projects: 'Project1'
@@ -123,7 +123,7 @@ End date defaults to yesterday to avoid incomplete data — PRs closed today may
 
 **Historical extraction:**
 ```yaml
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     organization: 'MyOrg'
     projects: 'Project1'
@@ -139,7 +139,7 @@ End date defaults to yesterday to avoid incomplete data — PRs closed today may
 Re-extracts recent data to catch late changes (reviewer votes, status updates):
 
 ```yaml
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     organization: 'MyOrg'
     projects: 'Project1'
@@ -157,7 +157,7 @@ Projects can be specified multiple ways:
 
 **One per line:**
 ```yaml
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     projects: |
       Project1
@@ -167,14 +167,14 @@ Projects can be specified multiple ways:
 
 **Comma-separated:**
 ```yaml
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     projects: 'Project1,Project2,Project3'
 ```
 
 **URL-encoded names:**
 ```yaml
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     projects: |
       Project%20With%20Spaces
@@ -225,7 +225,7 @@ stages:
               targetPath: '$(Pipeline.Workspace)/data'
 
           # Extract
-          - task: ExtractPullRequests@2
+          - task: ExtractPullRequests@3
             inputs:
               organization: 'MyOrg'
               projects: |

--- a/docs/user-guide/enable-ml-features.md
+++ b/docs/user-guide/enable-ml-features.md
@@ -27,7 +27,7 @@ Predictions work out-of-the-box with **no additional dependencies**. The built-i
 Simply enable predictions - no Prophet installation needed:
 
 ```yaml
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enablePredictions: true
@@ -72,7 +72,7 @@ The system automatically detects Prophet and uses it when available, falling bac
 Add the new inputs to your pipeline YAML:
 
 ```yaml
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     organization: $(System.CollectionUri)
     projects: |
@@ -114,7 +114,7 @@ stages:
               versionSpec: '3.12'
               addToPath: true
 
-          - task: ExtractPullRequests@2
+          - task: ExtractPullRequests@3
             inputs:
               organization: $(System.CollectionUri)
               projects: |

--- a/docs/user-guide/extension.md
+++ b/docs/user-guide/extension.md
@@ -151,7 +151,7 @@ stages:
               targetPath: '$(Pipeline.Workspace)/data'
 
           # Run the extraction task
-          - task: ExtractPullRequests@2
+          - task: ExtractPullRequests@3
             displayName: 'Extract PR Metrics'
             inputs:
               organization: 'YOUR_ORG_NAME'      # CHANGE THIS
@@ -274,7 +274,7 @@ schedules:
 Add backfill on Sundays to catch late PR changes:
 
 ```yaml
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     # ... other inputs ...
     backfillDays: 60  # Re-extract last 60 days
@@ -291,7 +291,7 @@ By default, the first extraction covers PRs from January 1st of the current year
 **To extract the past year of PR history**, add date overrides to your first run:
 
 ```yaml
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     organization: 'YOUR_ORG_NAME'
     projects: 'YOUR_PROJECT_1'
@@ -325,10 +325,10 @@ maintains coverage going forward.
 ### One-line YAML change
 
 Add a second pipeline (or a separate stage) that flips the same
-`ExtractPullRequests@2` task into backfill mode:
+`ExtractPullRequests@3` task into backfill mode:
 
 ```yaml
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     organization: 'YOUR_ORG'
     pat: '$(PAT_SECRET)'
@@ -375,7 +375,7 @@ one stopped.
 Narrow what a single run covers:
 
 ```yaml
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     organization: 'YOUR_ORG'
     projects: 'ProjectA'             # single project instead of all

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -231,7 +231,7 @@ progress lines and a zero-count closing line.
 
 **Solution:**
 1. Verify extension is installed: Organization Settings → Extensions
-2. Check task name is exactly `ExtractPullRequests@2`
+2. Check task name is exactly `ExtractPullRequests@3`
 3. Ensure pipeline agent can reach the marketplace
 4. Try creating a new pipeline
 

--- a/extension-verification-test.yml
+++ b/extension-verification-test.yml
@@ -62,9 +62,10 @@ stages:
             displayName: 'Check Database Status'
 
           # Step 4: Run the extension task
-          # Task Major version: 2 (update only on BREAKING TASK CHANGE)
-          # generateAggregates defaults to true in v2.7.0+
-          - task: ExtractPullRequests@2
+          # Task Major version: 3 (bumped from 2 to force agents to refresh
+          # their task cache; previously published 2.33.2 was higher than
+          # post-stamping 2.x.y output, so agents kept the stale 2.33.2.)
+          - task: ExtractPullRequests@3
             displayName: 'Extract PR Metrics'
             inputs:
               organization: 'oddessentials'

--- a/extension/overview.md
+++ b/extension/overview.md
@@ -43,7 +43,7 @@ Explore a working dashboard with sample data: [View Live Demo](https://oddessent
 2. **Enable the Dashboard** — A project or organization administrator must go to **Project Settings > Preview Features** and turn on **[GRI] PR Insights Dashboard**.
 3. **Create a PAT** — Generate a Personal Access Token with **Code (Read)** scope in Azure DevOps.
 4. **Store the PAT** — Add the PAT to a pipeline Variable Group named `ado-insights-secrets` as a secret variable `PAT_SECRET`.
-5. **Add the Pipeline Task** — Add `ExtractPullRequests@2` to a pipeline definition (see [Pipeline Task Reference](https://github.com/oddessentials/ado-git-repo-insights/blob/main/docs/reference/task-reference.md) for all inputs).
+5. **Add the Pipeline Task** — Add `ExtractPullRequests@3` to a pipeline definition (see [Pipeline Task Reference](https://github.com/oddessentials/ado-git-repo-insights/blob/main/docs/reference/task-reference.md) for all inputs).
 6. **View the Dashboard** — After a successful pipeline run, navigate to your project's Repos menu and select **PR Insights**.
 
 ![ExtractPullRequests pipeline task configuration in Azure DevOps](screenshots/pipeline-task.png)

--- a/extension/package.json
+++ b/extension/package.json
@@ -58,6 +58,7 @@
     "@types/node": "^25.6.0",
     "@typescript-eslint/eslint-plugin": "^8.59.2",
     "@typescript-eslint/parser": "^8.59.2",
+    "azure-pipelines-task-lib": "^5.0.0",
     "dependency-cruiser": "^17.4.0",
     "esbuild": "^0.28.0",
     "eslint": "^10.3.0",

--- a/extension/pnpm-lock.yaml
+++ b/extension/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.59.2
         version: 8.59.2(eslint@10.3.0)(typescript@6.0.3)
+      azure-pipelines-task-lib:
+        specifier: ^5.0.0
+        version: 5.2.10
       dependency-cruiser:
         specifier: ^17.4.0
         version: 17.4.0
@@ -936,6 +939,14 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+    engines: {node: '>=12.0'}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1041,6 +1052,9 @@ packages:
   azure-devops-node-api@14.1.0:
     resolution: {integrity: sha512-QhpgjH1LQ+vgDJ7oBwcmsZ3+o4ZpjLVilw0D3oJQpYpRzN+L39lk5jZDLJ464hLUgsDzWn/Ksv7zLLMKLfoBzA==}
     engines: {node: '>= 16.0.0'}
+
+  azure-pipelines-task-lib@5.2.10:
+    resolution: {integrity: sha512-6Wak5UB+Bs693LkPoE4gZTDNkNL5DDn2buQKMtvqIWh2ZCIJk+tc1nSzroGWntJa7USs8X3cYvdl0RiSsp4/5A==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -1625,6 +1639,15 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -1780,6 +1803,10 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -2321,12 +2348,20 @@ packages:
     resolution: {integrity: sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
   mime-types@2.1.18:
     resolution: {integrity: sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mimic-fn@2.1.0:
@@ -2396,6 +2431,9 @@ packages:
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  nodejs-file-downloader@4.13.0:
+    resolution: {integrity: sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -2593,6 +2631,14 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
+  q@1.5.1:
+    resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
+    engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
+    deprecated: |-
+      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
+      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
+
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
@@ -2707,6 +2753,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sanitize-filename@1.6.4:
+    resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -2714,6 +2763,10 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2958,6 +3011,9 @@ packages:
     resolution: {integrity: sha512-yG3Yb4ztlE1CZHNRWcBqjRIVSCXd8fx7HvL9gvlC37tpPrG3I5skNAY3mQApWeQiw0/3m83JWbfagwOAlmP/ww==}
     engines: {node: '>= 0.10.0'}
 
+  truncate-utf8-bytes@1.0.2:
+    resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -3105,6 +3161,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  utf8-byte-length@1.0.5:
+    resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -3118,6 +3177,11 @@ packages:
 
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
+
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -4174,6 +4238,14 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adm-zip@0.5.17: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv@6.15.0:
@@ -4302,6 +4374,19 @@ snapshots:
     dependencies:
       tunnel: 0.0.6
       typed-rest-client: 2.1.0
+
+  azure-pipelines-task-lib@5.2.10:
+    dependencies:
+      adm-zip: 0.5.17
+      minimatch: 3.1.5
+      nodejs-file-downloader: 4.13.0
+      q: 1.5.1
+      semver: 5.7.2
+      shelljs: 0.10.0
+      uuid: 3.4.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   b4a@1.8.0: {}
 
@@ -4992,6 +5077,8 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  follow-redirects@1.16.0: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -5154,6 +5241,13 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -5866,11 +5960,17 @@ snapshots:
 
   mime-db@1.33.0: {}
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
 
   mime-types@2.1.18:
     dependencies:
       mime-db: 1.33.0
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mimic-fn@2.1.0: {}
 
@@ -5917,6 +6017,16 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.38: {}
+
+  nodejs-file-downloader@4.13.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      https-proxy-agent: 5.0.1
+      mime-types: 2.1.35
+      sanitize-filename: 1.6.4
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   normalize-path@3.0.0: {}
 
@@ -6096,6 +6206,8 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
+  q@1.5.1: {}
+
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
@@ -6230,11 +6342,17 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sanitize-filename@1.6.4:
+    dependencies:
+      truncate-utf8-bytes: 1.0.2
+
   sax@1.6.0: {}
 
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  semver@5.7.2: {}
 
   semver@6.3.1: {}
 
@@ -6550,6 +6668,10 @@ snapshots:
       dateformat: 1.0.11
       tinytim: 0.1.1
 
+  truncate-utf8-bytes@1.0.2:
+    dependencies:
+      utf8-byte-length: 1.0.5
+
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -6732,6 +6854,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  utf8-byte-length@1.0.5: {}
+
   util-deprecate@1.0.2: {}
 
   util.promisify@1.1.3:
@@ -6752,6 +6876,8 @@ snapshots:
   uuid@13.0.0: {}
 
   uuid@14.0.0: {}
+
+  uuid@3.4.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/extension/tasks/extract-prs/index.d.ts
+++ b/extension/tasks/extract-prs/index.d.ts
@@ -1,0 +1,33 @@
+/**
+ * Type declarations for the JavaScript task runtime in this directory.
+ *
+ * Lets TypeScript callers (notably the packaged-runtime regression test
+ * at extension/tests/extract-prs-runtime.test.ts) `import` from
+ * `index.js` without `require()` and without the suppression that
+ * `@typescript-eslint/no-require-imports` would otherwise demand.
+ *
+ * The shape mirrors module.exports in index.js exactly. Helpers are
+ * declared loosely (object / unknown) since the test only needs `run`;
+ * widening these later (precise BuildExtractArgsConfig etc.) is fine
+ * but not part of this scope.
+ */
+
+export declare function run(): Promise<void>;
+
+export declare function buildExtractArgs(config: object): readonly string[];
+export declare function buildBackfillArgs(config: object): readonly string[];
+export declare function formatProjectsForDisplay(raw: unknown): string;
+export declare function isMeaningfullySet(value: unknown): boolean;
+export declare function normalizeCommentsMaxPrsPerRunRaw(
+  mode: string,
+  includeComments: boolean,
+  raw: unknown,
+): string | null | undefined;
+export declare function validateModeInputs(
+  mode: string,
+  inputs: Record<string, unknown>,
+): { ok: true } | { ok: false; message: string };
+export declare function validateNonNegativeInt(
+  name: string,
+  raw: unknown,
+): number | null | undefined;

--- a/extension/tasks/extract-prs/index.js
+++ b/extension/tasks/extract-prs/index.js
@@ -805,6 +805,7 @@ module.exports = {
   normalizeCommentsMaxPrsPerRunRaw,
   validateModeInputs,
   validateNonNegativeInt,
+  run,
 };
 
 if (require.main === module) {

--- a/extension/tasks/extract-prs/task.json
+++ b/extension/tasks/extract-prs/task.json
@@ -7,7 +7,7 @@
     "category": "Utility",
     "author": "Odd Essentials, LLC",
     "version": {
-        "Major": 2,
+        "Major": 3,
         "Minor": 27,
         "Patch": 1
     },

--- a/extension/tests/extract-prs-runtime-real-tasklib.test.ts
+++ b/extension/tests/extract-prs-runtime-real-tasklib.test.ts
@@ -1,0 +1,372 @@
+/**
+ * @jest-environment node
+ *
+ * Real-task-lib reproducer test for ExtractPullRequests@2.
+ *
+ * The companion test (extract-prs-runtime.test.ts) jest.mocks
+ * azure-pipelines-task-lib/task entirely with a stub. That bypasses the
+ * real task-lib's env-var → vault → getInput plumbing — exactly the path
+ * the customer's pipeline log shows is failing in production
+ * (configuration banner missing `Extract Comments: true`, mode falling
+ * back to `extract` despite YAML setting `mode: backfill-comments`).
+ *
+ * This test does NOT mock task-lib. It populates `process.env.INPUT_*`
+ * with the values Azure would set when running the customer's two-step
+ * YAML, lets real task-lib's _loadData() build its vault from those
+ * env vars, then calls `run()` and asserts the actual spawn args.
+ *
+ * Failure of either case here = bug reproduced against HEAD with real
+ * task-lib. Pass = bug is NOT in this combination, and investigation
+ * needs to look at deeper differences between this harness and the
+ * actual ADO agent runtime.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+// Type-only imports for the jest.mock<typeof X> generic parameters,
+// satisfying @typescript-eslint/consistent-type-imports.
+import type * as ChildProcessNS from "child_process";
+import type * as EventsNS from "events";
+
+// ---------------------------------------------------------------------------
+// Shared mutable state on globalThis under an inline literal key — the
+// hoisted jest.mock factory below reads this without referencing any
+// module-scope identifier (which jest's hoister would reject).
+// ---------------------------------------------------------------------------
+
+interface SpawnCall {
+  cmd: string;
+  args: readonly string[];
+}
+
+interface RuntimeState {
+  spawnCalls: SpawnCall[];
+  logLines: string[];
+}
+
+const state: RuntimeState = { spawnCalls: [], logLines: [] };
+(globalThis as Record<string, unknown>)["__realTasklibTestState"] = state;
+
+// ---------------------------------------------------------------------------
+// Mock ONLY child_process — capture spawn args, no real Python. Real
+// azure-pipelines-task-lib stays in place so we exercise the env→vault
+// →getInput path that the customer's pipeline log proves is failing.
+// ---------------------------------------------------------------------------
+
+jest.mock("child_process", () => {
+  const real = jest.requireActual<typeof ChildProcessNS>("child_process");
+  const { EventEmitter } =
+    jest.requireActual<typeof EventsNS>("events");
+  const getState = (): RuntimeState =>
+    (globalThis as Record<string, unknown>)[
+      "__realTasklibTestState"
+    ] as RuntimeState;
+  return {
+    ...real,
+    spawn: (cmd: string, args: readonly string[]) => {
+      getState().spawnCalls.push({ cmd, args: [...args] });
+      const proc = new EventEmitter() as InstanceType<typeof EventEmitter> & {
+        kill: () => void;
+      };
+      proc.kill = () => undefined;
+      setImmediate(() => proc.emit("close", 0));
+      return proc;
+    },
+    execSync: (cmd: string): string => {
+      const s = String(cmd);
+      if (/--version/.test(s)) return "Python 3.12.0\n";
+      if (/import ado_git_repo_insights/.test(s)) return "";
+      if (/pip install/.test(s)) {
+        throw new Error(`pip install must not run in test; cmd=${s}`);
+      }
+      return "";
+    },
+  };
+});
+
+// Capture console output so we can assert on the configuration banner
+// strings (Extract Comments: true, Mode: backfill-comments, etc.).
+// Install per-test (NOT module-scope) so the sibling
+// extract-prs-runtime.test.ts file's console.log capture isn't
+// clobbered when both test files load in the same jest worker under
+// `pnpm test:coverage` (--runInBand).
+let realLog: typeof console.log | null = null;
+
+// ---------------------------------------------------------------------------
+// Env-var harness
+// ---------------------------------------------------------------------------
+
+/**
+ * Capture every INPUT_*, AGENT_*, SYSTEM_* env var into a Map so we can
+ * restore them after each test. Also clear them from process.env so a
+ * stray host env doesn't leak into the task-lib vault.
+ *
+ * Reflect.* is used in place of bracket-notation get/set/delete on
+ * process.env so the security/detect-object-injection rule is not
+ * triggered by dynamic-key access patterns.
+ */
+function clearAdoEnv(): Map<string, string | undefined> {
+  const backup = new Map<string, string | undefined>();
+  for (const key of Object.keys(process.env)) {
+    if (
+      key.startsWith("INPUT_") ||
+      key.startsWith("AGENT_") ||
+      key.startsWith("SYSTEM_") ||
+      key.startsWith("ENDPOINT_") ||
+      key.startsWith("SECRET_") ||
+      key.startsWith("VSTS_")
+    ) {
+      backup.set(key, Reflect.get(process.env, key) as string | undefined);
+      Reflect.deleteProperty(process.env, key);
+    }
+  }
+  return backup;
+}
+
+function restoreAdoEnv(backup: Map<string, string | undefined>): void {
+  for (const [k, v] of backup) {
+    if (v === undefined) Reflect.deleteProperty(process.env, k);
+    else Reflect.set(process.env, k, v);
+  }
+}
+
+interface TaskRuntime {
+  run: () => Promise<void>;
+}
+
+/**
+ * Load index.js with a fresh module registry so task-lib's
+ * `_loadData()` re-runs against the env vars we just set. Uses
+ * `jest.resetModules()` + dynamic `await import()` so we don't need a
+ * `require()` call (no @typescript-eslint/no-require-imports
+ * suppression needed). `jest.mock()` factories above are still honored
+ * by the dynamic import — jest hooks both require and import.
+ */
+async function loadTaskWithFreshEnv(): Promise<TaskRuntime> {
+  jest.resetModules();
+  const mod = (await import("../tasks/extract-prs/index")) as unknown;
+  return mod as TaskRuntime;
+}
+
+let workRoot: string;
+let envBackup: Map<string, string | undefined> = new Map();
+
+beforeEach(() => {
+  workRoot = fs.mkdtempSync(path.join(os.tmpdir(), "extract-prs-real-tl-"));
+  state.spawnCalls = [];
+  state.logLines = [];
+  envBackup = clearAdoEnv();
+  // task-lib uses a global flag to skip _loadData on subsequent requires
+  // (see node_modules/.../task.js:2427 `if (!global['_vsts_task_lib_loaded'])`).
+  // Clear it so loadTaskWithFreshEnv below gets a freshly-initialized vault.
+  Reflect.deleteProperty(globalThis, "_vsts_task_lib_loaded");
+  // Install console.log capture for THIS test only.
+  realLog = console.log;
+  console.log = (...args: unknown[]): void => {
+    state.logLines.push(args.map((a) => String(a)).join(" "));
+  };
+});
+
+afterEach(() => {
+  if (realLog !== null) {
+    console.log = realLog;
+    realLog = null;
+  }
+  restoreAdoEnv(envBackup);
+  fs.rmSync(workRoot, { recursive: true, force: true });
+});
+
+// Customer-equivalent multi-line projects (real ADO agent passes the
+// raw YAML block scalar with newlines preserved).
+const CUSTOMER_PROJECTS_RAW = [
+  "IT%20Payer%20Applications",
+  "Apollo",
+  "Consumer%20Technology",
+  "Core%20Systems",
+].join("\n");
+
+/**
+ * Set the env vars Azure would set when running the customer's YAML
+ * step. Names follow `INPUT_<name>` with task-lib's `_getVariableKey`
+ * transform applied (replace `.` and ` ` with `_`, then uppercase).
+ */
+function setStep1ExtractEnv(): void {
+  process.env.INPUT_ORGANIZATION = "ITPayerApplications";
+  process.env.INPUT_PROJECTS = CUSTOMER_PROJECTS_RAW;
+  process.env.INPUT_PAT = "fake-pat";
+  process.env.INPUT_DATABASE = path.join(
+    workRoot,
+    "data",
+    "ado-insights.sqlite",
+  );
+  process.env.INPUT_OUTPUTDIR = path.join(workRoot, "csv_output");
+  process.env.INPUT_AGGREGATESDIR = path.join(workRoot, "aggregates");
+  process.env.INPUT_BACKFILLDAYS = "15";
+  process.env.INPUT_INCLUDECOMMENTS = "true";
+  process.env.INPUT_MODE = "extract"; // task.json defaultValue
+  process.env.INPUT_GENERATEAGGREGATES = "true"; // task.json defaultValue
+  process.env.INPUT_COMMENTSMAXTHREADSPERPR = "50"; // task.json defaultValue
+  process.env.INPUT_ENABLEPREDICTIONS = "false";
+  process.env.INPUT_ENABLEINSIGHTS = "false";
+  // Real agent sets these so task-lib's vault path resolution works.
+  process.env.AGENT_TEMPDIRECTORY = workRoot;
+  process.env.AGENT_WORKFOLDER = workRoot;
+}
+
+function setStep2BackfillEnv(): void {
+  process.env.INPUT_ORGANIZATION = "ITPayerApplications";
+  process.env.INPUT_PROJECTS = CUSTOMER_PROJECTS_RAW;
+  process.env.INPUT_PAT = "fake-pat";
+  process.env.INPUT_DATABASE = path.join(
+    workRoot,
+    "data",
+    "ado-insights.sqlite",
+  );
+  process.env.INPUT_OUTPUTDIR = path.join(workRoot, "csv_output");
+  process.env.INPUT_AGGREGATESDIR = path.join(workRoot, "aggregates");
+  process.env.INPUT_MODE = "backfill-comments";
+  process.env.INPUT_BACKFILLLIMIT = "2500";
+  process.env.INPUT_INCLUDECOMMENTS = "false"; // task.json defaultValue
+  process.env.INPUT_GENERATEAGGREGATES = "true";
+  process.env.INPUT_COMMENTSMAXTHREADSPERPR = "50";
+  process.env.INPUT_ENABLEPREDICTIONS = "false";
+  process.env.INPUT_ENABLEINSIGHTS = "false";
+  process.env.AGENT_TEMPDIRECTORY = workRoot;
+  process.env.AGENT_WORKFOLDER = workRoot;
+}
+
+function failureContext(): string {
+  return (
+    `spawnCalls=${JSON.stringify(state.spawnCalls)}; ` +
+    `logLines=${JSON.stringify(state.logLines)}`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests — same two contracts as the mocked test, but exercising the real
+// azure-pipelines-task-lib env→vault→getInput plumbing.
+// ---------------------------------------------------------------------------
+
+describe("ExtractPullRequests@2 with REAL azure-pipelines-task-lib", () => {
+  it("Step 1 (INPUT_INCLUDECOMMENTS=true) must invoke CLI extract subcommand WITH --include-comments", async () => {
+    setStep1ExtractEnv();
+    const taskModule = await loadTaskWithFreshEnv();
+
+    await taskModule.run();
+
+    const first = state.spawnCalls[0];
+    if (first === undefined) {
+      throw new Error(`no spawn calls captured; ${failureContext()}`);
+    }
+    expect(first.args.slice(0, 3)).toEqual([
+      "-m",
+      "ado_git_repo_insights.cli",
+      "extract",
+    ]);
+    expect(first.args).toContain("--include-comments");
+    expect(
+      state.logLines.some((line) => line.includes("Extract Comments: true")),
+    ).toBe(true);
+  });
+
+  it("Step 2 (INPUT_MODE=backfill-comments) must invoke CLI backfill-comments subcommand and never route to extract", async () => {
+    setStep2BackfillEnv();
+    const taskModule = await loadTaskWithFreshEnv();
+
+    await taskModule.run();
+
+    const first = state.spawnCalls[0];
+    if (first === undefined) {
+      throw new Error(`no spawn calls captured; ${failureContext()}`);
+    }
+    expect(first.args.slice(0, 3)).toEqual([
+      "-m",
+      "ado_git_repo_insights.cli",
+      "backfill-comments",
+    ]);
+    expect(
+      state.logLines.some((line) => line.includes("Mode: backfill-comments")),
+    ).toBe(true);
+    expect(
+      state.logLines.some((line) =>
+        line.includes("Running backfill-comments..."),
+      ),
+    ).toBe(true);
+    const wronglyExtract = state.spawnCalls.find(
+      (c) => c.args[2] === "extract",
+    );
+    expect(wronglyExtract).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Negative controls — prove the customer's pipeline-log failure shape
+  // appears IFF the agent never set INPUT_INCLUDECOMMENTS / INPUT_MODE.
+  // If these tests pass, the production failure is mechanically equivalent
+  // to "those env vars are not in process.env at task startup", which
+  // narrows the next investigation step from runtime wiring (proven sound
+  // above) to whatever step in the manifest / packaging / agent-side
+  // declaration prevents Azure from setting them.
+  // -------------------------------------------------------------------------
+
+  it("Step 1 with INPUT_INCLUDECOMMENTS missing reproduces customer banner-missing shape (no `Extract Comments: true`, no `--include-comments`)", async () => {
+    setStep1ExtractEnv();
+    delete process.env.INPUT_INCLUDECOMMENTS;
+    const taskModule = await loadTaskWithFreshEnv();
+
+    await taskModule.run();
+
+    // Banner line printed only inside `if (includeComments) { ... }`.
+    expect(
+      state.logLines.some((line) => line.includes("Extract Comments: true")),
+    ).toBe(false);
+    // Spawn args must NOT contain --include-comments.
+    const first = state.spawnCalls[0];
+    if (first === undefined) {
+      throw new Error(`no spawn calls captured; ${failureContext()}`);
+    }
+    expect(first.args).not.toContain("--include-comments");
+    // Subcommand still routes to `extract` and the step succeeds — exactly
+    // what the customer's pipeline log shows for the first task.
+    expect(first.args.slice(0, 3)).toEqual([
+      "-m",
+      "ado_git_repo_insights.cli",
+      "extract",
+    ]);
+  });
+
+  it("Step 2 with INPUT_MODE and INPUT_BACKFILLLIMIT both missing reproduces customer mode-fallback shape (`Running extraction...`, no `Mode: backfill-comments`)", async () => {
+    setStep2BackfillEnv();
+    // Drop both env vars together so the test only exercises the *if-then*
+    // behavior: with neither input set, mode falls back to "extract" and
+    // backfill-mode validation has nothing to reject. This matches the
+    // customer's pipeline log shape. The reason Azure didn't set those env
+    // vars in production is OUT OF SCOPE for this test — it's the open
+    // investigation question, not an assumption this test is allowed to bake
+    // in. (An earlier attempt to attribute it to a visibleRule-syntax
+    // cascade was disproved by the existing repo invariant in
+    // tests/unit/test_task_json_semantic_invariants.py:90-108.)
+    delete process.env.INPUT_MODE;
+    delete process.env.INPUT_BACKFILLLIMIT;
+    const taskModule = await loadTaskWithFreshEnv();
+
+    await taskModule.run();
+
+    // No "Mode: backfill-comments" banner line.
+    expect(
+      state.logLines.some((line) => line.includes("Mode: backfill-comments")),
+    ).toBe(false);
+    // Step label falls back to "Running extraction..." (index.js:680-682).
+    expect(
+      state.logLines.some((line) => line.includes("Running extraction...")),
+    ).toBe(true);
+    // Subcommand falls back to `extract` — exactly what the customer's
+    // pipeline log shows for the second task.
+    const first = state.spawnCalls[0];
+    if (first === undefined) {
+      throw new Error(`no spawn calls captured; ${failureContext()}`);
+    }
+    expect(first.args[2]).toBe("extract");
+  });
+});

--- a/extension/tests/extract-prs-runtime-real-tasklib.test.ts
+++ b/extension/tests/extract-prs-runtime-real-tasklib.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  *
- * Real-task-lib reproducer test for ExtractPullRequests@2.
+ * Real-task-lib reproducer test for ExtractPullRequests@3.
  *
  * The companion test (extract-prs-runtime.test.ts) jest.mocks
  * azure-pipelines-task-lib/task entirely with a stub. That bypasses the
@@ -57,8 +57,7 @@ const state: RuntimeState = { spawnCalls: [], logLines: [] };
 
 jest.mock("child_process", () => {
   const real = jest.requireActual<typeof ChildProcessNS>("child_process");
-  const { EventEmitter } =
-    jest.requireActual<typeof EventsNS>("events");
+  const { EventEmitter } = jest.requireActual<typeof EventsNS>("events");
   const getState = (): RuntimeState =>
     (globalThis as Record<string, unknown>)[
       "__realTasklibTestState"
@@ -249,7 +248,7 @@ function failureContext(): string {
 // azure-pipelines-task-lib env→vault→getInput plumbing.
 // ---------------------------------------------------------------------------
 
-describe("ExtractPullRequests@2 with REAL azure-pipelines-task-lib", () => {
+describe("ExtractPullRequests@3 with REAL azure-pipelines-task-lib", () => {
   it("Step 1 (INPUT_INCLUDECOMMENTS=true) must invoke CLI extract subcommand WITH --include-comments", async () => {
     setStep1ExtractEnv();
     const taskModule = await loadTaskWithFreshEnv();

--- a/extension/tests/extract-prs-runtime.test.ts
+++ b/extension/tests/extract-prs-runtime.test.ts
@@ -17,33 +17,31 @@
  * Why this test exists: a customer artifact (samples/) showed
  * `pr_threads = 0` and `comments_extracted_at = 0/45,715` even though
  * their pipeline YAML enabled both code paths and ran successfully for
- * weeks. Either (a) the task wiring drops the inputs, or (b) the
- * customer's installed task version diverges from HEAD. This test
- * proves which by exercising HEAD's runtime end-to-end.
+ * weeks. This test exercises HEAD's runtime end-to-end with mocked
+ * task-lib so we lock the if-then contract: given the inputs, the
+ * wiring routes them correctly.
  *
- * Notes on packaged equivalence: stage:tasks (npm install for tfx-flat
- * node_modules) does NOT transform `index.js`, so testing source equals
- * testing the packaged runtime today. If `stage:tasks` ever bundles or
- * transpiles, this test must be updated to load the staged artifact.
+ * Module isolation: under `pnpm test:coverage` (--runInBand), this file
+ * runs in the same jest worker as the sibling
+ * extract-prs-runtime-real-tasklib.test.ts which loads the REAL
+ * task-lib via dynamic import. Module-scope `jest.mock` + module-scope
+ * `require` would race against that sibling's resolution and the mock
+ * would be bypassed in CI. Each test here therefore owns its module
+ * registry: `jest.resetModules()` clears the cache, `jest.doMock(...)`
+ * installs the mock at runtime (not hoisted), then `await import(...)`
+ * loads a fresh `index.js` that picks up the doMock'd dependencies.
  */
 
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { run } from "../tasks/extract-prs/index";
-
-// Type-only imports so the jest.mock factories can reference module
-// shapes via `typeof X` without triggering @typescript-eslint/consistent-
-// type-imports on inline `import()` type annotations.
 import type * as ChildProcessNS from "child_process";
 import type * as EventsNS from "events";
 
 // ---------------------------------------------------------------------------
-// Shared mutable state placed on globalThis (under an inline literal key)
-// so the hoisted jest.mock() factories can read it without referencing any
-// closure-captured module-scope identifier (a reference jest's hoister would
-// reject). Factories are passed by value at hoist time but only invoked when
-// the mocked module is required, by which point this assignment has run.
+// Shared mutable state on globalThis under an inline literal key. Per-test
+// jest.doMock factories read this without referencing any closure variable,
+// matching the pattern in extract-prs-runtime-real-tasklib.test.ts.
 //
 // `inputs` and `boolInputs` use Map (not Record) so dynamic-key access in
 // the factories doesn't trip security/detect-object-injection.
@@ -72,18 +70,23 @@ const state: RuntimeState = {
 
 (globalThis as Record<string, unknown>)["__extractPrsTaskMockState"] = state;
 
-// ---------------------------------------------------------------------------
-// Mock azure-pipelines-task-lib/task — every getInput / getBoolInput /
-// setResult is routed through the shared state object.
-//
-// `virtual: true` because the package only exists in
-// extension/tasks/extract-prs/node_modules (staged for VSIX), not on the
-// test's resolution path under extension/tests/.
-// ---------------------------------------------------------------------------
+interface TaskRuntime {
+  run: () => Promise<void>;
+}
 
-jest.mock(
-  "azure-pipelines-task-lib/task",
-  () => {
+/**
+ * Per-test module isolation. Resets the registry, installs the
+ * azure-pipelines-task-lib/task and child_process mocks via
+ * `jest.doMock` (runtime, not hoisted), then dynamically imports
+ * `../tasks/extract-prs/index` so it picks up the freshly-mocked
+ * dependencies. Mirrors the sibling real-task-lib test's
+ * `loadTaskWithFreshEnv` shape so both files own their module
+ * registries independently of jest's worker order.
+ */
+async function loadTaskWithMocks(): Promise<TaskRuntime> {
+  jest.resetModules();
+
+  jest.doMock("azure-pipelines-task-lib/task", () => {
     const TaskResult = { Failed: 1, Succeeded: 0 };
     const getState = (): RuntimeState =>
       (globalThis as Record<string, unknown>)[
@@ -105,60 +108,51 @@ jest.mock(
       },
       debug: (): void => undefined,
     };
-  },
-  { virtual: true },
-);
+  });
 
-// ---------------------------------------------------------------------------
-// Mock child_process — capture spawn args, no real process launches; stub
-// execSync probes used by validatePythonEnvironment / installPackage.
-// ---------------------------------------------------------------------------
+  jest.doMock("child_process", () => {
+    const real = jest.requireActual<typeof ChildProcessNS>("child_process");
+    const { EventEmitter } = jest.requireActual<typeof EventsNS>("events");
+    const getState = (): RuntimeState =>
+      (globalThis as Record<string, unknown>)[
+        "__extractPrsTaskMockState"
+      ] as RuntimeState;
+    return {
+      ...real,
+      spawn: (cmd: string, args: readonly string[]) => {
+        getState().spawnCalls.push({ cmd, args: [...args] });
+        const proc = new EventEmitter() as InstanceType<typeof EventEmitter> & {
+          kill: () => void;
+        };
+        proc.kill = () => undefined;
+        setImmediate(() => proc.emit("close", 0));
+        return proc;
+      },
+      execSync: (cmd: string): string => {
+        const s = String(cmd);
+        // validatePythonEnvironment probes "<cmd> --version 2>&1"
+        if (/--version/.test(s)) return "Python 3.12.0\n";
+        // installPackage probes "<py> -c \"import ado_git_repo_insights\""
+        if (/import ado_git_repo_insights/.test(s)) return "";
+        // A real pip install must never run inside a unit test.
+        if (/pip install/.test(s)) {
+          throw new Error(`pip install must not run in test; cmd=${s}`);
+        }
+        return "";
+      },
+    };
+  });
 
-jest.mock("child_process", () => {
-  const real = jest.requireActual<typeof ChildProcessNS>("child_process");
-  const { EventEmitter } = jest.requireActual<typeof EventsNS>("events");
-  const getState = (): RuntimeState =>
-    (globalThis as Record<string, unknown>)[
-      "__extractPrsTaskMockState"
-    ] as RuntimeState;
-  return {
-    ...real,
-    spawn: (cmd: string, args: readonly string[]) => {
-      getState().spawnCalls.push({ cmd, args: [...args] });
-      const proc = new EventEmitter() as InstanceType<typeof EventEmitter> & {
-        kill: () => void;
-      };
-      proc.kill = () => undefined;
-      setImmediate(() => proc.emit("close", 0));
-      return proc;
-    },
-    execSync: (cmd: string): string => {
-      const s = String(cmd);
-      // validatePythonEnvironment probes "<cmd> --version 2>&1"
-      if (/--version/.test(s)) return "Python 3.12.0\n";
-      // installPackage probes "<py> -c \"import ado_git_repo_insights\""
-      if (/import ado_git_repo_insights/.test(s)) return "";
-      // A real pip install must never run inside a unit test.
-      if (/pip install/.test(s)) {
-        throw new Error(`pip install must not run in test; cmd=${s}`);
-      }
-      return "";
-    },
-  };
-});
-
-// Capture console output during each test only. Module-scope override
-// would conflict with the sibling real-task-lib test file under
-// `pnpm test:coverage` (--runInBand): whichever file loaded second
-// would win and intercept the other's banners. Per-test install/restore
-// keeps each file's state.logLines isolated from sibling test files.
-let realLog: typeof console.log | null = null;
+  const mod = (await import("../tasks/extract-prs/index")) as unknown;
+  return mod as TaskRuntime;
+}
 
 // ---------------------------------------------------------------------------
 // Per-test scaffolding
 // ---------------------------------------------------------------------------
 
 let workRoot: string;
+let realLog: typeof console.log | null = null;
 
 beforeEach(() => {
   workRoot = fs.mkdtempSync(path.join(os.tmpdir(), "extract-prs-runtime-"));
@@ -167,9 +161,8 @@ beforeEach(() => {
   state.lastResult = null;
   state.logLines = [];
   state.spawnCalls = [];
-  // Install console.log capture for THIS test only (sibling test file
-  // also captures; module-scope override would race with whichever
-  // file loaded last winning).
+  // Install console.log capture for THIS test only. Module-scope override
+  // races with the sibling real-task-lib test under --runInBand.
   realLog = console.log;
   console.log = (...args: unknown[]): void => {
     state.logLines.push(args.map((a) => String(a)).join(" "));
@@ -181,9 +174,6 @@ afterEach(() => {
     console.log = realLog;
     realLog = null;
   }
-  // rmSync with force:true is a no-op on missing paths, so we don't need
-  // a separate existsSync probe (which would also trip
-  // security/detect-non-literal-fs-filename without value).
   if (workRoot) {
     fs.rmSync(workRoot, { recursive: true, force: true });
   }
@@ -241,7 +231,8 @@ describe("packaged ExtractPullRequests@3 runtime — customer YAML contract", ()
     // task.json defaultValue "true" — Azure passes through to getBoolInput.
     state.boolInputs.set("generateAggregates", true);
 
-    await run();
+    const taskModule = await loadTaskWithMocks();
+    await taskModule.run();
 
     if (state.lastResult === null || state.lastResult.result !== 0) {
       throw new Error(`expected Succeeded; ${failureContext()}`);
@@ -277,7 +268,8 @@ describe("packaged ExtractPullRequests@3 runtime — customer YAML contract", ()
     // returns false from getBoolInput; mock mirrors that by default.
     state.boolInputs.set("generateAggregates", true);
 
-    await run();
+    const taskModule = await loadTaskWithMocks();
+    await taskModule.run();
 
     if (state.lastResult === null || state.lastResult.result !== 0) {
       throw new Error(`expected Succeeded; ${failureContext()}`);

--- a/extension/tests/extract-prs-runtime.test.ts
+++ b/extension/tests/extract-prs-runtime.test.ts
@@ -1,0 +1,310 @@
+/**
+ * @jest-environment node
+ *
+ * Packaged-runtime regression test for ExtractPullRequests@2.
+ *
+ * Loads the actual shipped extension/tasks/extract-prs/index.js with
+ * azure-pipelines-task-lib and child_process mocked, then drives the
+ * customer's exact YAML inputs through `run()` and asserts:
+ *
+ *   1. Step 1 (extract with `includeComments: true`) invokes the Python
+ *      CLI with the `extract` subcommand AND the `--include-comments`
+ *      flag, and the configuration banner prints `Extract Comments: true`.
+ *   2. Step 2 (`mode: backfill-comments`) invokes the Python CLI with
+ *      the `backfill-comments` subcommand (never routes to extract) and
+ *      the configuration banner prints `Mode: backfill-comments`.
+ *
+ * Why this test exists: a customer artifact (samples/) showed
+ * `pr_threads = 0` and `comments_extracted_at = 0/45,715` even though
+ * their pipeline YAML enabled both code paths and ran successfully for
+ * weeks. Either (a) the task wiring drops the inputs, or (b) the
+ * customer's installed task version diverges from HEAD. This test
+ * proves which by exercising HEAD's runtime end-to-end.
+ *
+ * Notes on packaged equivalence: stage:tasks (npm install for tfx-flat
+ * node_modules) does NOT transform `index.js`, so testing source equals
+ * testing the packaged runtime today. If `stage:tasks` ever bundles or
+ * transpiles, this test must be updated to load the staged artifact.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { run } from "../tasks/extract-prs/index";
+
+// Type-only imports so the jest.mock factories can reference module
+// shapes via `typeof X` without triggering @typescript-eslint/consistent-
+// type-imports on inline `import()` type annotations.
+import type * as ChildProcessNS from "child_process";
+import type * as EventsNS from "events";
+
+// ---------------------------------------------------------------------------
+// Shared mutable state placed on globalThis (under an inline literal key)
+// so the hoisted jest.mock() factories can read it without referencing any
+// closure-captured module-scope identifier (a reference jest's hoister would
+// reject). Factories are passed by value at hoist time but only invoked when
+// the mocked module is required, by which point this assignment has run.
+//
+// `inputs` and `boolInputs` use Map (not Record) so dynamic-key access in
+// the factories doesn't trip security/detect-object-injection.
+// ---------------------------------------------------------------------------
+
+interface SpawnCall {
+  cmd: string;
+  args: readonly string[];
+}
+
+interface RuntimeState {
+  inputs: Map<string, string>;
+  boolInputs: Map<string, boolean>;
+  lastResult: { result: number; message: string } | null;
+  logLines: string[];
+  spawnCalls: SpawnCall[];
+}
+
+const state: RuntimeState = {
+  inputs: new Map(),
+  boolInputs: new Map(),
+  lastResult: null,
+  logLines: [],
+  spawnCalls: [],
+};
+
+(globalThis as Record<string, unknown>)["__extractPrsTaskMockState"] = state;
+
+// ---------------------------------------------------------------------------
+// Mock azure-pipelines-task-lib/task — every getInput / getBoolInput /
+// setResult is routed through the shared state object.
+//
+// `virtual: true` because the package only exists in
+// extension/tasks/extract-prs/node_modules (staged for VSIX), not on the
+// test's resolution path under extension/tests/.
+// ---------------------------------------------------------------------------
+
+jest.mock(
+  "azure-pipelines-task-lib/task",
+  () => {
+    const TaskResult = { Failed: 1, Succeeded: 0 };
+    const getState = (): RuntimeState =>
+      (globalThis as Record<string, unknown>)[
+        "__extractPrsTaskMockState"
+      ] as RuntimeState;
+    return {
+      TaskResult,
+      getInput: (name: string): string | null => {
+        const v = getState().inputs.get(name);
+        return v == null ? null : v;
+      },
+      getBoolInput: (name: string): boolean =>
+        getState().boolInputs.get(name) === true,
+      setResult: (result: number, message: string): void => {
+        const s = getState();
+        s.lastResult = { result, message };
+        const tag = result === TaskResult.Succeeded ? "Succeeded" : "Failed";
+        s.logLines.push(`[setResult ${tag}] ${message}`);
+      },
+      debug: (): void => undefined,
+    };
+  },
+  { virtual: true },
+);
+
+// ---------------------------------------------------------------------------
+// Mock child_process — capture spawn args, no real process launches; stub
+// execSync probes used by validatePythonEnvironment / installPackage.
+// ---------------------------------------------------------------------------
+
+jest.mock("child_process", () => {
+  const real = jest.requireActual<typeof ChildProcessNS>("child_process");
+  const { EventEmitter } = jest.requireActual<typeof EventsNS>("events");
+  const getState = (): RuntimeState =>
+    (globalThis as Record<string, unknown>)[
+      "__extractPrsTaskMockState"
+    ] as RuntimeState;
+  return {
+    ...real,
+    spawn: (cmd: string, args: readonly string[]) => {
+      getState().spawnCalls.push({ cmd, args: [...args] });
+      const proc = new EventEmitter() as InstanceType<typeof EventEmitter> & {
+        kill: () => void;
+      };
+      proc.kill = () => undefined;
+      setImmediate(() => proc.emit("close", 0));
+      return proc;
+    },
+    execSync: (cmd: string): string => {
+      const s = String(cmd);
+      // validatePythonEnvironment probes "<cmd> --version 2>&1"
+      if (/--version/.test(s)) return "Python 3.12.0\n";
+      // installPackage probes "<py> -c \"import ado_git_repo_insights\""
+      if (/import ado_git_repo_insights/.test(s)) return "";
+      // A real pip install must never run inside a unit test.
+      if (/pip install/.test(s)) {
+        throw new Error(`pip install must not run in test; cmd=${s}`);
+      }
+      return "";
+    },
+  };
+});
+
+// Capture console output during each test only. Module-scope override
+// would conflict with the sibling real-task-lib test file under
+// `pnpm test:coverage` (--runInBand): whichever file loaded second
+// would win and intercept the other's banners. Per-test install/restore
+// keeps each file's state.logLines isolated from sibling test files.
+let realLog: typeof console.log | null = null;
+
+// ---------------------------------------------------------------------------
+// Per-test scaffolding
+// ---------------------------------------------------------------------------
+
+let workRoot: string;
+
+beforeEach(() => {
+  workRoot = fs.mkdtempSync(path.join(os.tmpdir(), "extract-prs-runtime-"));
+  state.inputs.clear();
+  state.boolInputs.clear();
+  state.lastResult = null;
+  state.logLines = [];
+  state.spawnCalls = [];
+  // Install console.log capture for THIS test only (sibling test file
+  // also captures; module-scope override would race with whichever
+  // file loaded last winning).
+  realLog = console.log;
+  console.log = (...args: unknown[]): void => {
+    state.logLines.push(args.map((a) => String(a)).join(" "));
+  };
+});
+
+afterEach(() => {
+  if (realLog !== null) {
+    console.log = realLog;
+    realLog = null;
+  }
+  // rmSync with force:true is a no-op on missing paths, so we don't need
+  // a separate existsSync probe (which would also trip
+  // security/detect-non-literal-fs-filename without value).
+  if (workRoot) {
+    fs.rmSync(workRoot, { recursive: true, force: true });
+  }
+});
+
+// Customer-equivalent multi-line projects from samples/ pipeline YAML.
+const CUSTOMER_PROJECTS_RAW = [
+  "IT%20Payer%20Applications",
+  "Apollo",
+  "Consumer%20Technology",
+  "Core%20Systems",
+].join("\n");
+
+function commonInputs(): Record<string, string> {
+  return {
+    organization: "ITPayerApplications",
+    projects: CUSTOMER_PROJECTS_RAW,
+    pat: "fake-pat",
+    database: path.join(workRoot, "data", "ado-insights.sqlite"),
+    outputDir: path.join(workRoot, "csv_output"),
+    aggregatesDir: path.join(workRoot, "aggregates"),
+    // task.json defaultValue "50" is passed through by real task-lib even
+    // when YAML omits it; mirror that here for fidelity.
+    commentsMaxThreadsPerPr: "50",
+  };
+}
+
+function seedInputs(values: Record<string, string>): void {
+  for (const [k, v] of Object.entries(values)) {
+    state.inputs.set(k, v);
+  }
+}
+
+function failureContext(): string {
+  return (
+    `lastResult=${JSON.stringify(state.lastResult)}; ` +
+    `spawnCalls=${JSON.stringify(state.spawnCalls)}; ` +
+    `logLines=${JSON.stringify(state.logLines)}`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("packaged ExtractPullRequests@2 runtime — customer YAML contract", () => {
+  it("Step 1 (extract with includeComments: true) invokes the CLI extract subcommand WITH --include-comments", async () => {
+    seedInputs({
+      ...commonInputs(),
+      backfillDays: "15",
+      // mode unset → task.json defaultValue "extract" applies; mirror that.
+      mode: "extract",
+    });
+    state.boolInputs.set("includeComments", true);
+    // task.json defaultValue "true" — Azure passes through to getBoolInput.
+    state.boolInputs.set("generateAggregates", true);
+
+    await run();
+
+    if (state.lastResult === null || state.lastResult.result !== 0) {
+      throw new Error(`expected Succeeded; ${failureContext()}`);
+    }
+
+    // First spawn must be the CLI extract subcommand.
+    // buildExtractArgs places ['-m', CLI_MODULE, 'extract', ...] at the head.
+    const first = state.spawnCalls[0];
+    if (first === undefined) {
+      throw new Error(`no spawn calls captured; ${failureContext()}`);
+    }
+    expect(first.args.slice(0, 3)).toEqual([
+      "-m",
+      "ado_git_repo_insights.cli",
+      "extract",
+    ]);
+    expect(first.args).toContain("--include-comments");
+
+    // Configuration banner proves boolean coercion of includeComments
+    // worked (printed inside `if (includeComments) { ... }` in index.js).
+    expect(
+      state.logLines.some((line) => line.includes("Extract Comments: true")),
+    ).toBe(true);
+  });
+
+  it("Step 2 (mode: backfill-comments) invokes the CLI backfill-comments subcommand and never routes to extract", async () => {
+    seedInputs({
+      ...commonInputs(),
+      mode: "backfill-comments",
+      backfillLimit: "2500",
+    });
+    // includeComments unset (task.json default "false") — real task-lib
+    // returns false from getBoolInput; mock mirrors that by default.
+    state.boolInputs.set("generateAggregates", true);
+
+    await run();
+
+    if (state.lastResult === null || state.lastResult.result !== 0) {
+      throw new Error(`expected Succeeded; ${failureContext()}`);
+    }
+
+    const first = state.spawnCalls[0];
+    if (first === undefined) {
+      throw new Error(`no spawn calls captured; ${failureContext()}`);
+    }
+    expect(first.args.slice(0, 3)).toEqual([
+      "-m",
+      "ado_git_repo_insights.cli",
+      "backfill-comments",
+    ]);
+
+    // Mode banner proves the mode getInput was wired and the
+    // backfill-comments routing branch fired.
+    expect(
+      state.logLines.some((line) => line.includes("Mode: backfill-comments")),
+    ).toBe(true);
+
+    // Routing-correctness: no spawn should have invoked the `extract`
+    // subcommand by accident. generate-csv / generate-aggregates have
+    // distinct subcommand strings and won't false-positive here.
+    const wronglyExtract = state.spawnCalls.find(
+      (c) => c.args[2] === "extract",
+    );
+    expect(wronglyExtract).toBeUndefined();
+  });
+});

--- a/extension/tests/extract-prs-runtime.test.ts
+++ b/extension/tests/extract-prs-runtime.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  *
- * Packaged-runtime regression test for ExtractPullRequests@2.
+ * Packaged-runtime regression test for ExtractPullRequests@3.
  *
  * Loads the actual shipped extension/tasks/extract-prs/index.js with
  * azure-pipelines-task-lib and child_process mocked, then drives the
@@ -229,7 +229,7 @@ function failureContext(): string {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("packaged ExtractPullRequests@2 runtime — customer YAML contract", () => {
+describe("packaged ExtractPullRequests@3 runtime — customer YAML contract", () => {
   it("Step 1 (extract with includeComments: true) invokes the CLI extract subcommand WITH --include-comments", async () => {
     seedInputs({
       ...commonInputs(),

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -6999,11 +6999,11 @@ var PRInsightsDashboard = (() => {
   // ../ui/modules/ml/setup-guides.ts
   var yamlStore = /* @__PURE__ */ new Map();
   var delegatedContainers = /* @__PURE__ */ new WeakSet();
-  var PREDICTIONS_YAML = `- task: ExtractPullRequests@2
+  var PREDICTIONS_YAML = `- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enablePredictions: true`;
-  var INSIGHTS_YAML = `- task: ExtractPullRequests@2
+  var INSIGHTS_YAML = `- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enableInsights: true

--- a/extension/tests/modules/ml/setup-guides.test.ts
+++ b/extension/tests/modules/ml/setup-guides.test.ts
@@ -27,7 +27,7 @@ describe("setup-guides", () => {
 
     it("includes predictions YAML snippet", () => {
       const html = renderPredictionsSetupGuide();
-      expect(html).toContain("- task: ExtractPullRequests@2");
+      expect(html).toContain("- task: ExtractPullRequests@3");
       expect(html).toContain("enablePredictions: true");
       expect(html).toContain("generateAggregates: true");
     });
@@ -59,7 +59,7 @@ describe("setup-guides", () => {
 
     it("includes insights YAML snippet", () => {
       const html = renderInsightsSetupGuide();
-      expect(html).toContain("- task: ExtractPullRequests@2");
+      expect(html).toContain("- task: ExtractPullRequests@3");
       expect(html).toContain("enableInsights: true");
       expect(html).toContain("openaiApiKey: $(OPENAI_API_KEY)");
     });
@@ -452,14 +452,14 @@ describe("setup-guides", () => {
   describe("getters", () => {
     it("getPredictionsYaml returns correct YAML", () => {
       const yaml = getPredictionsYaml();
-      expect(yaml).toContain("- task: ExtractPullRequests@2");
+      expect(yaml).toContain("- task: ExtractPullRequests@3");
       expect(yaml).toContain("generateAggregates: true");
       expect(yaml).toContain("enablePredictions: true");
     });
 
     it("getInsightsYaml returns correct YAML", () => {
       const yaml = getInsightsYaml();
-      expect(yaml).toContain("- task: ExtractPullRequests@2");
+      expect(yaml).toContain("- task: ExtractPullRequests@3");
       expect(yaml).toContain("generateAggregates: true");
       expect(yaml).toContain("enableInsights: true");
       expect(yaml).toContain("openaiApiKey: $(OPENAI_API_KEY)");

--- a/extension/ui/modules/ml/setup-guides.ts
+++ b/extension/ui/modules/ml/setup-guides.ts
@@ -16,7 +16,7 @@ const delegatedContainers = new WeakSet<HTMLElement>();
 /**
  * YAML snippet for enabling predictions in ADO pipeline.
  */
-const PREDICTIONS_YAML = `- task: ExtractPullRequests@2
+const PREDICTIONS_YAML = `- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enablePredictions: true`;
@@ -24,7 +24,7 @@ const PREDICTIONS_YAML = `- task: ExtractPullRequests@2
 /**
  * YAML snippet for enabling AI insights in ADO pipeline.
  */
-const INSIGHTS_YAML = `- task: ExtractPullRequests@2
+const INSIGHTS_YAML = `- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enableInsights: true

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -6999,11 +6999,11 @@ var PRInsightsDashboard = (() => {
   // ../ui/modules/ml/setup-guides.ts
   var yamlStore = /* @__PURE__ */ new Map();
   var delegatedContainers = /* @__PURE__ */ new WeakSet();
-  var PREDICTIONS_YAML = `- task: ExtractPullRequests@2
+  var PREDICTIONS_YAML = `- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enablePredictions: true`;
-  var INSIGHTS_YAML = `- task: ExtractPullRequests@2
+  var INSIGHTS_YAML = `- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enableInsights: true

--- a/tests/unit/test_setup_guides.py
+++ b/tests/unit/test_setup_guides.py
@@ -14,19 +14,19 @@ class TestYamlSnippetGeneration:
     def test_predictions_yaml_snippet_structure(self) -> None:
         """Predictions YAML snippet should have correct structure."""
         yaml_snippet = """
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enablePredictions: true
 """.strip()
 
-        assert "- task: ExtractPullRequests@2" in yaml_snippet
+        assert "- task: ExtractPullRequests@3" in yaml_snippet
         assert "enablePredictions: true" in yaml_snippet
         assert "generateAggregates: true" in yaml_snippet
 
     def test_predictions_yaml_indentation(self) -> None:
         """Predictions YAML should use 2-space indentation under inputs."""
-        yaml_snippet = """- task: ExtractPullRequests@2
+        yaml_snippet = """- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enablePredictions: true"""
@@ -41,14 +41,14 @@ class TestYamlSnippetGeneration:
     def test_insights_yaml_snippet_structure(self) -> None:
         """Insights YAML snippet should have correct structure."""
         yaml_snippet = """
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enableInsights: true
     openaiApiKey: $(OPENAI_API_KEY)
 """.strip()
 
-        assert "- task: ExtractPullRequests@2" in yaml_snippet
+        assert "- task: ExtractPullRequests@3" in yaml_snippet
         assert "enableInsights: true" in yaml_snippet
         assert "openaiApiKey" in yaml_snippet
 
@@ -65,7 +65,7 @@ class TestYamlSnippetGeneration:
     def test_combined_yaml_snippet(self) -> None:
         """Combined YAML should enable both features."""
         yaml_snippet = """
-- task: ExtractPullRequests@2
+- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enablePredictions: true
@@ -86,7 +86,7 @@ class TestClipboardCopy:
 
     def test_copy_content_is_string(self) -> None:
         """Content to copy should be a string."""
-        content = """- task: ExtractPullRequests@2
+        content = """- task: ExtractPullRequests@3
   inputs:
     generateAggregates: true
     enablePredictions: true"""


### PR DESCRIPTION
## Summary

- **Root cause:** Customer pipelines pinned to `ExtractPullRequests@2` are running an older cached task version (`2.33.2`) than the marketplace currently serves (`2.27.1`). The pre-Apr-1 marketplace had published task `2.33.2`; the major-bump dance (`3892925a` → `fdc8b870`) reset task version to `2.0.0` and let `stamp-extension-version.cjs` climb back up. Azure resolves `@2` by picking the highest installed task with `Major=2`, so agents with cached `2.33.2` keep using its older `task.json` — which doesn't declare `includeComments` or `mode`. Result: the customer's pipeline log shows the configuration banner missing `Extract Comments: true` and step 2 falling back to extract instead of `Running backfill-comments`, even though their YAML is correct and the marketplace publish is current.
- **Fix:** Bump `extension/tasks/extract-prs/task.json` `Major: 2 → 3`. Azure cannot compare `3.x.y > 2.33.2`, so once a customer updates their YAML to `ExtractPullRequests@3` they are guaranteed to pick up the freshly-published task code regardless of any cached prior `2.x` versions. `scripts/stamp-extension-version.cjs:154-161` reads `task.version.Major` dynamically, so semantic-release will preserve `Major: 3` on every subsequent release.
- **Customer-facing references** updated `@2 → @3`: `README.md`, `extension/overview.md` (marketplace listing), `docs/user-guide/{extension,enable-ml-features,troubleshooting}.md`, `docs/reference/task-reference.md`, `docs/operations/runbook.md`, `extension/ui/modules/ml/setup-guides.ts` (Settings UI YAML snippets), `extension-verification-test.yml`. Generated UI mirrors (`docs/dashboard.js`, `src/ado_git_repo_insights/ui_bundle/dashboard.js`, `extension/tests/fixtures/broken-docs/dashboard.js`) auto-synced by the pre-commit managed-artifact hook. `CHANGELOG.md:508` left as historical record.
- **Guardrail tests** (commit `3f301baa`): two new files prove the runtime contract end-to-end. `extract-prs-runtime.test.ts` is a fast logic-only check with mocked task-lib + child_process; `extract-prs-runtime-real-tasklib.test.ts` does NOT mock task-lib — it sets `process.env.INPUT_*` to mirror what Azure passes under the customer's YAML, lets the real `azure-pipelines-task-lib` vault load, and asserts the spawn args contain `--include-comments` and `backfill-comments`. Negative-control cases delete those env vars and reproduce the customer's exact failure shape, locking the *if-then* contract: when the agent provides the inputs, our wiring routes them correctly; when it doesn't, this is the failure mode you'll see. `azure-pipelines-task-lib` added to `extension/package.json` devDependencies so CI can resolve the real package without staging task deps.

## Test plan

- [ ] CI green on this PR.
- [ ] Verify the published `101.x.y` extension contains task version `3.x.y` (not `2.x.y`) — check the marketplace listing or `gh release view` after merge.
- [ ] Customer reruns their unmodified two-step YAML *after* updating from `ExtractPullRequests@2` to `ExtractPullRequests@3`. Pipeline log must show:
    - `Downloading task: ExtractPullRequests (3.x.x)`
    - `Extract Comments: true` in the configuration banner of step 1
    - `Mode: backfill-comments` and `[1/3] Running backfill-comments...` in step 2
- [ ] Customer's database state after the post-fix run:
    - `comments_extraction_metadata` gains rows
    - `pr_threads` count > 0
    - `pull_requests.comments_extracted_at IS NOT NULL` count grows on each subsequent run as backfill drains historical PRs
    - Manifest flips: `capabilities.comments_metrics: true`, `coverage.comments.status: "partial"` (transitioning to `"full"` as backfill completes)
- [ ] Internal verification pipeline (`extension-verification-test.yml`) executes against `ExtractPullRequests@3` after marketplace publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — signed off as Sloppy Claude