### PR TITLE
docs: streamline onboarding and development guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,278 +1,86 @@
 # Contributing to ADO Git Repo Insights
 
-Thank you for your interest in contributing! This document covers the essential guidelines.
+Thanks for contributing. This document covers PR workflow and commit conventions; environment setup lives in [`docs/development/setup.md`](docs/development/setup.md).
 
 ---
 
-## Required Tools
+## Setup
 
-| Tool | Version | Windows | macOS/Linux |
-|------|---------|---------|-------------|
-| Git (with Git Bash) | any | [git-scm.com](https://git-scm.com/download/win) | Package manager |
-| Python | >= 3.12 | [python.org](https://python.org) (includes `py` launcher) | Package manager |
-| Node.js | 22 | [nodejs.org](https://nodejs.org) | Package manager |
-| pnpm | 9.15.0 | `corepack enable` | `corepack enable` |
-| unzip | any | not required (test uses PowerShell) | Package manager (`apt install unzip`); pre-installed on macOS. Required by the VSIX-artifact inspection test. |
+**Recommended**: open the repo in a [Dev Container](.devcontainer/). It handles every per-platform tooling concern automatically.
 
-**Windows note:** Git for Windows must include Git Bash (provides `sh` for
-Husky hooks). Python for Windows includes the `py` launcher, which is the
-primary Python resolution mechanism on Windows.
-
-## Quick Start
-
-See [Development Setup Guide](docs/development/setup.md#quick-setup) for the full
-environment bootstrap (uv-managed Python 3.12, root + extension Node deps, Husky
-hooks, Playwright browsers). In brief:
-
-```bash
-git clone https://github.com/oddessentials/ado-git-repo-insights.git
-cd ado-git-repo-insights
-pnpm install                 # activates Husky; MUST be first
-uv python install 3.12       # canonical interpreter for CI-hard gates
-uv sync --extra dev          # project venv + Python dev deps
-cd extension && pnpm install # extension deps + Playwright browsers
-```
+**Native setup (advanced)**: see [`docs/development/setup.md`](docs/development/setup.md).
 
 ---
 
-## Running Tests
+## Pull Requests
 
-```bash
-# Python (use the launcher — it isolates coverage paths on all platforms)
-python scripts/run_pytest.py
+1. Branch from `main`.
+2. Write tests for new behavior.
+3. Run the authoritative local PR preflight before pushing:
+   ```bash
+   python scripts/run_pr_preflight.py
+   ```
+   Pre-push hooks invoke this automatically; run it standalone when pushing from an environment that skips hooks.
+4. Keep PRs focused — one feature or fix per PR.
+5. Update docs only when behavior changes.
 
-# Python with arguments
-python scripts/run_pytest.py tests/unit/ -v
-python scripts/run_pytest.py -k test_foo
+### Documentation drift prevention
 
-# Extension
-cd extension && pnpm test
+Don't hardcode counts, line numbers, or matrix dimensions that derive from a source of truth elsewhere. Describe the property and link to the authoritative file. Prerequisite versions a user must install (Node 22, Python 3.12) are fine to state directly — they're actionable, not derived.
 
-# Authoritative local PR gate
-python scripts/run_pr_preflight.py
+### Test floor & coverage thresholds
 
-# High-confidence CI parity for supported Python versions
-python scripts/run_ci_parity.py
+- Adding tests requires bumping the matching suite in [`.test-floor-contract.json`](.test-floor-contract.json) **in the same commit**.
+- Changing a coverage threshold (`pyproject.toml::fail_under` or any `extension/jest.config.ts` threshold) requires `[threshold-update]` in the commit subject.
+- Bypass markers `[ratchet-realignment]` and `[ratchet-test-removal]` apply to Python only.
+- Full workflow & recovery decision tree: [`docs/development/ratchets.md`](docs/development/ratchets.md).
 
-# Deeper parity with isolated per-version environments
-python scripts/run_ci_parity.py --mode full
-```
+### CI
 
-`run_pytest.py` isolates coverage paths to avoid Windows repo-root lock
-issues. See [Testing Guide](docs/development/testing.md#running-tests)
-for the full rationale and when to use bare `pytest` instead.
-
-`run_pr_preflight.py` resolves Python 3.12 explicitly, so it stays on a
-supported baseline interpreter even if your shell default points elsewhere.
-It is authoritative by default: if CI-hard local tooling such as Node-backed
-extension gates or `gitleaks` is unavailable, the command fails instead of
-silently degrading. Use `--allow-local-degraded` only for diagnostics on a
-broken workstation. Pre-push hooks invoke the preflight automatically; run
-it standalone when pushing from an environment that skips hooks.
-
-**Detailed testing:** [Testing Guide](docs/development/testing.md)
+All PRs pass the gates declared in [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Local equivalents and the gate-by-gate parity contract: [`LOCAL_CI_PARITY_INVARIANTS.md`](LOCAL_CI_PARITY_INVARIANTS.md).
 
 ---
 
-## Pull Request Guidelines
+## Commit messages
 
-1. **Create a feature branch** from `main`
-2. **Write tests** for new functionality
-3. **Run the full test suite** before submitting
-4. **Keep PRs focused** — one feature or fix per PR
-5. **Update documentation** if behavior changes
+Follow [Conventional Commits](https://www.conventionalcommits.org/): `<type>(<scope>): <description>`.
 
-### Documentation Drift Prevention
-
-When updating docs, never hardcode values that are derived from a source of truth
-elsewhere. Hardcoded counts, line numbers, and matrix dimensions rot silently.
-
-| Instead of | Do this |
-|------------|---------|
-| Counting items ("26 invariants") | Describe the property; the linked file has the count |
-| Line number references ("line 245") | Name the function or code block; lines shift on every edit |
-| Derived totals ("9 OS/version combos") | Describe the property + link to source ("see CI workflow") |
-| Enumerating volatile lists ("ruff, mypy, ...") | Point to the authoritative script or config |
-
-Prerequisite versions users must install (Node.js 22, Python 3.12+) are fine to state
-directly — they are actionable requirements, not derived counts.
-
-### Test-Count Floor & Coverage Thresholds
-
-Adding tests requires bumping the matching suite in `.test-floor-contract.json`
-in the same commit. Changing a coverage threshold (`pyproject.toml::fail_under`
-or any `extension/jest.config.ts` threshold, global or per-file) requires
-`[threshold-update]` in the commit subject. Bypass markers for test-count drift
-(`[ratchet-realignment]`, `[ratchet-test-removal]`) apply to Python only —
-extension drift has no marker escape. See
-[docs/development/ratchets.md](docs/development/ratchets.md) for the full
-workflow, recovery decision tree, and the partial-branches baseline gate.
-
-### CI Checks
-
-All PRs must pass the discrete CI jobs declared in
-[`.github/workflows/ci.yml`](/.github/workflows/ci.yml). The workflow is the
-source of truth; the list is intentionally not enumerated here to avoid drift.
-Gate families that land on PRs include:
-
-- Security scanning (e.g. gitleaks)
-- Repository policy gates (line endings, pnpm lockfile, UI bundle parity,
-  invariant guards, version guards, commitlint, etc.)
-- Python tests across the OS/Python matrix declared in the workflow
-- Extension tests (Jest, type-tests, smoke)
-- Lint/format/suppression audits (one CI step invokes `pre-commit run
-  --all-files` alongside standalone jobs)
-- Release packaging checks
-
-CI enforces each of these as a **separate job**, not as a single "pre-commit"
-step. To reproduce a given failure locally, look up the failing job name in
-the workflow and run its documented local equivalent -- some map to
-`pre-commit run --all-files --hook-stage pre-push`, others to `python
-scripts/run_repo_hook.py pre-push`, and the authoritative full check is
-`python scripts/run_pr_preflight.py`. See
-[`LOCAL_CI_PARITY_INVARIANTS.md`](/LOCAL_CI_PARITY_INVARIANTS.md) for the
-gate-by-gate parity contract.
-
----
-
-## Commit Messages
-
-This project uses [Conventional Commits](https://www.conventionalcommits.org/):
-
-```
-<type>(<scope>): <description>
-```
-
-### Types
-
-| Type | Purpose | Version Bump |
+| Type | Purpose | Version bump |
 |------|---------|--------------|
-| `feat` | New feature | Minor |
-| `fix` | Bug fix | Patch |
-| `docs` | Documentation only | None |
-| `test` | Adding/updating tests | None |
-| `chore` | Maintenance | None |
-| `refactor` | Code changes (no behavior change) | None |
-| `perf` | Performance improvements | Patch |
-| `ci` | CI/CD changes | None |
+| `feat` | New feature | minor |
+| `fix` | Bug fix | patch |
+| `perf` | Performance | patch |
+| `docs` / `test` / `chore` / `refactor` / `ci` | n/a | none |
 
-### Breaking Changes
+**Breaking changes**: `feat!:` (or `fix!:`) AND `BREAKING CHANGE:` in the body.
 
-Add `BREAKING CHANGE:` in body or `!` after type:
-
-```
-feat(api)!: change response format
-
-BREAKING CHANGE: The API now returns dates in ISO 8601 format.
-```
-
-### Task Version Changes
-
-Changes to the Azure DevOps task Major version require special approval. Include `BREAKING TASK CHANGE:` in the PR title or commit message.
+**ADO task major-version bumps**: include `BREAKING TASK CHANGE:` in the PR title or commit message.
 
 ---
 
-## Generated UI And Demo Artifacts
+## Generated artifacts
 
-The dashboard UI exists in two locations that must stay synchronized:
-- `extension/ui/` — Source of truth
-- `src/ado_git_repo_insights/ui_bundle/` — Copy for pip package
-
-Additional published/demo mirrors are also managed:
-- `docs/` — published demo shell and built UI assets
-- `extension/tests/fixtures/broken-docs/` — broken-docs fixture shell/assets
-
-**Always edit `extension/ui/`** and use the managed artifact sync before committing:
+The dashboard UI lives in two synced locations: `extension/ui/` (source of truth) and `src/ado_git_repo_insights/ui_bundle/` (pip package). Always edit `extension/ui/`; sync with:
 
 ```bash
 python scripts/manage_generated_artifacts.py sync --scope ui
 git add extension/ui/ src/ado_git_repo_insights/ui_bundle/
 ```
 
-If your change affects the published demo or you want the full generated surface
-refreshed explicitly:
-
-```bash
-python scripts/manage_generated_artifacts.py sync --scope all
-```
-
-To run the repo-owned hooks directly:
-
-```bash
-python scripts/run_repo_hook.py pre-commit
-python scripts/run_repo_hook.py pre-push
-
-# Optional: strict preflight with explicit base ref (hook runs non-strict by default)
-BASE_REF=main python scripts/run_pr_preflight.py --strict
-```
-
-**Details:** [UI Bundle Sync Guide](docs/development/ui-bundle-sync.md)
-
----
-
-## Line Endings
-
-This repo uses LF line endings. Configure Git:
-
-```bash
-git config core.autocrlf false
-```
-
----
-
-## Architecture Notes
-
-### Dataset Contract
-
-Changes to the dataset schema require:
-1. Version bump in manifest
-2. Update to schema documentation
-3. Backward compatibility consideration
-
-**Details:** [Dataset Contract](docs/reference/dataset-contract.md)
-
-### ML Features
-
-ML features are optional and gated behind `[ml]`:
-
-```bash
-pip install ado-git-repo-insights[ml]
-```
-
-The base package must function without ML dependencies.
-
----
-
-## Development Documentation
-
-| Document | Description |
-|----------|-------------|
-| [Development Setup](docs/development/setup.md) | Environment setup |
-| [Testing Guide](docs/development/testing.md) | Test organization and patterns |
-| [UI Bundle Sync](docs/development/ui-bundle-sync.md) | Dashboard synchronization |
+Details: [`docs/development/ui-bundle-sync.md`](docs/development/ui-bundle-sync.md).
 
 ---
 
 ## Governance
 
-Internal development principles (for agents and maintainers):
-
-| Document | Description |
-|----------|-------------|
-| [Invariants](agents/INVARIANTS.md) | Non-negotiable system invariants |
-| [Definition of Done](agents/definition-of-done.md) | Completion criteria |
-| [Verification Gates](agents/definition-of-done.md#end-to-end-verification-gates) | Verification checkpoints |
-
-**How to use these docs:** Invariants are organized by category (Output
-Contract, Persistence, Extraction, etc.) — read the category that matches
-your change area. Definition of Done maps each category to its evidence
-(test files and CI gates), so use it to find which tests cover your change.
-Victory Gates is the end-to-end verification checklist to run before
-declaring a feature complete.
+- [`agents/INVARIANTS.md`](agents/INVARIANTS.md) — system invariants, organized by category
+- [`agents/definition-of-done.md`](agents/definition-of-done.md) — completion criteria
+- [`LOCAL_CI_PARITY_INVARIANTS.md`](LOCAL_CI_PARITY_INVARIANTS.md) — gate-by-gate parity contract
 
 ---
 
 ## Questions?
 
-- Check existing [GitHub Issues](https://github.com/oddessentials/ado-git-repo-insights/issues)
-- Open a new issue with the `question` label
+- Existing issues: [GitHub Issues](https://github.com/oddessentials/ado-git-repo-insights/issues)
+- Open a new issue with the `question` label.
+</content>

--- a/README.md
+++ b/README.md
@@ -199,18 +199,9 @@ The dashboard supports optional ML-powered features: **time-series forecasting**
 
 ## 🛠️ Developer Setup
 
-Prerequisites: Node.js 22+, Python 3.12+, pnpm (extension only).
-
-```bash
-# Python (uv-managed)
-uv sync --extra dev
-
-# Extension (pnpm)
-corepack enable
-cd extension && pnpm install && pnpm run build
-```
-
-For full setup, contribution workflow, and quality gates: [Contributing Guide](CONTRIBUTING.md) and [Development Setup](docs/development/setup.md). For the canonical demo build, see [Demo Data Versioning](docs/DEMO-DATA-VERSIONING.md).
+- **Recommended**: open in a [Dev Container](.devcontainer/) — handles all per-platform tooling automatically.
+- **Native setup (advanced)**: [`docs/development/setup.md`](docs/development/setup.md).
+- **Contributing**: [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 

--- a/docs/development/ratchets.md
+++ b/docs/development/ratchets.md
@@ -2,17 +2,7 @@
 
 # Ratchets
 
-How the test-count and coverage-threshold gates work, how to update them, and how to recover when one fails.
-
-> **CI is authoritative. Local success does not prove CI correctness.**
-> Thresholds and floors are computed on the canonical CI leg. If CI disagrees
-> with your local run, trust CI and re-compute against the canonical leg before
-> filing a ratchet change.
-
-> **TypeScript test-count drift does NOT accept marker waivers.**
-> `[ratchet-realignment]` and `[ratchet-test-removal]` apply to the Python
-> suite only. For extension drift, re-measure and bump the floor directly —
-> there is no marker escape. See [Recovery](#recovery) for why.
+How the test-count and coverage-threshold gates work, how to update them, and how to recover when one fails. Gate-by-gate authority lives in [`LOCAL_CI_PARITY_INVARIANTS.md`](/LOCAL_CI_PARITY_INVARIANTS.md) (rows 25, 26, 27, 27a, 32); this doc is the contributor workflow for those gates.
 
 ---
 
@@ -28,23 +18,13 @@ How the test-count and coverage-threshold gates work, how to update them, and ho
 
 ## Markers
 
-| Marker | What it waives | Gate that honors it | Applies to |
-|---|---|---|---|
-| `[threshold-update]` | Coverage threshold value change | [`threshold-change-guard`](/.github/workflows/ci.yml) + [`scripts/check_threshold_changes.py`](/scripts/check_threshold_changes.py) | Python + TypeScript, global and per-file alike |
-| `[ratchet-realignment]` | Test-count floor jumped past the test-add delta (catching up historical drift) | [`ratchet-bump-guard`](/.github/workflows/ci.yml) via [`scripts/check_ratchet_bump.py`](/scripts/check_ratchet_bump.py) | **Python only** — Extension equality drift is never waived |
-| `[ratchet-test-removal]` | Test-count floor decreased intentionally | `ratchet-bump-guard` | **Python only** |
+| Marker | What it waives | Applies to |
+|---|---|---|
+| `[threshold-update]` | Coverage threshold value change | Python + TypeScript, global and per-file alike |
+| `[ratchet-realignment]` | Test-count floor jumped past the test-add delta (catching up historical drift) | **Python only** — Extension equality drift is never waived |
+| `[ratchet-test-removal]` | Test-count floor decreased intentionally | **Python only** |
 
-**Placement rules for every marker above:**
-
-- Must appear in a commit **subject line** within the PR's base-to-head range.
-  Scanned via `git log --oneline`; markers placed in commit bodies are NOT honored.
-- Marker scope is commit-local. `[ratchet-realignment]` on a later commit does
-  not retroactively cover an earlier un-marked commit, because the gate walks
-  first-parent history and checks each commit against its parent.
-
-Governance: [`LOCAL_CI_PARITY_INVARIANTS.md`](/LOCAL_CI_PARITY_INVARIANTS.md)
-Rows 25 (`threshold-change-guard`), 26/27 (test count), 27a (`ratchet-bump-guard`),
-32 (coverage-delta) own the full gate contracts.
+**Placement**: must appear in a commit **subject line** within the PR's base-to-head range. Markers in commit bodies are NOT honored. Marker scope is commit-local — a marker on a later commit does not retroactively cover an earlier un-marked commit.
 
 ---
 
@@ -52,100 +32,48 @@ Rows 25 (`threshold-change-guard`), 26/27 (test count), 27a (`ratchet-bump-guard
 
 ### Python
 
-1. Measure the authoritative floor on any OS:
+```bash
+python scripts/check_ratchet_bump.py --base-ref origin/main --junit-extension extension/test-results.xml
+```
 
-    ```
-    python scripts/check_ratchet_bump.py --base-ref origin/main --junit-extension extension/test-results.xml
-    ```
+The output line `actual=N (cross-platform (Windows-filtered))` is the correct floor regardless of the developer's OS. A bare `pytest --collect-only` on Windows over-reports by the platform-conditional delta and is not a valid measurement.
 
-    The output line `actual=N (cross-platform (Windows-filtered))` is the
-    correct floor regardless of the developer's OS. A bare
-    `pytest --collect-only` on Windows over-reports by the platform-conditional
-    delta and is not a valid measurement.
-
-2. Update `python.min_collected` in the test-floor contract to `N`.
-3. Stage the test additions and the contract bump in the same commit.
+Update `python.min_collected` in the test-floor contract to `N` and stage with the test additions.
 
 ### TypeScript
 
-1. Produce the canonical JUnit artifact:
+```bash
+cd extension && pnpm test:coverage          # writes extension/test-results.xml
+cd .. && python scripts/check_ratchet_bump.py --base-ref origin/main --junit-extension extension/test-results.xml
+```
 
-    ```
-    cd extension && pnpm test:coverage
-    ```
-
-    `pnpm test:coverage` is the minimum command — it enables `--reporters=jest-junit`
-    which writes `extension/test-results.xml`. `pnpm test:ci` also works but
-    additionally runs partial-branches, smoke, and format checks you may not
-    want in the same step.
-
-2. Run the ratchet gate (step 1 of the Python flow) to print the authoritative
-   extension count.
-3. Update `extension.min_collected` in the test-floor contract.
-4. Stage together.
+Update `extension.min_collected` in the test-floor contract to the printed count and stage together.
 
 ### Python-only contributors
 
-The ratchet-bump gate always reads `extension/test-results.xml`, even when
-your change touches no TypeScript. Run `cd extension && pnpm test:coverage`
-once to populate that file, or the gate exits with a SETUP error complaining
-about a missing or stale JUnit artifact.
+The ratchet-bump gate always reads `extension/test-results.xml` even when your change touches no TypeScript. Run `cd extension && pnpm test:coverage` once to populate that file, or the gate exits with SETUP.
 
 ---
 
 ## I changed a coverage threshold
 
-1. Compute the new threshold from actual coverage on the canonical leg
-   (see [Canonical env](#canonical-env)):
-   `threshold = floor(actual − 2.0)`.
-2. Edit the threshold at source (see the [Source of truth](#source-of-truth)
-   table) — Python via `pyproject.toml` → `fail_under`, TypeScript via
-   `extension/jest.config.ts` (global `coverageThreshold` or any per-file
-   key).
-3. Add `[threshold-update]` to a commit subject line in the PR.
+1. Compute the new threshold from actual coverage on the [canonical env](#canonical-env): `threshold = floor(actual − 2.0)`.
+2. Edit the threshold at source — Python via `pyproject.toml::fail_under`, TypeScript via `extension/jest.config.ts` (global `coverageThreshold` or any per-file key).
+3. Add `[threshold-update]` to a commit subject line.
 
-**Per-file thresholds are enforced identically to globals.** Bumping
-`ui/modules/ml.ts`, `ui/artifact-client.ts`, or any other per-file entry
-requires the same marker — the threshold-change-guard's regex matches indented
-per-file values exactly the same way as the top-level global.
-
-The following extension modules currently carry per-file thresholds, set
-1–2% below their current coverage to allow minor fluctuation:
-
-- `ui/schemas/types.ts`, `ui/schemas/errors.ts`, `ui/schemas/rollup.schema.ts`
-- `ui/dataset-loader.ts`
-- `ui/error-codes.ts`, `ui/error-types.ts`
-- `ui/modules/ml.ts`
-- `ui/artifact-client.ts`
-- `ui/modules/shared/security.ts`
-
-Authoritative per-metric values (statements / branches / functions / lines)
-live in [`extension/jest.config.ts`](/extension/jest.config.ts). Excluded
-from coverage requirements: barrel/index re-export files, TypeScript type
-declarations, and DOM-heavy entry points (`dashboard.ts`, `settings.ts`)
-that need browser integration tests rather than unit coverage.
+Per-file thresholds are enforced identically to globals. Authoritative per-metric values (statements / branches / functions / lines) live in [`extension/jest.config.ts`](/extension/jest.config.ts).
 
 ---
 
 ## Partial branches (different model)
 
-Extension-only. Not marker-waivable. Not a floor — a strict **baseline co-change**
-contract.
+Extension-only. Not marker-waivable. Not a floor — a strict **baseline co-change** contract.
 
-**Both directions fail the gate.** A count increase is a regression
-(`COVERAGE_REGRESSION`). A count decrease also fails (`BASELINE_COCHANGE_REQUIRED`)
-because the baseline must move downward in the same commit that drove the count
-down. "Lowering is good" is not how this gate works — the baseline tracks strict
-per-file equality, not an upper bound.
+**Both directions fail the gate.** A count increase is a regression (`COVERAGE_REGRESSION`). A count decrease also fails (`BASELINE_COCHANGE_REQUIRED`) because the baseline must move downward in the same commit that drove the count down.
 
-**Several files are locked at zero forever** via `LOCKED_ZERO_FILES` in
-[`scripts/check_partial_branches.py`](/scripts/check_partial_branches.py).
-Any non-zero baseline entry for those paths is rejected with `SETUP`. To recover
-from a locked-file regression, drive the partial-branch count back to zero —
-no marker exists.
+**Several files are locked at zero forever** via `LOCKED_ZERO_FILES` in [`scripts/check_partial_branches.py`](/scripts/check_partial_branches.py). Any non-zero baseline entry for those paths is rejected. To recover from a locked-file regression, drive the partial-branch count back to zero — no marker exists.
 
-When the gate fails it prints the exact JSON patch to apply to the baseline file.
-Copy it in verbatim and stage in the same commit as the code change.
+When the gate fails it prints the exact JSON patch to apply to the baseline. Copy it verbatim and stage in the same commit as the code change.
 
 ---
 
@@ -153,82 +81,32 @@ Copy it in verbatim and stage in the same commit as the code change.
 
 ### Python test-count drift
 
-The drift direction determines the fix, and the commit's push state determines
-whether a marker is needed.
-
 | State | Fix |
 |---|---|
-| Drift introduced on **HEAD**, not yet pushed | Update the contract and `git commit --amend` |
-| Drift introduced **earlier** in the branch, not yet pushed | `git commit --fixup=<sha>` with the fix, then `git rebase -i --autosquash origin/main` |
+| Drift introduced on **HEAD**, not yet pushed | Update contract and `git commit --amend` |
+| Drift introduced **earlier** in the branch, not yet pushed | `git commit --fixup=<sha>`, then `git rebase -i --autosquash origin/main` |
 | Drift-introducing commit **already pushed** | New commit with `[ratchet-realignment]` (catch-up bump) or `[ratchet-test-removal]` (intentional reduction) in the subject |
-
-A follow-up commit without a marker does **not** retroactively waive an
-earlier commit's drift. Marker scope is per-commit first-parent.
 
 ### Extension test-count drift
 
-One path:
-
-1. `cd extension && pnpm test:coverage` — refresh `extension/test-results.xml`.
-2. `python scripts/check_ratchet_bump.py --base-ref origin/main --junit-extension extension/test-results.xml` —
-   prints the authoritative extension count.
-3. Update the `extension.min_collected` key in the test-floor contract to
-   that count; stage with the code change that caused the drift.
-
-Markers are ignored for extension drift because `extension/test-results.xml`
-is not tracked in git, so per-commit historical snapshots cannot be
-materialized.
+`cd extension && pnpm test:coverage` to refresh the JUnit, then re-measure with `check_ratchet_bump.py` and update `extension.min_collected`. Markers don't apply — `extension/test-results.xml` is not tracked in git so per-commit historical snapshots cannot be materialized.
 
 ### Partial-branches regression or co-change required
 
-Regenerate the Jest LCOV artifact first (`cd extension && pnpm test:coverage`)
-so `extension/coverage/lcov.info` reflects HEAD, then run
-`cd extension && pnpm test:partial-branches`. Apply the printed JSON patch
-to the baseline. Stage in the same commit. For locked-zero files, drive the
-count to zero instead of raising the baseline.
+`cd extension && pnpm test:coverage && pnpm test:partial-branches`. Apply the printed JSON patch to the baseline. For locked-zero files, drive the count to zero instead.
 
 ### Coverage threshold drift
 
-Recompute the threshold on the canonical leg (`floor(actual − 2.0)`) and add
-`[threshold-update]` to the commit subject.
-
----
-
-## Two floor scripts, distinct jobs
-
-| Script | What it checks | When it runs | Marker |
-|---|---|---|---|
-| [`scripts/check_test_floor_contract.py`](/scripts/check_test_floor_contract.py) | HEAD snapshot equals the test-floor contract (Python + Extension) | Preflight, CI | — always factual; not marker-waivable |
-| [`scripts/check_ratchet_bump.py`](/scripts/check_ratchet_bump.py) | Per-commit first-parent `floor_delta == actual_delta`; inter-file parity between [`run_pr_preflight.py`](/scripts/run_pr_preflight.py) and [`.github/workflows/ci.yml`](/.github/workflows/ci.yml) | Pre-push, preflight, CI (`ratchet-bump-guard` job) | `[ratchet-realignment]` / `[ratchet-test-removal]` — Python only |
+Recompute the threshold on the canonical env (`floor(actual − 2.0)`) and add `[threshold-update]` to the commit subject.
 
 ---
 
 ## Canonical env
 
 ```
-Canonical env (authoritative for threshold values and floor values):
-  Python     : ubuntu-latest + Python 3.12
-  Extension  : ubuntu-latest + Node 22
-Local measurements on other OS/runtime combinations may differ — re-compute
-on the canonical leg before filing a ratchet change.
+Python     : ubuntu-latest + Python 3.12
+Extension  : ubuntu-latest + Node 22
 ```
 
-This exact block appears in the failure output of
-[`check_threshold_changes.py`](/scripts/check_threshold_changes.py),
-[`check_ratchet_bump.py`](/scripts/check_ratchet_bump.py), and the
-`threshold-change-guard` CI echo so the canonical leg is surfaced at every
-drift event. If the block needs to change, grep all four copies and update
-them in the same commit.
-
-The canonical leg is not enforced by a gate — it is enforced by doc,
-co-location with the CI matrix, and reviewer discipline. Altering the matrix
-in [`.github/workflows/ci.yml`](/.github/workflows/ci.yml) without
-recomputing thresholds and floors is a silent correctness break.
-
----
-
-## See also
-
-- [`LOCAL_CI_PARITY_INVARIANTS.md`](/LOCAL_CI_PARITY_INVARIANTS.md) — governance contract for every gate; rows 25 / 26 / 27 / 27a / 32 own the policies in this doc
-- [`extension/tests/meta/`](/extension/tests/meta/) — meta-gates that can fire on test-adding commits but are not ratchets (config-parity, any-type, build-output-format, smoke-determinism, suppression-ratchet)
-- [Testing guide](testing.md) — test organization and local run recipes
+Local measurements on other OS/runtime combinations may differ — re-compute on the canonical leg before filing a ratchet change. This block is co-located in the failure output of `check_threshold_changes.py`, `check_ratchet_bump.py`, and the `threshold-change-guard` CI echo; if it changes here, grep all four copies and update them in the same commit.
+</content>

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -1,239 +1,98 @@
 # Development Setup
 
-How to set up a development environment for contributing to ado-git-repo-insights.
+How to set up a development environment for ado-git-repo-insights.
 
 ---
 
-## Prerequisites
+## Recommended: Dev Container
 
-| Requirement | Version | Notes |
-|-------------|---------|-------|
-| uv | 0.9+ | Canonical Python + project venv manager. [install](https://docs.astral.sh/uv/getting-started/installation/). Provides `uv python install 3.12`, which is **required for CI-pinned gates** (CLI-reference-drift skips on non-3.12). |
-| Python | 3.12 | Acquire via `uv python install 3.12`. Runtime supports 3.12/3.13/3.14 but CI-canonical is 3.12. |
-| Node.js | 22 | For extension development. |
-| pnpm | 9.15.0 | Enforced by `packageManager` field. Enable via `corepack enable`. |
-| Git | Any recent version | Windows: must include Git Bash (Husky requires `sh`). |
-| gitleaks | Any recent version | Secret scanning (CI parity). Preflight fails closed if missing — no silent skip. Install: `winget install -e --id Gitleaks.Gitleaks` (Windows), `brew install gitleaks` (macOS), `apt install gitleaks` or a [release binary](https://github.com/gitleaks/gitleaks/releases) (Linux). **Windows note:** winget updates PATH for future shells only; if `gitleaks --version` fails in your current shell after install, restart it. |
-| unzip | Any recent version | macOS/Linux only — used by the VSIX-artifact inspection test (`extension/tests/vsix-artifact-inspection.test.ts`) to read the packaged extension contents. Windows uses PowerShell instead. Install: `apt install unzip` (Linux) or pre-installed on macOS. The test fails with an explicit remediation message if `unzip` is missing under `VSIX_REQUIRED=true`. |
-| Chromium system libs (Playwright) | (system packages) | macOS/Linux only — Playwright smoke tests load `chrome-headless-shell`, which links against system shared libraries (`libnspr4`, `libnss3`, …). The `extension/` postinstall fetches the Chromium binary but not these libs; CI installs them via `playwright install --with-deps`. We deliberately keep `--with-deps` out of the local postinstall so routine `pnpm install` never prompts for sudo. On a Linux/WSL workstation with nvm-managed Node, install the libs once: `cd extension && NODE_BIN="$(dirname "$(which node)")" && sudo env "PATH=$NODE_BIN:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" "$NODE_BIN/npx" playwright install-deps chromium`. This pattern hands sudo a controlled PATH containing the nvm-installed Node and invokes `npx` directly, avoiding the `sudo pnpm: command not found` trap (sudo strips PATH; the nvm-managed pnpm shim is not on root's default `$PATH`). macOS: typically pre-installed. |
+Open the repo in any [Dev Containers-compatible runtime](https://containers.dev/supporting) — VS Code with the **Dev Containers** extension, JetBrains Gateway, etc. The container handles every per-platform variance (Node 22, Python 3.12, pnpm 9.15.0 via Corepack, gitleaks, unzip, Playwright Chromium runtime libraries) and the IDE runs `postCreateCommand` to install repo dependencies automatically.
+
+**Prerequisite**: a runtime — Docker Desktop, OrbStack, Rancher Desktop, or Podman with Dev Containers integration.
+
+**Open**:
+- VS Code: install the **Dev Containers** extension, then run "Dev Containers: Reopen in Container."
+- Other IDEs: follow your runtime's Dev Containers instructions.
+- Ad-hoc `docker run`: see [`.devcontainer/README.md`](../../.devcontainer/README.md) — `--user "$(id -u):$(id -g)"` and a temp clone are required to avoid root-owned host artifacts.
+
+**Verify**:
+```bash
+python scripts/run_pr_preflight.py
+```
+
+This is the recommended path for **all platforms**. It is the only supported path on Apple Silicon Mac (the dev container is multi-arch) and any host where modifying the system Python/Node toolchain is undesirable.
 
 ---
 
-## Quick Setup
+## Advanced: Native setup
+
+Use this when you can't run a container. The dev container is the canonical source — these steps reproduce its layered installs on the host.
+
+### Prerequisites
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| uv | 0.9+ | https://docs.astral.sh/uv/getting-started/installation/ |
+| Python | 3.12 | `uv python install 3.12`. CI-pinned gates require 3.12 specifically. |
+| Node.js | 22 (LTS) | `nvm install 22 && nvm use 22 && nvm alias default 22`. CI pins to 22. |
+| pnpm | 9.15.0 | `corepack enable` activates it via `package.json::packageManager`. |
+| Git | any recent | Windows: include Git Bash (Husky requires `sh`). |
+| gitleaks | any recent | `apt install gitleaks` (Linux), `brew install gitleaks` (macOS), `winget install Gitleaks.Gitleaks` (Windows). |
+| unzip | any recent | macOS/Linux only. `apt install unzip`; pre-installed on macOS. |
+| Chromium system libs (Playwright) | system pkgs | Linux/WSL only. One-time: `cd extension && NODE_BIN="$(dirname "$(which node)")" && sudo env "PATH=$NODE_BIN:$PATH" "$NODE_BIN/npx" playwright install-deps chromium`. |
+
+### Quick Setup
 
 ```bash
-# Clone the repository
-git clone https://github.com/oddessentials/ado-git-repo-insights.git
-cd ado-git-repo-insights
+# 1. Repo-local LF policy
+git config core.autocrlf false
 
-# 1. Install uv if you don't already have it
-#    https://docs.astral.sh/uv/getting-started/installation/
-
-# 2. Acquire the canonical Python interpreter (3.12)
-#    Some CI-hard gates (e.g. CLI-reference-drift) are pinned to 3.12
-#    and will SKIP locally on any other interpreter.
+# 2. Canonical Python interpreter
 uv python install 3.12
 
-# 3. Install root Node dependencies and activate Husky git hooks
-#    This MUST be the first Node step — hooks enforce all quality gates.
+# 3. Root pnpm install — MUST be first Node step (activates Husky hooks)
 pnpm install
 
-# 4. Create the project venv and install Python dev deps
+# 4. Project venv + Python dev deps
 uv sync --extra dev
 
-# 5. Install extension Node dependencies
-#    This also auto-downloads the pinned Playwright browser (~110 MB)
-#    via the extension's `postinstall` script — watch for the progress bar.
-cd extension && pnpm install && cd ..
+# 5. Extension deps (Playwright Chromium downloads ~110 MB)
+pnpm --dir extension install
+
+# 6. Verify with the authoritative gate
+python scripts/run_pr_preflight.py
 ```
 
-> **Not using uv?** You can substitute `python -m venv .venv` + `pip install -e .[dev]` for step 4, **but** you must first ensure your `python` resolves to 3.12 — otherwise gates pinned to 3.12 will silently skip locally while CI (always 3.12) remains authoritative.
+Step 6 should print `[OK] Local PR preflight passed`.
+
+### Platform notes
+
+**WSL**: confirm `which -a pnpm` resolves the Linux-native pnpm first. A Windows-side `pnpm.cmd` leaked through `/mnt/c/...` PATH integration breaks repo scripts that resolve pnpm by name.
+
+**Apple Silicon Mac**: native setup may require manual workarounds for some system libraries. Prefer the dev container.
+
+**Windows native**: requires Git Bash for Husky (`sh`). The dev container or WSL is recommended.
 
 ---
 
-## Python Development
+## Hooks
 
-### Install Options
+Repo-owned git hooks fire automatically through Husky on `git commit` and `git push`. Implementation lives in [`scripts/run_repo_hook.py`](../../scripts/run_repo_hook.py); see [`LOCAL_CI_PARITY_INVARIANTS.md`](../../LOCAL_CI_PARITY_INVARIANTS.md) for the gate-by-gate parity contract.
 
-The `Quick Setup` section above uses `uv sync --extra dev`, which installs every
-optional group needed for development. If you need a narrower surface:
-
-| Goal | Command |
-|------|---------|
-| Runtime only (no dev tools) | `uv sync` |
-| Development (tests, lint, type-check) | `uv sync --extra dev` |
-| With ML extras (Prophet, OpenAI) | `uv sync --extra dev --extra ml` |
-
-Non-uv users can substitute `pip install -e .[dev]` / `pip install -e .[ml]`
-after activating a Python 3.12 venv, with the caveat noted in Quick Setup.
-
-### Code Quality Tools
-
-**Linting:**
-```bash
-ruff check .
-```
-
-**Auto-format:**
-```bash
-ruff format .
-```
-
-**Type checking:**
-```bash
-mypy src/
-```
-
-### Running Tests
-
-Use the launcher — it isolates coverage paths so Windows file locking
-cannot brick future runs:
-
-```bash
-# All tests (with coverage)
-python scripts/run_pytest.py
-
-# Specific test file
-python scripts/run_pytest.py tests/unit/test_cli_args.py
-
-# Verbose output
-python scripts/run_pytest.py -v
-```
-
----
-
-## Extension Development
-
-### Setup
-
-```bash
-cd extension
-pnpm install
-```
-
-### Running Tests
-
-```bash
-pnpm test
-```
-
-### Building the VSIX
-
-From the `extension/` directory:
-
-```bash
-pnpm run package:vsix
-```
-
-This builds the UI bundles, stages pipeline task dependencies, and creates
-`OddEssentials.ado-git-repo-insights-X.Y.Z.vsix` in the `extension/` directory.
-No global tool install is needed — `tfx-cli` is a repo devDependency.
-
-### Local Testing
-
-Upload the VSIX to a test Azure DevOps organization:
-1. Go to `https://dev.azure.com/{test-org}/_settings/extensions`
-2. Click **Browse local extensions** → **Manage extensions**
-3. Click **Upload extension** → select the `.vsix` file from `extension/`
-
----
-
-## Repo Hooks
-
-Repo-owned hooks run automatically on `git commit` and `git push` through
-Husky wrapper files under `.husky/`.
-The authoritative implementation lives in:
-
-- `scripts/run_repo_hook.py`
-- `scripts/manage_generated_artifacts.py`
-
-Authoritative local parity now fails closed. If `python scripts/run_pr_preflight.py`
-cannot run a CI-hard gate such as Node-backed extension checks or `gitleaks`, it
-exits nonzero instead of silently skipping that gate.
-
-You do not need to run `pre-commit install` manually for normal repo usage.
-`pre-commit` is still required because the repo hooks delegate Python lint/format
-checks to it.
-
-The commit/push workflow currently includes:
-
-| Hook | Purpose |
-|------|---------|
-| `pre-commit` | Python formatting/lint checks, ACL health on Windows, VSS SDK drift sync, compiled artifact guard, invariant artifact contract verification, managed UI/demo artifact sync when UI files are staged |
-| `pre-push` | version guard, baseline integrity, `pre-commit --all-files`, CRLF guard, marketplace asset validation, invariant artifact contract verification, and local PR preflight |
-
-### Manual Run
+To run hooks manually:
 
 ```bash
 python scripts/run_repo_hook.py pre-commit
 python scripts/run_repo_hook.py pre-push
-
-# Optional: strict preflight with explicit base ref (hook runs non-strict by default)
-BASE_REF=main python scripts/run_pr_preflight.py --strict
-
-# Or via the extension package scripts
-cd extension
-pnpm run hooks:precommit
-pnpm run hooks:prepush
 ```
 
-### Skip Hooks (Not Recommended)
-
-```bash
-git commit --no-verify -m "message"
-```
+`--no-verify` is forbidden by project policy. If a hook fails, fix the underlying issue and re-commit.
 
 ---
 
-## Line Endings
+## See also
 
-This repo uses **LF line endings** for cross-platform compatibility.
-
-**Recommended Git config:**
-```bash
-# Let .gitattributes be the source of truth
-git config core.autocrlf false
-```
-
-If you see "CRLF will be replaced by LF" warnings, that's expected behavior.
-
-**Bulk-edit scripts must write LF explicitly** (`Path.write_bytes()` with
-`\n`, or `open(path, 'w', newline='\n')`). Windows default text mode emits
-CRLF; `git add` normalizes to LF in the index but leaves CRLF in the
-worktree until something rewrites the file, which can confuse Windows-only
-diagnostics.
-
----
-
-## Project Structure
-
-```
-ado-git-repo-insights/
-├── src/ado_git_repo_insights/    # Python package source
-│   ├── cli.py                    # CLI entry point
-│   ├── ado_client.py             # Azure DevOps API client
-│   ├── pr_extractor.py           # Extraction logic
-│   ├── repository.py             # SQLite operations
-│   ├── csv_generator.py          # CSV generation
-│   ├── aggregates.py             # Dashboard aggregates
-│   └── ui_bundle/                # Dashboard UI (synced from extension)
-├── extension/                     # Azure DevOps extension
-│   ├── task/                      # Pipeline task
-│   ├── ui/                        # Dashboard UI (source of truth)
-│   └── hub/                       # Extension hub
-├── tests/                         # Test suite
-│   ├── unit/                      # Unit tests
-│   ├── integration/               # Integration tests
-│   └── fixtures/                  # Test data
-├── scripts/                       # Build and utility scripts
-├── agents/                        # Governance documents
-└── docs/                          # Documentation
-```
-
----
-
-## See Also
-
-- [Testing Guide](testing.md) — Test organization and patterns
-- [UI Bundle Sync](ui-bundle-sync.md) — Dashboard UI synchronization
-- [Contributing Guide](../../CONTRIBUTING.md) — Contribution workflow
+- [`docs/development/testing.md`](testing.md) — running and writing tests
+- [`docs/development/ratchets.md`](ratchets.md) — test floor & coverage gate workflow
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md) — PR workflow & commit conventions
+</content>

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -4,376 +4,103 @@ How tests are organized and how to run them.
 
 ---
 
-## Test Organization
+## Organization
 
 ```
 tests/
-├── unit/                  # Isolated component tests
-│   ├── test_cli_args.py
-│   ├── test_config_validation.py
-│   ├── test_secret_redaction.py
-│   └── ...
+├── unit/                  # Isolated component tests (mocks)
 ├── integration/           # End-to-end workflow tests
-│   ├── test_golden_outputs.py
-│   ├── test_incremental_run.py
-│   └── ...
-└── fixtures/              # Test data
-    ├── golden/            # Golden reference data
-    ├── nested_artifacts/  # Staging normalization fixtures
-    ├── staged_artifacts/  # Pipeline artifact fixtures
-    └── README.md          # Fixtures documentation
+└── fixtures/              # Test data (golden output, staged artifacts)
 ```
+
+`extension/tests/` mirrors this layout for TypeScript/Jest tests, plus `extension/tests/smoke/` for Playwright smoke tests.
 
 ---
 
-## Running Tests
+## Running tests
 
-### Python Tests
+### Python
 
 ```bash
-# Supported local entrypoint (Windows-safe path, same pytest-cov semantics as CI)
-python scripts/run_pytest.py
-
-# Specific file
+python scripts/run_pytest.py                    # all tests, with coverage
 python scripts/run_pytest.py tests/unit/test_cli_args.py
-
-# Specific test
-python scripts/run_pytest.py tests/unit/test_cli_args.py::test_parse_args_minimal
-
-# Verbose
-python scripts/run_pytest.py -v
-
-# Stop on first failure
-python scripts/run_pytest.py -x
+python scripts/run_pytest.py -v -k test_foo
 ```
 
-Bare `python -m pytest` remains available for advanced/manual use, but it is not
-the hardened local dev path on Windows. Use the launcher above for routine local
-runs so temp-path and coverage behavior match the supported workflow.
+The launcher isolates per-run coverage paths to avoid Windows file-locking issues. Bare `python -m pytest` works for advanced/manual use but is not the supported local dev path on Windows.
 
-### Extension Tests
+### Extension
 
 ```bash
-cd extension
-pnpm test
+cd extension && pnpm test                       # unit tests
+cd extension && pnpm test:coverage              # with coverage + JUnit (needed for ratchet-bump-guard)
+cd extension && pnpm run test:smoke             # Playwright smoke
 ```
 
----
-
-## Test Categories
-
-### Unit Tests
-
-Isolated component tests using mocks.
-
-**Key files:**
-| File | Tests |
-|------|-------|
-| `test_cli_args.py` | CLI argument parsing |
-| `test_config_validation.py` | Configuration loading |
-| `test_secret_redaction.py` | PAT is never logged |
-| `test_logging_config.py` | Logging formatters |
-| `test_run_summary.py` | Summary file generation |
-
-### Integration Tests
-
-End-to-end workflow validation.
-
-**Key files:**
-| File | Tests |
-|------|-------|
-| `test_golden_outputs.py` | CSV contract compliance |
-| `test_incremental_run.py` | Incremental extraction |
-| `test_db_operations.py` | SQLite UPSERT semantics |
-
-### Drift Guards
-
-CI guards that prevent documentation from going stale.
-
-**Example:** `test_summary_drift_guard.py` verifies documentation accuracy.
-
----
-
-## Golden Tests
-
-The `test_golden_outputs.py` tests verify CSV output against known-good baselines.
-Golden tests use **dynamic fixtures** — they create temporary SQLite databases and
-generate CSVs at test time, then validate schema, determinism, and column contracts
-without pre-baked reference files on disk.
-
----
-
-## Mocking
-
-### ADO API Mocks
-
-Integration tests use mocked API responses:
-
-```python
-@pytest.fixture
-def mock_ado_client(mocker):
-    client = mocker.Mock()
-    client.get_pull_requests.return_value = [
-        {"pullRequestId": 1, ...}
-    ]
-    return client
-```
-
-### Extension Mocks
-
-Extension tests mock the ADO SDK:
-
-```typescript
-jest.mock('azure-devops-extension-sdk', () => ({
-  init: jest.fn().mockResolvedValue(undefined),
-  getConfiguration: jest.fn().mockReturnValue({}),
-}));
-```
-
----
-
-## CI Integration
-
-### Python CI Matrix
-
-Tests run across the full OS x Python version matrix defined in
-[`.github/workflows/ci.yml`](/.github/workflows/ci.yml). The
-`requires-python` floor in `pyproject.toml` defines packaging
-compatibility; CI validates a specific subset of that range.
-
-For the test-count floor and coverage-threshold workflows — including the
-recovery decision tree, marker rules, and the Python/TypeScript
-asymmetry — see [Ratchets](ratchets.md).
-
-### Local CI Parity
-
-The default pre-push hook is a strong workstation gate, but it is not a full
-replacement for the CI matrix. Before high-risk pushes, run the repo parity
-runner:
-
-```bash
-python scripts/run_ci_parity.py
-```
-
-What it verifies:
-- CI-critical Python scripts under the supported interpreter matrix
-- drift checks such as tool-version parity and suppression auditing
-- version-specific import/runtime issues in CI-invoked Python entrypoints
-
-For stronger confidence on machines with healthy local interpreter installs:
-
-```bash
-python scripts/run_ci_parity.py --mode full
-```
-
-Requirements:
-- Local Python 3.12, 3.13, and 3.14 must be installed, or the script will fail
-- `compatibility` mode runs directly on those interpreters and is the minimum
-  pre-push cross-version gate
-- `full` mode additionally creates per-version virtual environments and runs
-  targeted smoke tests
-- Docker Desktop can be used for future Linux parity expansion, but the script
-  currently only checks whether Docker is reachable
-- If interpreter discovery differs on your machine, set environment overrides
-  such as `CI_PARITY_PYTHON_3_12`, `CI_PARITY_PYTHON_3_13`, and
-  `CI_PARITY_PYTHON_3_14`
-
-For the current machine, treat a missing interpreter as a blocker rather than a
-warning if you need CI-grade confidence before pushing.
-
-### Gate Hierarchy
-
-Three escalating gate scopes run between your editor and CI:
-
-| Gate | Trigger | Scope | What it runs |
-|------|---------|-------|--------------|
-| Pre-commit | `git commit` | **Staged files only** | Hooks declared with `stages: [pre-commit]` in [`.pre-commit-config.yaml`](/.pre-commit-config.yaml), plus the pre-commit branch of [`scripts/run_repo_hook.py`](/scripts/run_repo_hook.py) |
-| Pre-push | `git push` | **All files (full worktree)** | Hooks declared with `stages: [pre-push]` run on all files, plus the pre-push-only guards in `scripts/run_repo_hook.py` (see `run_pre_push_hook`); **preflight is invoked within the same pre-push run** before the push completes |
-| Preflight | Embedded inside pre-push, or standalone via `python scripts/run_pr_preflight.py` | **Full worktree** | Authoritative CI-parity gate (see [`scripts/run_pr_preflight.py`](/scripts/run_pr_preflight.py) docstring for the current gate list) |
-
-**Stages are distinct.** Pre-commit and pre-push use separate `stages` entries
-in `.pre-commit-config.yaml` — not all hooks run at both stages. Some auto-fix
-hooks run only on commit; some stricter checks run only on push. A small set
-of framework-provided hooks intentionally registers for **both** stages
-(e.g. `detect-private-key`, `check-added-large-files`, `check-merge-conflict`,
-`env-guard`, `tool-version-parity`) so they fire regardless of which invocation
-triggered; `.pre-commit-config.yaml` is authoritative for the current list.
-If a push fails when the commit passed, that's a pre-push-only hook catching
-something staged-only checks intentionally skip. Treat `.pre-commit-config.yaml`
-**and** `scripts/run_repo_hook.py` as co-authoritative: the YAML declares which
-hooks run at each stage; the Python script orchestrates the stage-specific
-custom guards that aren't expressible as plain pre-commit hooks.
-
-### Local PR Preflight
-
-Before any push that is expected to keep an open PR green, run the repo-owned
-preflight:
+### Authoritative local gate
 
 ```bash
 python scripts/run_pr_preflight.py
 ```
 
-What it verifies: the full set of CI-parity gates — lint/type/test/build/parity
-checks across Python and the VS Code extension — as declared in the
-`CommandSpec` list inside [`scripts/run_pr_preflight.py`](/scripts/run_pr_preflight.py).
-Treat that script as the source for the current gate inventory; this document
-intentionally does not enumerate the list to avoid drift.
-
-Why this exists:
-- it uses stable temp/cache/coverage paths under the OS temp directory
-- it avoids the Windows repo-root lock problems that can make ad hoc pytest runs
-  noisy or misleading
-- it makes demo validation a required local gate instead of a remembered extra step
-- it resolves Python 3.12 explicitly, so the gate runs on a supported baseline
-  interpreter even if your shell default points elsewhere
-- it fails closed if CI-hard local tooling such as Node child-process support or
-  `gitleaks` is unavailable, so local success cannot silently become weaker than CI
-
-Diagnostic-only degraded mode:
-
-```bash
-python scripts/run_pr_preflight.py --allow-local-degraded
-```
-
-Use degraded mode only to gather partial diagnostics on a broken workstation. It
-is non-authoritative and must not be treated as local/CI parity.
-
-Recommended workflow:
-1. `python scripts/run_repo_hook.py pre-commit`
-2. `python scripts/run_repo_hook.py pre-push`
-3. `python scripts/run_ci_parity.py` for higher-confidence matrix parity when needed
-4. push only after the relevant gates pass for the change you made
-
-### CI Checks
-
-All PRs must pass:
-
-CI runs each gate as a **separate job** (not as a single "pre-commit" step).
-The authoritative list lives in
-[`.github/workflows/ci.yml`](/.github/workflows/ci.yml); this section points
-at categories, not an enumerated job list.
-
-| Category | What it covers |
-|----------|----------------|
-| Security scanning | e.g. gitleaks |
-| Repository policy gates | line endings, pnpm lockfile, UI bundle parity, invariant guards, version guards, commitlint, etc. |
-| Python tests | full OS/Python matrix declared in the workflow |
-| Extension tests | Jest, type-tests, smoke |
-| Lint/format/suppression audits | one CI step invokes `pre-commit run --all-files` alongside standalone jobs |
-| Release packaging checks | VSIX, Python package build |
-
-To reproduce a specific CI failure locally, consult the failing job's steps
-in the workflow -- some map to `pre-commit run --all-files --hook-stage
-pre-push`, others to `python scripts/run_repo_hook.py pre-push`, and the
-authoritative full check is `python scripts/run_pr_preflight.py`. See
-[`LOCAL_CI_PARITY_INVARIANTS.md`](/LOCAL_CI_PARITY_INVARIANTS.md) for the
-gate-by-gate parity contract.
+This is the source of truth for "what CI will run." It fails closed on missing tooling (`gitleaks`, Node child-processes, `unzip`) rather than silently degrading. Pre-push hooks invoke it automatically; run it standalone when pushing from an environment that skips hooks.
 
 ---
 
-## Test Coverage
+## CI parity
 
-**Target:** 70%+ code coverage (enforced in CI)
+CI runs each gate as a separate job in [`.github/workflows/ci.yml`](/.github/workflows/ci.yml). The local equivalents and the parity contract are documented in [`LOCAL_CI_PARITY_INVARIANTS.md`](/LOCAL_CI_PARITY_INVARIANTS.md). To reproduce a specific CI failure, look up the failing job name in the workflow and run its documented local equivalent — the fastest single-command reproduction is `python scripts/run_pr_preflight.py`.
 
-**Check coverage:**
+For higher-confidence cross-version parity (full Python OS × version matrix locally), use:
+
+```bash
+python scripts/run_ci_parity.py                 # subset, fast
+python scripts/run_ci_parity.py --mode full     # per-version venvs
+```
+
+`--mode full` requires Python 3.12, 3.13, and 3.14 installed on the host.
+
+---
+
+## Coverage
+
+Floor and threshold management — when to bump, what marker to use, how to recover from drift — is in [`docs/development/ratchets.md`](ratchets.md).
+
+To check coverage locally:
+
 ```bash
 python scripts/run_pytest.py --cov=src --cov-report=html
 open htmlcov/index.html
 ```
-(The launcher accepts arbitrary pytest args and forwards them to pytest,
-while adding launcher-managed coverage settings when needed — e.g. a
-per-run `COVERAGE_FILE` under the OS temp directory and
-`--cov-fail-under=0` for subset runs like `-k`, `-m`, `--lf`, or an
-explicit test path. Full-suite runs, preflight, and CI still enforce the
-real coverage floor.)
+
+The launcher accepts arbitrary pytest args and forwards them, while adding launcher-managed coverage settings (per-run `COVERAGE_FILE` under the OS temp directory, `--cov-fail-under=0` for subset runs like `-k`/`-m`/`--lf`/explicit paths). Full-suite runs, preflight, and CI still enforce the real floor.
 
 ---
 
-## Cleaning Ephemeral State
-
-Repo-local ephemeral directories (pytest cache, demo scratch,
-`tmp_test_work/pid-*/`, extension coverage and build outputs, and so on)
-are managed by a single authoritative cleaner. The pnpm wrappers are the
-primary entry points:
+## Cleaning ephemeral state
 
 ```bash
-pnpm clean:dry    # preview what would be swept
-pnpm clean        # apply the sweep
+pnpm clean:dry                                  # preview
+pnpm clean                                      # apply
 ```
 
-Both are thin delegators; the underlying command is
-`python scripts/clean_ephemeral.py` and the registry of eligible paths
-lives at `scripts/ephemeral_registry.json`.
-
-**Exit codes** (contract, enforced by the `ephemeral-cleaner-smoke` CI
-job on ubuntu / windows / macos):
-
-- `0` — nothing to do OR sweep succeeded
-- `3` — dry-run found work pending (`EXIT_DRY_RUN_PENDING`,
-  informational)
-- `2` — setup failure (registry missing, not in a git repo, registry
-  unparseable). Distinct from `3` so preflight whitelisting
-  "work pending" never masks real failures.
-- `1` — validation failure or a delete was refused (e.g. a tracked
-  file lives under a registered target)
-
-For same-boot peer-subprocess scratch in the demo suite, an atexit
-hook in `tests/demo/test_demo_parity_pipeline.py` complements the
-session-scope R7 fixture in `tests/demo/conftest.py`; see the module
-docstrings for the dual-cleanup rationale.
+The registry of eligible paths lives in [`scripts/ephemeral_registry.json`](/scripts/ephemeral_registry.json). Exit codes (cross-OS-enforced by the `ephemeral-cleaner-smoke` CI job): `0` = clean or sweep succeeded, `3` = dry-run found work pending (informational), `2` = setup failure, `1` = validation/refusal.
 
 ---
 
-## Writing Tests
+## Conventions
 
-### Naming Conventions
-
-```python
-# File: test_{module}.py
-# Function: test_{behavior}_when_{condition}
-
-def test_extract_returns_empty_when_no_prs():
-    ...
-
-def test_csv_columns_match_schema():
-    ...
-```
-
-### Test Invariants
-
-Many tests verify system invariants:
-
-```python
-def test_pat_not_logged(caplog):
-    """PATs must never be logged (see agents/INVARIANTS.md)."""
-    # ... test implementation
-```
-
-Reference `agents/INVARIANTS.md` for the full list.
+- File: `test_{module}.py`
+- Function: `test_{behavior}_when_{condition}`
+- Many tests verify invariants from [`agents/INVARIANTS.md`](../../agents/INVARIANTS.md). Reference that file for the full list.
+- Golden tests use **dynamic fixtures** — temporary SQLite DBs created at test time; no pre-baked reference files on disk. See `tests/fixtures/golden/` for reference data.
+- Drift guards (e.g. `test_summary_drift_guard.py`) lock documentation against silent rot.
 
 ---
 
-## Fixtures
+## See also
 
-### Golden Test Data
-
-Golden output tests use dynamic fixtures -- temporary SQLite databases are created
-and populated at test time. See `tests/fixtures/golden/` for reference data such as
-constant-series forecasts.
-
-### Staging Fixtures
-
-`tests/fixtures/nested_artifacts/` and `tests/fixtures/staged_artifacts/` contain
-artifact layout fixtures for staging normalization and pipeline artifact loading tests.
-
-### Legacy Datasets
-
-`extension/tests/fixtures/legacy-datasets/` contains old schema versions for backward compatibility testing.
-
----
-
-## See Also
-
-- [Development Setup](setup.md) — Environment setup
-- [Invariants](../../agents/INVARIANTS.md) — System guarantees to test
-- [Definition of Done](../../agents/definition-of-done.md) — Completion criteria
+- [`docs/development/setup.md`](setup.md) — environment setup
+- [`docs/development/ratchets.md`](ratchets.md) — test floor / coverage threshold workflow
+- [`agents/INVARIANTS.md`](../../agents/INVARIANTS.md) — system invariants to test against
+</content>

--- a/docs/development/ui-bundle-sync.md
+++ b/docs/development/ui-bundle-sync.md
@@ -1,135 +1,35 @@
 # UI Bundle Synchronization
 
-The dashboard UI files must be kept synchronized between two locations.
+The dashboard UI is duplicated between two locations because pip wheels can't preserve symlinks:
 
----
-
-## Why Two Locations?
-
-| Location | Purpose |
-|----------|---------|
-| `extension/ui/` | **Source of truth** for Azure DevOps extension |
-| `src/ado_git_repo_insights/ui_bundle/` | Copy for Python pip package |
-
-**Why not symlinks?** Symlinks don't work with pip packages. When building Python wheels with setuptools, symlinks are not preserved — the wheel would contain broken symlinks instead of actual files.
-
-**Why needed?** The `ado-insights dashboard` command requires bundled UI files. When users install via `pip install ado-git-repo-insights`, the UI files must be physically present in the package.
-
----
-
-## Synchronization Process
-
-### Automatic (Pre-commit Hook)
-
-The repo-owned pre-commit hook runs sync automatically when UI files are staged.
-The hook is launched by Husky, but the source of truth is the Python
-orchestrator in [`scripts/run_repo_hook.py`](../../scripts/run_repo_hook.py).
-
-```bash
-# Just commit normally — sync runs if UI files changed
-git add extension/ui/modules/metrics.ts
-git commit -m "Update dashboard"
-# → managed generated artifact sync runs automatically
-```
-
-### Manual Sync
-
-```bash
-# Sync VSS SDK + build UI + refresh ui_bundle
-python scripts/manage_generated_artifacts.py sync --scope ui
-
-# Sync the full managed surface, including docs/ and broken-docs fixture outputs
-python scripts/manage_generated_artifacts.py sync --scope all
-
-# Verify parity without staging changes
-python scripts/manage_generated_artifacts.py verify --scope ui
-python scripts/manage_generated_artifacts.py verify --scope all
-```
+| Location | Role |
+|---|---|
+| `extension/ui/` | **Source of truth.** Edit here. |
+| `src/ado_git_repo_insights/ui_bundle/` | Copy bundled into the pip package so `ado-insights dashboard` works after `pip install`. |
 
 ---
 
 ## Workflow
 
-1. **Edit files in `extension/ui/`** — This is the source of truth
-2. **Run sync** — Either via the repo-owned pre-commit hook or manually
-3. **Commit both locations** — Always commit together
+Edit files in `extension/ui/`, then commit both locations. The pre-commit hook syncs automatically when UI files are staged. To sync manually:
 
 ```bash
-# Example workflow
-vim extension/ui/modules/metrics.ts
-python scripts/manage_generated_artifacts.py sync --scope ui
+python scripts/manage_generated_artifacts.py sync --scope ui      # ui_bundle only
+python scripts/manage_generated_artifacts.py sync --scope all     # ui_bundle + docs/ demo shell
+python scripts/manage_generated_artifacts.py verify --scope ui    # check parity, don't stage
+```
+
+After sync, stage both locations:
+
+```bash
 git add extension/ui/ src/ado_git_repo_insights/ui_bundle/
-git commit -m "Update dashboard UI"
 ```
 
 ---
 
-## CI Enforcement
+## CI enforcement
 
-The `ui-bundle-sync` CI job verifies synchronization on every PR.
+The `ui-bundle-sync` CI job fails the build if `extension/ui/` and `src/ado_git_repo_insights/ui_bundle/` diverge. Fix with the manual sync command above and re-commit.
 
-**If out of sync, the job will:**
-1. Fail the build
-2. Show a patch-format diff of differences
-3. Provide instructions to fix
-
-**To fix:**
-```bash
-python scripts/manage_generated_artifacts.py sync --scope ui
-git add extension/ui/ src/ado_git_repo_insights/ui_bundle/
-git commit --amend  # or new commit
-```
-
----
-
-## Ignored Files
-
-The following patterns are ignored during sync:
-
-| Pattern | Reason |
-|---------|--------|
-| `*.map` | Source maps (not needed in package) |
-| `.DS_Store` | macOS metadata |
-| `*.swp`, `*~`, `*.bak` | Editor backup files |
-
----
-
-## Troubleshooting
-
-### "UI bundle out of sync" CI failure
-
-```bash
-python scripts/manage_generated_artifacts.py sync --scope ui
-git add -A
-git commit --amend
-git push --force-with-lease
-```
-
-### Files differ unexpectedly
-
-1. Check for whitespace/line-ending differences
-2. Verify you edited `extension/ui/` (not `ui_bundle/`)
-3. Re-run sync and inspect the diff
-
-### Sync script not found
-
-Ensure you're in the repository root:
-```bash
-cd /path/to/ado-git-repo-insights
-python scripts/manage_generated_artifacts.py sync --scope ui
-```
-
-### Which command should I use?
-
-| Goal | Command |
-|------|---------|
-| Refresh only the pip package UI copy | `python scripts/manage_generated_artifacts.py sync --scope ui` |
-| Refresh UI bundle plus published demo shell/assets | `python scripts/manage_generated_artifacts.py sync --scope all` |
-| Verify parity without staging | `python scripts/manage_generated_artifacts.py verify --scope ui` or `--scope all` |
-
----
-
-## See Also
-
-- [Development Setup](setup.md) — Environment setup
-- [Contributing Guide](../../CONTRIBUTING.md) — Contribution workflow
+Ignored during sync: `*.map`, `.DS_Store`, editor backups (`*.swp`, `*~`, `*.bak`).
+</content>

--- a/docs/user-guide/enable-ml-features.md
+++ b/docs/user-guide/enable-ml-features.md
@@ -1,30 +1,17 @@
-# Enabling ML Features (Phase 5)
+# Enabling ML Features
 
-This guide explains how to enable and configure the Phase 5 ML features: **Predictions** (time-series forecasting) and **AI Insights** (OpenAI-powered analysis).
+Two opt-in dashboard tabs:
 
-## Overview
+- **Predictions** — 4-week forecasts for PR throughput, cycle time, and review time. Zero-config (NumPy linear forecaster) by default; Prophet upgrades the model with seasonality detection when installed.
+- **AI Insights** — OpenAI-generated observations on bottlenecks, trends, and anomalies. Requires an OpenAI API key.
 
-Phase 5 adds two new dashboard tabs:
+Enable per pipeline run via task inputs.
 
-- **Predictions**: Forecasts for PR throughput, cycle time, and review time over the next 4 weeks
-- **AI Insights**: AI-generated observations about bottlenecks, trends, and anomalies
+---
 
-Both features are opt-in via pipeline task inputs.
+## Predictions
 
-## Prerequisites
-
-### For Predictions
-
-**Zero-Config Option (Fallback Forecaster)**
-
-Predictions work out-of-the-box with **no additional dependencies**. The built-in NumPy-based linear forecaster provides:
-
-- Linear trend extrapolation with confidence bands
-- Outlier detection and clipping at 3σ
-- Data quality assessment (insufficient/low_confidence/normal)
-- Minimum 4 weeks of data required (8+ recommended for best results)
-
-Simply enable predictions - no Prophet installation needed:
+Works with **no extra dependencies** — the built-in NumPy linear forecaster handles trend extrapolation, 3σ outlier clipping, and a data-quality assessment (`insufficient` / `low_confidence` / `normal`). Minimum 4 weeks of data; 8+ recommended.
 
 ```yaml
 - task: ExtractPullRequests@3
@@ -33,320 +20,87 @@ Simply enable predictions - no Prophet installation needed:
     enablePredictions: true
 ```
 
-**Enhanced Option (Prophet)**
+For seasonality-aware forecasts, install Prophet (requires a C++ compiler — platform-specific instructions: [Prophet Installation](https://facebook.github.io/prophet/docs/installation.html)). The system automatically detects Prophet and uses it when present, falling back to the linear forecaster otherwise.
 
-For more sophisticated forecasting with seasonality detection, install Prophet:
+---
 
-**Ubuntu/Debian:**
-```bash
-sudo apt-get install -y build-essential cmake python3-dev
-pip install prophet>=1.1.0
-```
+## AI Insights
 
-**Windows:**
-- Install Visual Studio Build Tools with C++ workload
-- Or use a hosted agent where Prophet is pre-installed
-
-**macOS:**
-```bash
-xcode-select --install
-pip install prophet>=1.1.0
-```
-
-The system automatically detects Prophet and uses it when available, falling back to linear forecasting otherwise.
-
-### For AI Insights (OpenAI)
-
-1. Create an OpenAI account at https://platform.openai.com
-2. Generate an API key
-3. Store the key as a secret in Azure DevOps:
-   - Go to Pipelines > Library > Variable Groups
-   - Create a new variable group (e.g., "OpenAI Secrets")
-   - Add variable: `OPENAI_API_KEY` = `sk-...` (mark as secret)
-   - Link the variable group to your pipeline
-
-## Pipeline Configuration
-
-### Basic Configuration
-
-Add the new inputs to your pipeline YAML:
+1. Create an OpenAI account, generate an API key.
+2. In ADO: **Pipelines** → **Library** → create variable group `OpenAI Secrets` → add variable `OPENAI_API_KEY` (mark as secret) → link to the pipeline.
+3. Enable on the task:
 
 ```yaml
 - task: ExtractPullRequests@3
   inputs:
-    organization: $(System.CollectionUri)
-    projects: |
-      ProjectA
-      ProjectB
-    pat: $(PAT)
     generateAggregates: true
-    # Enable ML features
-    enablePredictions: true
     enableInsights: true
     openaiApiKey: $(OPENAI_API_KEY)
 ```
 
-### Full Example
+---
 
-```yaml
-trigger:
-  - main
-
-schedules:
-  - cron: "0 6 * * *"  # Run daily at 6 AM
-    displayName: Daily PR Insights
-    branches:
-      include: [main]
-    always: true
-
-variables:
-  - group: OpenAI Secrets  # Contains OPENAI_API_KEY
-
-stages:
-  - stage: Extract
-    jobs:
-      - job: ExtractPRs
-        pool:
-          vmImage: 'ubuntu-latest'
-        steps:
-          - task: UsePythonVersion@0
-            inputs:
-              versionSpec: '3.12'
-              addToPath: true
-
-          - task: ExtractPullRequests@3
-            inputs:
-              organization: $(System.CollectionUri)
-              projects: |
-                MyProject
-              pat: $(PAT)
-              generateAggregates: true
-              enablePredictions: true
-              enableInsights: true
-              openaiApiKey: $(OPENAI_API_KEY)
-
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: '$(Pipeline.Workspace)/aggregates'
-              artifact: 'aggregates'
-```
-
-## Task Input Reference
+## Task inputs
 
 | Input | Type | Default | Description |
-|-------|------|---------|-------------|
-| `enablePredictions` | boolean | `false` | Generate ML predictions using Prophet |
-| `enableInsights` | boolean | `false` | Generate AI insights using OpenAI |
-| `openaiApiKey` | string | - | OpenAI API key (required if `enableInsights` is true) |
+|---|---|---|---|
+| `enablePredictions` | bool | `false` | Generate forecasts |
+| `enableInsights` | bool | `false` | Generate AI insights |
+| `openaiApiKey` | string | — | Required when `enableInsights: true` |
 
-## Output Files
+---
 
-When ML features are enabled, additional files are generated:
+## Output files
 
 ```
 aggregates/
 ├── dataset-manifest.json    # features.predictions / features.ai_insights = true
-├── aggregates/
-│   └── ...
-├── predictions/
-│   └── trends.json          # When enablePredictions=true
-└── insights/
-    └── summary.json         # When enableInsights=true
+├── predictions/trends.json  # when enablePredictions=true
+└── insights/summary.json    # when enableInsights=true
 ```
 
-### predictions/trends.json
+### `predictions/trends.json`
 
-Contains 4-week forecasts for key metrics:
+4-week forecasts per metric (`pr_throughput`, `cycle_time_minutes`, `review_time_minutes`). Each forecast value carries `predicted`, `lower_bound`, `upper_bound`, and `period_start`. Top-level `forecaster` is `linear` or `prophet`; `data_quality` is `normal` (8+ weeks), `low_confidence` (4–7 weeks), or `insufficient` (<4 weeks → no forecasts emitted).
 
-```json
-{
-  "schema_version": 1,
-  "generated_at": "2026-01-18T12:00:00Z",
-  "is_stub": false,
-  "generated_by": "linear-v1.0",
-  "forecaster": "linear",
-  "data_quality": "normal",
-  "forecasts": [
-    {
-      "metric": "pr_throughput",
-      "unit": "PRs/week",
-      "values": [
-        {
-          "period_start": "2026-01-20",
-          "predicted": 28,
-          "lower_bound": 22,
-          "upper_bound": 34
-        }
-      ]
-    }
-  ]
-}
-```
+### `insights/summary.json`
 
-**Forecaster Types:**
+Each insight has `id`, `category` (`bottleneck` / `trend` / `anomaly`), `severity` (`critical` / `warning` / `info`), `title`, `description`, `affected_entities`, `data` (with metric, current/previous values, sparkline), and `recommendation` (action + priority + effort). Insights are sorted deterministically: severity, then category, then id — for stable display.
 
-| Value | Description |
-|-------|-------------|
-| `linear` | NumPy-based linear regression (zero-config) |
-| `prophet` | Facebook Prophet with seasonality (requires installation) |
+---
 
-**Data Quality Indicators:**
+## Cost
 
-| Value | Meaning | Recommendation |
-|-------|---------|----------------|
-| `normal` | 8+ weeks of data | High confidence forecasts |
-| `low_confidence` | 4-7 weeks of data | Forecasts may be less accurate |
-| `insufficient` | <4 weeks of data | Predictions not generated |
+| Surface | Cost | Runtime overhead | Caching |
+|---|---|---|---|
+| Linear forecaster | free | <1 s | — |
+| Prophet | free | +10–30 s; CPU-intensive during model fit | — |
+| OpenAI Insights | ~$0.001–0.01 per run, depends on PR count | +5–15 s | 12 h on identical inputs (delete `insights/cache.json` to force regeneration) |
 
-### insights/summary.json
+---
 
-Contains AI-generated insights with actionable recommendations (v2 schema):
+## Dev preview
 
-```json
-{
-  "schema_version": 1,
-  "generated_at": "2026-01-18T12:00:00Z",
-  "is_stub": false,
-  "generated_by": "openai-v1.0",
-  "insights": [
-    {
-      "id": "bottleneck-abc123",
-      "category": "bottleneck",
-      "severity": "warning",
-      "title": "Review latency increasing",
-      "description": "Average time to first review has increased by 15%.",
-      "affected_entities": [
-        {"type": "team", "name": "Backend Team", "member_count": 5}
-      ],
-      "data": {
-        "metric": "review_time_minutes",
-        "current_value": 180,
-        "previous_value": 157,
-        "change_percent": 14.6,
-        "trend_direction": "up",
-        "sparkline": [140, 150, 157, 165, 180]
-      },
-      "recommendation": {
-        "action": "Consider adding more code reviewers or implementing automated review checks",
-        "priority": "high",
-        "effort": "medium"
-      }
-    }
-  ]
-}
-```
+To preview the tabs against synthetic data without running the pipeline: append `?devMode=true` to the dashboard URL. Works only on `localhost` or `file://`; never available on `dev.azure.com`. Shows a "PREVIEW — Demo Data" banner.
 
-**Insight Categories:**
-
-| Category | Description |
-|----------|-------------|
-| `bottleneck` | Process friction or capacity constraints |
-| `trend` | Directional changes in metrics over time |
-| `anomaly` | Unusual patterns or outliers |
-
-**Severity Levels:**
-
-| Severity | Description | Dashboard Display |
-|----------|-------------|-------------------|
-| `critical` | Immediate attention required | 🔴 Red indicator |
-| `warning` | Should be addressed soon | 🟡 Yellow indicator |
-| `info` | Informational observation | 🔵 Blue indicator |
-
-**Insight Ordering:**
-
-Insights are sorted deterministically for consistent display:
-1. Severity (critical → warning → info)
-2. Category (alphabetical)
-3. ID (alphabetical)
-
-## Dashboard Display
-
-Once ML features are enabled and data is generated:
-
-1. **Predictions tab**: Shows forecast charts with confidence intervals
-2. **AI Insights tab**: Shows categorized insight cards grouped by severity
-
-If no data is available, the tabs show "Coming Soon" state with instructions to enable the features in the pipeline.
+---
 
 ## Troubleshooting
 
-### "Predictions show 'Insufficient Data'"
+| Symptom | Fix |
+|---|---|
+| "Insufficient Data" on Predictions | Need 4+ weeks of completed PRs. `sqlite3 data.db "SELECT MIN(closed_date), MAX(closed_date), COUNT(*) FROM pull_requests WHERE status='completed'"` to check coverage. |
+| "Using linear forecaster instead of Prophet" | Expected when Prophet isn't installed. Install with `pip install "ado-git-repo-insights[ml]"` if you want Prophet. |
+| AI Insights enabled but OPENAI key missing | `openaiApiKey` input must be set AND the variable group containing `OPENAI_API_KEY` must be linked to the pipeline. |
+| OpenAI rate limit | Wait for window reset, or upgrade OpenAI plan. Insights cache for 12 h on identical inputs. |
+| "Low Confidence" data quality | 4–7 weeks of data; accumulate 8+ weeks for higher-confidence forecasts. |
+| Prophet install fails | Skip it — the linear fallback is fine for most use. Prophet's platform-specific build issues are documented at https://facebook.github.io/prophet/docs/installation.html. |
 
-Predictions require a minimum of 4 weeks of PR data. Check your data coverage:
-```bash
-sqlite3 data.db "SELECT MIN(closed_date), MAX(closed_date), COUNT(*) FROM pull_requests WHERE status='completed'"
-```
-
-### "Using linear forecaster instead of Prophet"
-
-This is expected behavior. The system automatically uses Prophet when installed, otherwise falls back to the linear forecaster. To use Prophet:
-```bash
-pip install "ado-git-repo-insights[ml]"
-# Or directly:
-pip install prophet>=1.1.0
-```
-
-### "AI Insights enabled but OpenAI API Key not provided"
-
-Ensure `openaiApiKey` input is set and the variable group is linked to your pipeline.
-
-### Prophet installation fails
-
-Prophet requires additional build tools. See [Prophet Installation](https://facebook.github.io/prophet/docs/installation.html) for platform-specific instructions.
-
-The linear fallback forecaster provides good results without Prophet - consider using it if Prophet installation is problematic.
-
-### OpenAI rate limits
-
-The insights generator caches results for 12 hours to minimize API calls. If you hit rate limits:
-1. Wait for the rate limit window to reset
-2. Consider using a higher-tier OpenAI plan
-3. Delete `insights/cache.json` to force regeneration
-
-### "Low Confidence" data quality warning
-
-This indicates 4-7 weeks of data. Forecasts are generated but may be less accurate. For best results, accumulate 8+ weeks of data before relying on predictions.
-
-## Cost Considerations
-
-### Linear Forecaster (Predictions - Zero Config)
-- **Cost**: Free (runs locally)
-- **Runtime**: <1 second per pipeline run
-- **Dependencies**: NumPy only (included with base install)
-
-### Prophet (Predictions - Enhanced)
-- **Cost**: Free (runs locally)
-- **Runtime**: +10-30 seconds per pipeline run
-- **Resource**: CPU-intensive during model fitting
-- **Dependencies**: Requires C++ compiler for installation
-
-### OpenAI (AI Insights)
-- **Cost**: ~$0.001-0.01 per run (depends on PR count)
-- **Runtime**: +5-15 seconds per pipeline run
-- **Caching**: Results cached for 12 hours (same data = no API call)
-
-## Dev Mode Preview
-
-For local development and testing, synthetic preview data is available:
-
-1. **Requirements:**
-   - Must be running on localhost or file:// protocol
-   - Add `?devMode=true` to the URL
-
-2. **Behavior:**
-   - Shows synthetic predictions and insights
-   - Displays prominent "PREVIEW - Demo Data" banner
-   - Never available in production (dev.azure.com)
-
-3. **Use Cases:**
-   - Testing dashboard UI without real data
-   - Demonstrating features to stakeholders
-   - Development and debugging
+---
 
 ## Security
 
-- **PAT**: Never logged, passed securely to Python process
-- **OpenAI API Key**: Passed via environment variable, never logged
-- **Data**: PR metadata is sent to OpenAI for analysis (titles, cycle times, counts)
-
-If your organization has data residency requirements, consider using Azure OpenAI Service instead.
+- PAT and OpenAI key are passed via environment / variable group; never logged.
+- AI Insights sends PR metadata (titles, cycle times, counts) to OpenAI. If you have data residency requirements, route through Azure OpenAI Service instead.
+- Full security posture: [`docs/SECURITY.md`](../SECURITY.md).
+</content>

--- a/docs/user-guide/extension.md
+++ b/docs/user-guide/extension.md
@@ -1,114 +1,71 @@
 # Extension User Guide
 
-This guide walks you through installing and using the **Git Repo Insights** extension in Azure DevOps.
+How to install and use the **Git Repo Insights** Azure DevOps extension.
 
 ---
 
-## What You Get
+## What you get
 
-- **PR Insights Dashboard** — Visual analytics directly in your ADO project
-- **PowerBI-compatible CSVs** — Export data for custom reporting
-- **SQLite Database** — Persistent storage of PR history via pipeline artifacts
-- **Incremental Updates** — Efficient daily extraction with optional backfill
-- **Parity with the CLI dashboard** — The extension and CLI consume the same dashboard bundle contract
-
-## Demo Parity Reference
-
-The published GitHub Pages demo is not a separate product surface. It is built
-from the same dashboard bundle contract used by the extension and is backed by
-the canonical enterprise synthetic dataset generated via:
-
-```bash
-python scripts/build-demo-dataset.py --commit-canonical
-```
-
-That dataset is promoted into `docs/data/` for publishing and is intended to
-exercise the same supported dashboard capabilities users should expect in an
-enterprise environment.
+- **PR Insights Dashboard** — visual analytics in your ADO project
+- **PowerBI-compatible CSVs** — exported per pipeline run for custom reporting
+- **SQLite Database** — persistent PR history via pipeline artifacts
+- **Incremental Updates** — efficient daily extraction with optional backfill
 
 ---
 
 ## Prerequisites
 
 | Requirement | Details |
-|-------------|---------|
-| Azure DevOps Organization | Any ADO organization (cloud) |
-| Extension Install Permission | Organization admin OR "Manage extensions" permission |
-| Project Access | Access to project(s) you want to analyze |
+|---|---|
+| Azure DevOps Organization | Any cloud-hosted ADO organization |
+| Permission | Organization admin OR "Manage extensions" |
+| Project access | Access to project(s) you want to analyze |
 
 ---
 
-## Step 1: Install the Extension
+## Step 1 — Install the extension
 
-### Option A: Install from Marketplace (Recommended)
+**From Marketplace (recommended)**: visit [Git Repo Insights on the Marketplace](https://marketplace.visualstudio.com/items?itemName=OddEssentials.ado-git-repo-insights), click **Get it free**, select your organization, click **Install**.
 
-1. Go to: [Git Repo Insights on Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=OddEssentials.ado-git-repo-insights)
-2. Click **Get it free**
-3. Select your organization from the dropdown
-4. Click **Install**
-5. Click **Proceed to organization**
-
-### Option B: Install from VSIX (Private/Testing)
-
-1. Download the `.vsix` from [GitHub Releases](https://github.com/oddessentials/ado-git-repo-insights/releases)
-2. Go to: `https://dev.azure.com/{your-org}/_settings/extensions`
-3. Click **Browse local extensions** → **Manage extensions** → **Upload extension**
-4. Select the `.vsix` file and upload
-5. Click **Get it free** → Select your organization → **Install**
+**From VSIX (private/testing)**: download the `.vsix` from [GitHub Releases](https://github.com/oddessentials/ado-git-repo-insights/releases). In ADO go to `https://dev.azure.com/{your-org}/_settings/extensions` → **Browse local extensions** → **Manage extensions** → **Upload extension**.
 
 ---
 
-## Step 2: Create a Personal Access Token (PAT)
+## Step 2 — Create a Personal Access Token (PAT)
 
-The extension needs a PAT to read Pull Request data from your repositories.
+The extension reads PR data via the Azure DevOps REST API; it needs a PAT with **Code (Read)** scope.
 
-1. In Azure DevOps, click your profile picture (top right) → **Personal access tokens**
-2. Click **+ New Token**
-3. Configure:
+1. ADO → profile picture (top right) → **Personal access tokens** → **+ New Token**.
+2. Configure:
    | Field | Value |
-   |-------|-------|
+   |---|---|
    | Name | `pr-insights-extraction` |
-   | Organization | Your target organization |
+   | Organization | Your target org |
    | Expiration | 90+ days recommended |
-   | Scopes | Click "Show all scopes" → check **Code → Read** |
-4. Click **Create**
-5. **Copy the token immediately** — you won't see it again
+   | Scopes | "Show all scopes" → check **Code → Read** |
+3. **Copy the token immediately** — you can't see it again.
+
+This is the canonical PAT setup; the [CLI guide](local-cli.md) and [troubleshooting](troubleshooting.md) link back here.
 
 ---
 
-## Step 3: Store PAT in a Variable Group
+## Step 3 — Store PAT in a Variable Group
 
-Secrets should never be stored in pipeline YAML files. Use a Variable Group instead.
+Never put secrets in pipeline YAML.
 
-1. Navigate to: **Pipelines** → **Library**
-2. Click **+ Variable group**
-3. Configure:
-   | Field | Value |
-   |-------|-------|
-   | Variable group name | `ado-insights-secrets` |
-4. Click **+ Add** and enter:
-   | Name | Value |
-   |------|-------|
-   | `PAT_SECRET` | Your PAT from Step 2 |
-5. Click the lock icon to mark as secret
-6. Click **Save**
+1. **Pipelines** → **Library** → **+ Variable group**.
+2. Name it `ado-insights-secrets`.
+3. Add a variable `PAT_SECRET` with your PAT value; click the **lock** icon to mark it secret.
+4. **Save**.
 
 ---
 
-## Step 4: Create the Pipeline
+## Step 4 — Create the pipeline
 
-### Using an Existing Repository
-
-You can store the pipeline YAML in any repository you have access to. Common choices:
-- A dedicated "pipelines" or "infrastructure" repository
-- The main repository of the project being analyzed
-
-### Pipeline YAML
-
-Create a new file (e.g., `pr-insights-pipeline.yml`) with:
+The pipeline YAML can live in any repo you can access. Create a new file (e.g. `pr-insights-pipeline.yml`):
 
 ```yaml
-trigger: none  # Configure schedule below or run manually
+trigger: none
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -121,25 +78,21 @@ stages:
     displayName: 'Extract PR Metrics'
     jobs:
       - job: ExtractPRs
-        displayName: 'Extract and Publish'
         steps:
-          # Create required directories
           - pwsh: |
               New-Item -ItemType Directory -Force -Path "$(Pipeline.Workspace)/data" | Out-Null
               New-Item -ItemType Directory -Force -Path "$(Pipeline.Workspace)/csv_output" | Out-Null
               New-Item -ItemType Directory -Force -Path "$(Pipeline.Workspace)/aggregates" | Out-Null
-            displayName: 'Create Directories'
+            displayName: 'Create directories'
 
-          # Ensure Node.js is available
           - task: UseNode@1
             displayName: 'Install Node.js 22'
             inputs:
               version: '22.x'
 
-          # Download previous database (enables incremental extraction)
           - task: DownloadPipelineArtifact@2
-            displayName: 'Download Previous Database'
-            continueOnError: true  # First run will have no artifact
+            displayName: 'Download previous database'
+            continueOnError: true
             inputs:
               buildType: 'specific'
               project: '$(System.TeamProjectId)'
@@ -150,36 +103,32 @@ stages:
               artifactName: 'ado-insights-db'
               targetPath: '$(Pipeline.Workspace)/data'
 
-          # Run the extraction task
           - task: ExtractPullRequests@3
-            displayName: 'Extract PR Metrics'
+            displayName: 'Extract PR metrics'
             inputs:
-              organization: 'YOUR_ORG_NAME'      # CHANGE THIS
+              organization: 'YOUR_ORG_NAME'
               projects: |
-                YOUR_PROJECT_1                    # CHANGE THIS
-                YOUR_PROJECT_2                    # Add more as needed
+                YOUR_PROJECT_1
+                YOUR_PROJECT_2
               pat: '$(PAT_SECRET)'
               database: '$(Pipeline.Workspace)/data/ado-insights.sqlite'
               outputDir: '$(Pipeline.Workspace)/csv_output'
               aggregatesDir: '$(Pipeline.Workspace)/aggregates'
 
-          # Publish database (enables incremental runs)
           - task: PublishPipelineArtifact@1
-            displayName: 'Publish Database'
+            displayName: 'Publish database'
             condition: succeeded()
             inputs:
               targetPath: '$(Pipeline.Workspace)/data'
               artifact: 'ado-insights-db'
 
-          # Publish aggregates (enables dashboard)
           - task: PublishPipelineArtifact@1
-            displayName: 'Publish Aggregates'
+            displayName: 'Publish aggregates'
             condition: succeeded()
             inputs:
               targetPath: '$(Pipeline.Workspace)/aggregates'
               artifact: 'aggregates'
 
-          # Publish CSVs for download
           - task: PublishPipelineArtifact@1
             displayName: 'Publish CSVs'
             condition: succeeded()
@@ -188,144 +137,93 @@ stages:
               artifact: 'csv-output'
 ```
 
-**Customize the placeholders:**
+Replace `YOUR_ORG_NAME` and project names. Then in ADO: **Pipelines** → **New pipeline** → select your repo → **Existing Azure Pipelines YAML file** → choose the file → **Save and run**.
 
-| Placeholder | Replace With |
-|-------------|--------------|
-| `YOUR_ORG_NAME` | Your Azure DevOps organization name |
-| `YOUR_PROJECT_1` | Name of a project to analyze |
-| `YOUR_PROJECT_2` | Additional projects (or remove) |
-
-### Create the Pipeline in Azure DevOps
-
-1. Navigate to **Pipelines** → **Pipelines** → **New pipeline**
-2. Select **Azure Repos Git** (or GitHub)
-3. Select your repository
-4. Select **Existing Azure Pipelines YAML file** and choose your YAML file
-5. Click **Save and run**
+The full reference template lives at [`pr-insights-pipeline.yml`](../../pr-insights-pipeline.yml) at repo root.
 
 ---
 
-## Step 5: Verify the Pipeline Run
+## Step 5 — Verify the run
 
-After the pipeline completes:
-
-1. Navigate to **Pipelines** → Click your pipeline → View the latest run
-2. All steps should show green checkmarks
-3. View the **Artifacts** section:
+After the pipeline completes, check the **Artifacts** section:
 
 | Artifact | Purpose |
-|----------|---------|
+|---|---|
 | `ado-insights-db` | SQLite database (enables incremental runs) |
 | `aggregates` | Dashboard data (enables PR Insights hub) |
 | `csv-output` | PowerBI-compatible CSVs |
 
 ---
 
-## Step 6: View the PR Insights Dashboard
+## Step 6 — View the dashboard
 
-After a successful pipeline run with the `aggregates` artifact:
+After a successful run that publishes the `aggregates` artifact:
 
-1. Navigate to your Azure DevOps project
-2. Find **PR Insights** in the left navigation under **Repos**
-3. The dashboard automatically discovers pipelines that publish aggregates
+1. Navigate to your ADO project.
+2. Find **PR Insights** in the left navigation under **Repos**.
+3. The dashboard auto-discovers pipelines that publish aggregates.
 
-### Dashboard Configuration
+If you have multiple pipelines publishing aggregates, set a default in **Project Settings** → **PR Insights Settings**.
 
-If you have multiple pipelines publishing aggregates, configure a default:
+The dashboard also accepts `?dataset=<url>` (dev/testing) or `?pipelineId=<id>` (override) URL parameters.
 
-1. Go to **Project Settings** → **PR Insights Settings**
-2. Select your preferred default pipeline
-
-**Configuration precedence:**
-1. `?dataset=<url>` — Direct URL (dev/testing only)
-2. `?pipelineId=<id>` — Query parameter override
-3. Extension settings — User-scoped saved preference
-4. Auto-discovery — Find pipelines with 'aggregates' artifact
-
-### Filter Behavior Notes
-
-- **Author filter** is a searchable single-select control keyed by stable author identity.
-- **Author + team** is constrained: the dashboard keeps the team selection visible but computes author-only metrics.
-- **Author + repository** uses exact metrics when the dataset exposes `by_author_and_repo`; otherwise legacy datasets fall back safely.
-- **Reviewer + repository** is constrained and uses reviewer-only metrics while retaining repository state.
-- **Reviewer + team** is disallowed and the dashboard clears the team selection with explicit UI messaging.
-- **Comments coverage** is shown as `full` or `partial`; `partial` means extraction was capped and comments remain an auxiliary analytics surface rather than part of the PowerBI CSV contract.
+For details on filter behavior — author/team/repository constraints, comments-coverage indicator (`full` vs `partial`) — see [`docs/reference/dataset-contract.md`](../reference/dataset-contract.md).
 
 ---
 
-## Setting Up a Schedule
+## Schedule the pipeline
 
-For continuous metrics, add a schedule trigger:
+For continuous metrics:
 
 ```yaml
-trigger: none
-
 schedules:
-  - cron: "0 6 * * *"  # Daily at 6 AM UTC
+  - cron: "0 6 * * *"        # daily at 6 AM UTC
     displayName: "Daily PR Extraction"
     branches:
       include: [main]
     always: true
 ```
 
-### Weekly Backfill (Recommended)
+### Weekly backfill (recommended)
 
-Add backfill on Sundays to catch late PR changes:
+Add a weekly task that re-extracts the recent window to converge late changes:
 
 ```yaml
 - task: ExtractPullRequests@3
   inputs:
     # ... other inputs ...
-    backfillDays: 60  # Re-extract last 60 days
+    backfillDays: 60
 ```
 
-Or use the production-ready template: [pr-insights-pipeline.yml](../../pr-insights-pipeline.yml)
+A production-ready template with both daily and weekly stages lives at [`pr-insights-pipeline.yml`](../../pr-insights-pipeline.yml).
 
 ---
 
-## Extracting Historical Data
+## Extracting historical data
 
-By default, the first extraction covers PRs from January 1st of the current year through yesterday.
-
-**To extract the past year of PR history**, add date overrides to your first run:
+By default, the first extraction covers PRs from January 1st of the current year through yesterday. To extend further back, add date overrides on your first run only:
 
 ```yaml
 - task: ExtractPullRequests@3
   inputs:
-    organization: 'YOUR_ORG_NAME'
-    projects: 'YOUR_PROJECT_1'
-    pat: '$(PAT_SECRET)'
-    database: '$(Pipeline.Workspace)/data/ado-insights.sqlite'
-    # Add for historical extraction (remove after first run)
+    # ... other inputs ...
     startDate: '2025-01-01'
     endDate: '2026-01-19'
 ```
 
-After the first run, remove `startDate` and `endDate` — subsequent runs automatically do incremental daily extraction.
+After the first run, remove `startDate`/`endDate` — subsequent runs do incremental daily extraction automatically.
 
 ---
 
-## Backfilling Historical PR Comments
+## Backfilling historical PR comments
 
-When you enable `includeComments: true` on your extract pipeline, incremental
-runs start fetching thread data for newly-closed PRs — but historical PRs
-already in the database (`comments_extracted_at IS NULL`) are not retroactively
-covered. For organizations with large histories, you need a **one-time backfill
-pipeline** to catch everything up. After that, the regular extract pipeline
-maintains coverage going forward.
+When you enable `includeComments: true` on your extract pipeline, incremental runs start fetching comment threads for newly-closed PRs — but historical PRs already in the database (`comments_extracted_at IS NULL`) are not retroactively covered. For organizations with large histories, run a **one-time backfill pipeline** to catch up. After the backlog is drained, the regular extract pipeline maintains coverage going forward.
 
-> **Precondition.** Your DB artifact must already contain the
-> `pr_threads` / `pr_comments` tables (schema migrations add them on any
-> modern extract run). Backfill against an older DB logs
-> `backfill-comments: skipped (legacy schema; no thread storage tables)`
-> and exits 0 with zero work done — run your extract pipeline once under
-> the current task version first, then start the backfill.
+> **Precondition.** The DB artifact must already contain `pr_threads` / `pr_comments` tables (added by schema migrations on any modern extract run). Backfill against an older DB logs `backfill-comments: skipped (legacy schema; no thread storage tables)` and exits 0 with zero work done — run your extract pipeline once under the current task version first, then start the backfill.
 
 ### One-line YAML change
 
-Add a second pipeline (or a separate stage) that flips the same
-`ExtractPullRequests@3` task into backfill mode:
+A separate pipeline (or stage) flips the `ExtractPullRequests@3` task into backfill mode:
 
 ```yaml
 - task: ExtractPullRequests@3
@@ -333,122 +231,78 @@ Add a second pipeline (or a separate stage) that flips the same
     organization: 'YOUR_ORG'
     pat: '$(PAT_SECRET)'
     database: '$(Pipeline.Workspace)/data/ado-insights.sqlite'
-    mode: backfill-comments          # <-- the only line that changes
-    backfillLimit: 2500              # <-- sized to fit inside a 60-min timeout
+    mode: backfill-comments          # the only line that changes
+    backfillLimit: 2500              # sized to fit a 60-min job timeout
 ```
 
-The task downloads the existing DB artifact (same pattern as incremental
-extract), drains up to `backfillLimit` uncovered PRs (oldest by `closed_date`
-first), and republishes the updated DB artifact. Runs that find nothing
-uncovered exit without any upstream API calls, so scheduling the backfill
-daily is safe even after the backlog is fully drained.
+The task downloads the existing DB, drains up to `backfillLimit` uncovered PRs (oldest by `closed_date` first), and republishes. Runs that find nothing uncovered exit without API calls, so daily scheduling is safe even after the backlog is drained.
 
 ### Sizing `backfillLimit`
 
-> **Empirical guidance, not a guarantee.** Backfill throughput measured on
-> hosted Ubuntu agents against the Azure DevOps cloud REST API is
-> approximately **one PR per second steady-state**. Actual throughput
-> depends on thread volume per PR and upstream rate limiting; treat every
-> estimate derived from this rate as order-of-magnitude.
+> **Empirical guidance, not a guarantee.** Backfill throughput measured on hosted Ubuntu agents against the Azure DevOps cloud REST API is approximately **one PR per second steady-state**. Actual throughput depends on thread volume per PR and upstream rate limiting; treat every estimate derived from this rate as order-of-magnitude.
 
-Pick `backfillLimit` so each run fits inside your pipeline's job timeout
-with room for setup, artifact publish, and aggregate regeneration:
+| Pipeline job timeout | Suggested `backfillLimit` (~1 PR/sec) |
+|---|---|
+| 60 min (default hosted) | `2500` |
+| 120 min | `6000` |
+| 360 min (hosted max / self-hosted) | `18000` |
 
-| Pipeline job timeout                | Suggested `backfillLimit` (derived at ~1 PR/sec) |
-|-------------------------------------|--------------------------------------------------|
-| 60 min (default hosted)             | `2500`  |
-| 120 min                             | `6000`  |
-| 360 min (hosted max / self-hosted)  | `18000` |
-
-For organizations with tens of thousands of historical PRs, a daily or
-weekly scheduled backfill drains the backlog over repeated runs — nothing
-to tune per-run beyond a `backfillLimit` that fits your timeout.
-Resumability is automatic: the selection query filters on
-`comments_extracted_at IS NULL`, so re-runs only see PRs that haven't been
-covered yet. If a run is interrupted (pipeline timeout, SIGINT, transient
-failure), PRs that already committed stay stamped and the in-progress PR
-rolls back untouched — the next run picks up exactly where the previous
-one stopped.
+Resumability is automatic: the selection query filters on `comments_extracted_at IS NULL`, so re-runs only see PRs that haven't been covered yet. Interrupted runs (timeout, SIGINT, transient failure) leave already-committed PRs stamped and roll back the in-progress PR untouched — the next run resumes from where the previous stopped.
 
 ### Optional scope filters
-
-Narrow what a single run covers:
 
 ```yaml
 - task: ExtractPullRequests@3
   inputs:
     organization: 'YOUR_ORG'
-    projects: 'ProjectA'             # single project instead of all
+    projects: 'ProjectA'             # single project
     pat: '$(PAT_SECRET)'
     database: '$(Pipeline.Workspace)/data/ado-insights.sqlite'
     mode: backfill-comments
-    backfillSince: '2024-01-01'      # closed on or after this date
-    backfillUntil: '2025-01-01'      # closed strictly before (exclusive)
+    backfillSince: '2024-01-01'      # closed on or after
+    backfillUntil: '2025-01-01'      # closed strictly before
     backfillLimit: 1000
 ```
 
-Leaving all three filter inputs empty drains every uncovered PR across every
-project. `backfillSince` / `backfillUntil` are strict `YYYY-MM-DD`.
+`backfillSince`/`backfillUntil` are strict `YYYY-MM-DD`. Leaving all three empty drains every uncovered PR across every project.
 
 ### Inputs rejected in this mode (fail fast)
 
-The task rejects mixed-intent input combinations at start-up so the run
-fails before any API call. In `mode: backfill-comments`, the following
-extract-only inputs cause an immediate task failure — remove them from
-your backfill pipeline:
+In `mode: backfill-comments`, these extract-only inputs cause an immediate task failure:
 
-| Input                   | Backfill equivalent or reason |
-|-------------------------|-------------------------------|
+| Input | Backfill equivalent or reason |
+|---|---|
 | `startDate` / `endDate` | Use `backfillSince` / `backfillUntil`. |
-| `backfillDays`          | Not applicable; backfill does not re-fetch PR metadata. |
+| `backfillDays` | N/A — backfill does not re-fetch PR metadata. |
 | `includeComments: true` | Backfill always fetches comments; this is the mode. |
-| `commentsMaxPrsPerRun`  | Use `backfillLimit`. |
+| `commentsMaxPrsPerRun` | Use `backfillLimit`. |
 
-Symmetrically, `backfillSince` / `backfillUntil` / `backfillLimit` in
-`mode: extract` also fail fast. Keep backfill and extract as separate
-pipelines (or separate stages) with clean input surfaces.
+Symmetrically, `backfillSince` / `backfillUntil` / `backfillLimit` in `mode: extract` also fail fast. Keep backfill and extract as separate pipelines (or stages) with clean input surfaces.
 
 ### How to tell it's working
 
-The task's console log emits three signals; every line is prefixed
-`backfill-comments: `.
+Console logs are prefixed `backfill-comments:`.
 
 | Signal | What it means |
-|--------|---------------|
-| `backfill run over N pull request(s)` | Opening line. `N` is the size of the selection this run will attempt. |
-| `covered PR <uid> (ordinal of total) [Processed]` or `[Failed]` | Per-PR progress; one line per PR in the selection. `Processed` = coverage marker stamped this run; `Failed` = marker left NULL so the PR is reselected on the next run. |
-| `processed N pull requests (K failures)` | Closing line after the last PR, including on empty-selection runs (`processed 0 pull requests (0 failures)`). |
+|---|---|
+| `backfill run over N pull request(s)` | Opening line. `N` is the size of the selection. |
+| `covered PR <uid> (ordinal of total) [Processed]` or `[Failed]` | Per-PR progress. `Processed` = coverage marker stamped; `Failed` = marker left NULL so the PR is reselected next run. |
+| `processed N pull requests (K failures)` | Closing line — same on empty-selection runs (`processed 0 pull requests (0 failures)`). |
 
-The backlog is drained when a run's opening line reports `over 0 pull
-request(s)` and no per-PR lines appear before
-`processed 0 pull requests (0 failures)`. At that point the regular
-extract pipeline (with `includeComments: true`) maintains coverage going
-forward.
+The backlog is drained when a run's opening line reports `over 0 pull request(s)` and no per-PR lines appear before the closing line. After that, the regular extract pipeline (with `includeComments: true`) maintains coverage going forward.
 
-The published `run_summary.json` artifact carries a matching
-`backfill-comments: loop-complete: processed=X failed=Y` entry in its
-`warnings` list for programmatic consumers; console log users read the
-`processed N pull requests (K failures)` line above.
+The published `run_summary.json` artifact carries a matching `backfill-comments: loop-complete: processed=X failed=Y` entry in its `warnings` list for programmatic consumers; console-log readers grep for `processed N pull requests (K failures)`.
 
-After the loop the task re-runs `generate-csv` and `generate-aggregates`
-exactly like extract does, so the dashboard's `review_time_p50` /
-`review_time_p90` and the PowerBI `auxiliary/comments/` CSVs refresh in
-the next published artifact. The comments-coverage indicator (shown as
-`full` or `partial` on the dashboard) updates on the next dashboard load.
+After the loop, the task re-runs `generate-csv` and `generate-aggregates` exactly like extract, so dashboard percentiles (`review_time_p50`/`review_time_p90`) and the PowerBI `auxiliary/comments/` CSVs refresh in the next published artifact. The dashboard's comments-coverage indicator (`full`/`partial`) updates on the next load.
 
 ---
 
-## Next Steps
+## Next steps
 
-- [Task Input Reference](../reference/task-reference.md) — All configuration options
-- [Troubleshooting](troubleshooting.md) — Common issues and solutions
-- [Runbook](../operations/runbook.md) — Operational procedures
-- [CSV Schema](../reference/csv-schema.md) — Output file specifications
+- [Task Input Reference](../reference/task-reference.md) — all task inputs
+- [Troubleshooting](troubleshooting.md)
+- [Runbook](../operations/runbook.md) — operational procedures
+- [CSV Schema](../reference/csv-schema.md)
 
----
-
-## Support
-
-For issues and feature requests, visit the [GitHub repository](https://github.com/oddessentials/ado-git-repo-insights).
-
-**Publisher**: OddEssentials
+For issues and feature requests: [GitHub repository](https://github.com/oddessentials/ado-git-repo-insights). Publisher: OddEssentials.
+</content>

--- a/docs/user-guide/local-cli.md
+++ b/docs/user-guide/local-cli.md
@@ -1,128 +1,52 @@
 # CLI User Guide
 
-This guide covers using the Python CLI for local PR analysis and custom CI/CD integration.
-
----
-
-## What You Get
-
-- **Command-line tool** for extraction and CSV generation
-- **Local dashboard server** for viewing metrics
-- **Configuration file support** for complex setups
-- **Works anywhere Python runs** — local machines, GitHub Actions, Jenkins, etc.
+How to use the Python CLI for local PR analysis and custom CI/CD integration.
 
 ---
 
 ## Prerequisites
 
 | Requirement | Details |
-|-------------|---------|
+|---|---|
 | Python | 3.12, 3.13, or 3.14 |
-| Azure DevOps PAT | Code (Read) scope |
+| Azure DevOps PAT | Code (Read) scope — see [PAT setup in the extension guide](extension.md#step-2--create-a-personal-access-token-pat) (canonical) |
 
 ---
 
-## Installation
-
-### Recommended: pipx (Frictionless)
-
-pipx handles PATH configuration automatically and isolates dependencies:
+## Install
 
 ```bash
-# Install pipx if needed
-python -m pip install --user pipx
-pipx ensurepath
-
-# Install ado-insights
-pipx install ado-git-repo-insights
-
-# Verify
-ado-insights --version
+pipx install ado-git-repo-insights        # recommended — isolated, PATH handled
+uv tool install ado-git-repo-insights     # alternative — same frictionless shape
+pip install ado-git-repo-insights         # advanced — may need `ado-insights setup-path`
 ```
 
-### Alternative: uv (Frictionless)
+Verify with `ado-insights --version`. Diagnose install issues with `ado-insights doctor` (prints install location, PATH status, conflicts) — see [troubleshooting](troubleshooting.md) for installer-specific recipes (Ansible, Docker, scripted PATH setup, validation in CI/CD).
 
-uv is a fast, modern alternative with similar frictionless installation:
-
-```bash
-# Install uv if needed (see https://astral.sh/uv)
-# Then install ado-insights
-uv tool install ado-git-repo-insights
-
-# Verify
-ado-insights --version
-```
-
-### Advanced: pip (Manual PATH Setup)
-
-For developers who prefer pip directly:
+### ML extras
 
 ```bash
-pip install ado-git-repo-insights
-```
-
-If `ado-insights` is not found after installation, run:
-
-```bash
-# Option 1: Automatic PATH setup
-ado-insights setup-path
-
-# Option 2: See the command without modifying files
-ado-insights setup-path --print-only
-```
-
-Then restart your terminal.
-
-### Verify Installation
-
-```bash
-ado-insights --version
-```
-
-### Diagnose Issues
-
-If you encounter problems:
-
-```bash
-ado-insights doctor
-```
-
-This shows installation location, PATH status, and detects conflicts.
-
-### Optional: ML Features
-
-For Prophet forecasting and AI insights:
-
-```bash
-# pipx
 pipx inject ado-git-repo-insights prophet openai
-
-# pip
+# or:
 pip install ado-git-repo-insights[ml]
 ```
+
+Setup details and AI-insights configuration: [Enable ML Features](enable-ml-features.md).
 
 ---
 
 ## Quick Start
 
-### 1. Set Up Your PAT
-
-Create a PAT in Azure DevOps with **Code (Read)** scope:
-1. Azure DevOps → Profile → Personal access tokens → + New Token
-2. Scope: Code → Read
-3. For multi-org setups, enable "All accessible organizations"
-
-Store it as an environment variable:
+Set your PAT (one-time):
 
 ```bash
 # Linux/macOS
 export ADO_PAT="your-pat-here"
-
 # Windows PowerShell
 $env:ADO_PAT = "your-pat-here"
 ```
 
-### 2. Extract PR Data
+### 1. Extract PRs
 
 ```bash
 ado-insights extract \
@@ -132,12 +56,9 @@ ado-insights extract \
   --database ./ado-insights.sqlite
 ```
 
-**What happens:**
-1. Creates a SQLite database (or updates existing)
-2. Fetches completed PRs from the Azure DevOps API
-3. Stores data with UPSERT semantics
+Creates or updates a SQLite database with PR data using UPSERT semantics.
 
-### 3. Generate CSVs
+### 2. Generate CSVs
 
 ```bash
 ado-insights generate-csv \
@@ -145,189 +66,89 @@ ado-insights generate-csv \
   --output ./csv_output
 ```
 
-**Output files:**
-- `organizations.csv`
-- `projects.csv`
-- `repositories.csv`
-- `pull_requests.csv`
-- `users.csv`
-- `reviewers.csv`
+Output files (one per dimension): `organizations.csv`, `projects.csv`, `repositories.csv`, `pull_requests.csv`, `users.csv`, `reviewers.csv`. Schema: [CSV Schema](../reference/csv-schema.md).
 
-### 4. View the Dashboard
+### 3. View the dashboard
 
-**Option A: Production Artifacts (Recommended)**
-
-Download artifacts from your Azure DevOps pipeline:
+**From production pipeline artifacts (recommended)**:
 
 ```bash
 ado-insights stage-artifacts \
-  --org MyOrg \
-  --project MyProject \
-  --pipeline-id 123 \
-  --pat $ADO_PAT \
-  --out ./run_artifacts
-
-# Start the dashboard server
+  --org MyOrg --project MyProject --pipeline-id 123 \
+  --pat $ADO_PAT --out ./run_artifacts
 ado-insights dashboard --dataset ./run_artifacts --open
 ```
 
-> **Build Selection:** The command selects the most recent completed build with
-> result `succeeded` or `partiallySucceeded`. Artifacts from partially succeeded
-> builds are valid and usable — only non-critical pipeline stages failed.
+`stage-artifacts` selects the most recent completed build (status `succeeded` or `partiallySucceeded`); legacy nested `aggregates/aggregates` layouts are auto-flattened.
 
-> **Layout Normalization:** If the artifact has a nested `aggregates/aggregates`
-> structure (legacy layout), it is automatically flattened during extraction.
-> The normalized layout has `dataset-manifest.json` at the root.
-
-
-
-**Option B: Local Database (Dev Mode)**
-
-Generate from a local SQLite database:
+**From a local database (dev)**:
 
 ```bash
-# Generate aggregates first
-ado-insights build-aggregates \
-  --db ./ado-insights.sqlite \
-  --out ./run_artifacts
-
-# Start the dashboard server
+ado-insights build-aggregates --db ./ado-insights.sqlite --out ./run_artifacts
 ado-insights dashboard --dataset ./run_artifacts --open
 ```
 
-> ⚠️ **Note:** `build-aggregates` is intended for local development. For production use, prefer `stage-artifacts` to download validated pipeline artifacts.
+Use `stage-artifacts` for production analysis; `build-aggregates` is for local iteration.
 
-**Option C: Synthetic Testing**
-
-Generate synthetic data for UI testing:
+**Synthetic / demo data**:
 
 ```bash
-# Generate the canonical enterprise demo dataset (writes to artifacts/demo-enterprise/)
 python scripts/build-demo-dataset.py --commit-canonical
-
-# Start the dashboard server against the canonical artifact
 ado-insights dashboard --dataset ./artifacts/demo-enterprise/data --open
 ```
 
-`docs/data/` is the published GitHub Pages mirror of the same canonical dataset.
-Use [DEMO-DATA-VERSIONING.md](../DEMO-DATA-VERSIONING.md)
-for the generation and promotion policy.
+The same canonical dataset backs the [public demo](https://oddessentials.github.io/ado-git-repo-insights/) (mirrored in `docs/data/`). Promotion policy: [DEMO-DATA-VERSIONING.md](../DEMO-DATA-VERSIONING.md).
 
-Dashboard options:
-- `--port 8080` — HTTP server port (default: 8080)
-- `--open` — Automatically open browser
+Dashboard flags: `--port 8080` (default), `--open` (auto-launch browser).
 
 ---
 
-## Date Range Behavior
+## Date range behavior
 
-### Default Behavior
+| Mode | Start date | End date |
+|---|---|---|
+| First run | Jan 1 of current year | Yesterday |
+| Incremental | Last extraction + 1 day | Yesterday |
+| Backfill | Today − backfill days | Yesterday |
 
-| Mode | Start Date | End Date |
-|------|------------|----------|
-| First run | January 1 of current year | Yesterday |
-| Incremental | Last extraction date + 1 day | Yesterday |
-| Backfill | Today minus backfill days | Yesterday |
-
-**Why yesterday?** PRs closed today may still receive updates (reviewer votes, comments). Extracting yesterday ensures complete data.
-
-### Override Dates
-
-```bash
-# Include today's data
-ado-insights extract \
-  --organization MyOrg \
-  --projects "Project1" \
-  --pat $ADO_PAT \
-  --database ./ado-insights.sqlite \
-  --end-date $(date +%Y-%m-%d)
-
-# Extract specific range
-ado-insights extract \
-  --organization MyOrg \
-  --projects "Project1" \
-  --pat $ADO_PAT \
-  --database ./ado-insights.sqlite \
-  --start-date 2024-01-01 \
-  --end-date 2024-12-31
-```
+**Why yesterday?** PRs closed today may still receive updates (reviewer votes, comments). Override with `--start-date YYYY-MM-DD` and/or `--end-date YYYY-MM-DD` for historical extraction or to include today's data.
 
 ---
 
-## Incremental vs Backfill Mode
+## Incremental vs backfill mode
 
-### Daily Incremental (Default)
+Daily incremental (default): `ado-insights extract ...` — only new PRs since last run.
 
-Extracts only new PRs since last run:
-
-```bash
-ado-insights extract \
-  --organization MyOrg \
-  --projects "Project1" \
-  --pat $ADO_PAT \
-  --database ./ado-insights.sqlite
-```
-
-### Backfill Mode
-
-Re-extracts recent data to catch late changes (reviewer votes, status updates):
+Recent-window backfill (catches late changes like reviewer votes):
 
 ```bash
-ado-insights extract \
-  --organization MyOrg \
-  --projects "Project1" \
-  --pat $ADO_PAT \
-  --database ./ado-insights.sqlite \
-  --backfill-days 60
+ado-insights extract ... --backfill-days 60
 ```
 
-**Recommended schedule:**
-| Schedule | Mode | Purpose |
-|----------|------|---------|
-| Daily | Incremental | Capture new PRs |
-| Weekly (Sundays) | Backfill 60 days | Convergence for late changes |
+Recommended schedule: daily incremental + weekly Sunday backfill of last 60 days.
 
-### Backfill Historical Comments
+### Backfill historical PR comments
 
-The `--backfill-days` flag above re-extracts PR metadata to converge
-late reviewer votes and status updates. It does **not** backfill PR
-comment thread data.
-
-If you enable `--include-comments` on extract after historical PRs are
-already in the database, those historical PRs are never retroactively
-covered by incremental runs. Use the separate `backfill-comments`
-subcommand for a one-time catch-up:
+`--backfill-days` does not backfill comment thread data — for comments coverage on historical PRs (after enabling `--include-comments` on extract), use the dedicated subcommand:
 
 ```bash
 ado-insights backfill-comments \
-  --organization MyOrg \
-  --pat $ADO_PAT \
+  --organization MyOrg --pat $ADO_PAT \
   --database ./ado-insights.sqlite \
   --limit 2500
 ```
 
-**Precondition:** the database must already contain the `pr_threads` /
-`pr_comments` tables (created by schema migrations on any modern
-extract run). Running backfill against an older schema exits 0 without
-processing — run your extract pipeline once under the current CLI
-version first.
-
-See [CLI Command Reference § backfill-comments](../reference/cli-reference.md#backfill-comments)
-for the full flag list, and the [Extension User Guide § Backfilling
-Historical PR Comments](extension.md#backfilling-historical-pr-comments)
-for sizing guidance and observable-signals reference (same behavior
-whether you run the CLI or the ADO extension task).
+The behavior, sizing guidance, observable signals, and inputs-rejected-in-this-mode constraints are identical to the ADO task. See the canonical narrative: [Backfilling Historical PR Comments](extension.md#backfilling-historical-pr-comments). CLI-specific flag reference: [cli-reference.md § backfill-comments](../reference/cli-reference.md#backfill-comments).
 
 ---
 
-## Configuration File
+## Configuration file
 
-For complex setups, use a YAML configuration file:
+For complex setups:
 
 ```yaml
 # config.yaml
 organization: MyOrg
-
 projects:
   - ProjectOne
   - ProjectTwo
@@ -346,8 +167,6 @@ backfill:
   window_days: 60
 ```
 
-Use with:
-
 ```bash
 ado-insights extract --config config.yaml --pat $ADO_PAT
 ```
@@ -360,10 +179,9 @@ ado-insights extract --config config.yaml --pat $ADO_PAT
 
 ```yaml
 name: PR Metrics
-
 on:
   schedule:
-    - cron: '0 6 * * *'  # Daily at 6 AM UTC
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 jobs:
@@ -371,44 +189,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
-      - name: Install
-        run: pip install ado-git-repo-insights
-
-      - name: Download previous database
-        uses: actions/download-artifact@v4
+      - run: pip install ado-git-repo-insights
+      - uses: actions/download-artifact@v4
         with:
           name: ado-insights-db
           path: ./data
         continue-on-error: true
-
-      - name: Extract
-        run: |
+      - run: |
           ado-insights extract \
             --organization ${{ vars.ADO_ORG }} \
             --projects "${{ vars.ADO_PROJECTS }}" \
             --pat ${{ secrets.ADO_PAT }} \
             --database ./data/ado-insights.sqlite
-
-      - name: Generate CSVs
-        run: |
+      - run: |
           ado-insights generate-csv \
             --database ./data/ado-insights.sqlite \
             --output ./csv_output
-
-      - name: Upload database
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: ado-insights-db
           path: ./data/ado-insights.sqlite
-
-      - name: Upload CSVs
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: csv-output
           path: ./csv_output/
@@ -418,7 +222,6 @@ jobs:
 
 ```yaml
 trigger: none
-
 pool:
   vmImage: 'ubuntu-latest'
 
@@ -426,37 +229,29 @@ steps:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: '3.12'
-
   - script: pip install ado-git-repo-insights
     displayName: 'Install'
-
   - task: DownloadPipelineArtifact@2
-    displayName: 'Download Previous DB'
     continueOnError: true
     inputs:
       artifact: ado-insights-db
       path: $(System.DefaultWorkingDirectory)/data
-
   - script: |
       ado-insights extract \
-        --organization $(ADO_ORG) \
-        --projects "$(ADO_PROJECTS)" \
+        --organization $(ADO_ORG) --projects "$(ADO_PROJECTS)" \
         --pat $(PAT_SECRET) \
         --database $(System.DefaultWorkingDirectory)/data/ado-insights.sqlite
     displayName: 'Extract PRs'
-
   - script: |
       ado-insights generate-csv \
         --database $(System.DefaultWorkingDirectory)/data/ado-insights.sqlite \
         --output $(System.DefaultWorkingDirectory)/csv_output
     displayName: 'Generate CSVs'
-
   - task: PublishPipelineArtifact@1
     condition: succeeded()
     inputs:
       targetPath: $(System.DefaultWorkingDirectory)/data/ado-insights.sqlite
       artifact: ado-insights-db
-
   - task: PublishPipelineArtifact@1
     condition: succeeded()
     inputs:
@@ -464,160 +259,51 @@ steps:
       artifact: csv-output
 ```
 
----
-
-## Enterprise & Scripted Deployment
-
-All installation commands are **non-interactive** and suitable for automated deployments.
-
-### Non-Interactive Installation
-
-```bash
-# All methods work without user prompts:
-pipx install ado-git-repo-insights       # No prompts
-uv tool install ado-git-repo-insights    # No prompts
-pip install ado-git-repo-insights        # No prompts
-```
-
-### Scripted PATH Configuration
-
-For automated deployments where PATH setup needs to be scripted:
-
-**Option 1: Capture and Execute**
-
-```bash
-# Bash/Linux
-PATH_CMD=$(python -m ado_git_repo_insights.cli setup-path --print-only)
-echo "$PATH_CMD" >> ~/.bashrc
-source ~/.bashrc
-```
-
-```powershell
-# PowerShell/Windows
-$pathCmd = python -m ado_git_repo_insights.cli setup-path --print-only
-Add-Content $PROFILE $pathCmd
-. $PROFILE
-```
-
-**Option 2: Direct Execution**
-
-```bash
-# Bash - append to profile automatically
-ado-insights setup-path
-
-# Verify (in new shell)
-ado-insights --version
-```
-
-### Ansible Playbook Example
-
-```yaml
-- name: Install ado-insights
-  hosts: analytics_servers
-  tasks:
-    - name: Install via pipx
-      community.general.pipx:
-        name: ado-git-repo-insights
-        state: present
-
-    - name: Verify installation
-      command: ado-insights --version
-      changed_when: false
-```
-
-### Docker Deployment
-
-```dockerfile
-FROM python:3.12-slim
-
-RUN pip install --no-cache-dir pipx && \
-    pipx install ado-git-repo-insights && \
-    pipx ensurepath
-
-# pipx installs to /root/.local/bin
-ENV PATH="/root/.local/bin:$PATH"
-
-ENTRYPOINT ["ado-insights"]
-```
-
-### Validation in CI/CD
-
-```bash
-# Validate installation succeeded
-ado-insights doctor
-
-# Check exit code: 0 = OK, 1 = issues detected
-if [ $? -ne 0 ]; then
-    echo "Installation issues detected"
-    exit 1
-fi
-```
+For ADO with the bundled task UI rather than scripted CLI, use the Marketplace [extension](extension.md) instead.
 
 ---
 
-## Output Artifacts
+## Output
 
-### Run Summary
+| Path | Purpose |
+|---|---|
+| `./ado-insights.sqlite` | Authoritative PR data store |
+| `./csv_output/*.csv` | PowerBI-compatible exports |
+| `./run_artifacts/` | Logs (`logs.jsonl` with `--log-format jsonl`) and `run_summary.json` |
+| `./run_artifacts/run_summary.json` | Always written, even on failure — useful for debugging |
 
-Every extraction writes `run_artifacts/run_summary.json`:
+`run_summary.json` shape:
 
 ```json
 {
   "status": "success",
   "start_time": "2026-01-19T06:00:00Z",
   "end_time": "2026-01-19T06:05:23Z",
-  "projects": [
-    {"name": "Project1", "prs_extracted": 42, "status": "success"}
-  ],
+  "projects": [{"name": "Project1", "prs_extracted": 42, "status": "success"}],
   "total_prs": 42,
   "first_error": null
 }
 ```
 
-Written even on failure for debugging.
-
-### Logging
-
-- **Default:** Console output (INFO level)
-- **JSONL logging:** `--log-format jsonl` → `run_artifacts/logs.jsonl`
-- **Debug mode:** `export PYTHONLOGLEVEL=DEBUG`
+Set `PYTHONLOGLEVEL=DEBUG` for verbose console logging.
 
 ---
 
-## Data Storage
+## Recovery
 
-### Where Data Lives
+The SQLite database is the source of truth; deleting it deletes all retained history. To recover:
 
-| File | Purpose |
-|------|---------|
-| `ado-insights.sqlite` | Authoritative PR data store |
-| `csv_output/*.csv` | Derived PowerBI-compatible exports |
-| `dataset/` | Dashboard aggregates |
-| `run_artifacts/` | Logs and run summary |
-
-### Retention
-
-- Data persists as long as the database file exists
-- Deleting the file deletes all retained history
-- Incremental runs update the same file over time
-
-### Recovery
-
-If the database is corrupted or missing:
-1. Delete the file
-2. Re-run extraction with `--start-date` to specify historical range
+```bash
+rm ./ado-insights.sqlite
+ado-insights extract ... --start-date YYYY-MM-DD       # bootstrap from a historical date
+```
 
 ---
 
-## Next Steps
+## Next steps
 
-- [CLI Command Reference](../reference/cli-reference.md) — All commands and options
-- [Troubleshooting](troubleshooting.md) — Common issues and solutions
-- [CSV Schema](../reference/csv-schema.md) — Output file specifications
-- [Architecture](../reference/architecture.md) — System design diagrams
-
----
-
-## Support
-
-For issues and feature requests, visit the [GitHub repository](https://github.com/oddessentials/ado-git-repo-insights).
+- [CLI Command Reference](../reference/cli-reference.md) — full command and flag inventory
+- [Troubleshooting](troubleshooting.md)
+- [CSV Schema](../reference/csv-schema.md) — output file specifications
+- [Architecture](../reference/architecture.md) — system design diagrams
+</content>

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -1,393 +1,180 @@
 # Troubleshooting
 
-Common issues and solutions for both CLI and Extension users.
+Common issues and fixes for both CLI and Extension users.
 
 ---
 
-## Installation Issues
+## Installation
 
 ### "ado-insights: command not found"
 
-**Run the doctor command** to diagnose:
-
-```bash
-python -m ado_git_repo_insights.cli doctor
-```
-
-**Cause:** Scripts directory is not on PATH.
-
-**Solutions by installation method:**
+Diagnose: `python -m ado_git_repo_insights.cli doctor`. Cause is typically that the install method's scripts directory isn't on PATH.
 
 | Method | Fix |
-|--------|-----|
-| pipx | Run: `pipx ensurepath` then restart terminal |
-| uv | Run: `uv tool update-shell` then restart terminal |
-| pip | Run: `ado-insights setup-path` then restart terminal |
-
-**Manual fix:** Add the scripts directory to your PATH. Use `ado-insights setup-path --print-only` to see the command.
+|---|---|
+| pipx | `pipx ensurepath`, restart terminal |
+| uv | `uv tool update-shell`, restart terminal |
+| pip | `ado-insights setup-path` (or `ado-insights setup-path --print-only` to preview) |
 
 ### Multiple installations conflict
 
-**Symptoms:** Wrong version runs, or commands behave unexpectedly.
-
-**Diagnose:**
+Symptoms: wrong version runs, or commands behave unexpectedly. `ado-insights doctor` flags this.
 
 ```bash
-ado-insights doctor
-```
-
-If doctor shows "Multiple installations found":
-
-1. **Keep pipx/uv, remove pip:**
-   ```bash
-   pip uninstall ado-git-repo-insights
-   ```
-
-2. **Keep uv, remove pipx:**
-   ```bash
-   pipx uninstall ado-git-repo-insights
-   ```
-
-3. **Start fresh:**
-   ```bash
-   pip uninstall ado-git-repo-insights
-   pipx uninstall ado-git-repo-insights
-   uv tool uninstall ado-git-repo-insights
-   # Then reinstall with your preferred method
-   pipx install ado-git-repo-insights
-   ```
-
-### Upgrade issues
-
-**Upgrade commands by installation method:**
-
-```bash
-# pipx
-pipx upgrade ado-git-repo-insights
-
-# uv
-uv tool upgrade ado-git-repo-insights
-
-# pip
-pip install --upgrade ado-git-repo-insights
-```
-
-### Uninstallation
-
-**If you used setup-path, remove it first:**
-
-```bash
-ado-insights setup-path --remove
-```
-
-**Then uninstall:**
-
-```bash
-# pipx
+# Pick one and remove the others:
 pipx uninstall ado-git-repo-insights
-
-# uv
 uv tool uninstall ado-git-repo-insights
-
-# pip
 pip uninstall ado-git-repo-insights
+# Then reinstall via the method you want to keep.
 ```
 
----
+### Upgrade / uninstall
 
-## Authentication Issues
-
-### "401 Unauthorized"
-
-**Cause:** PAT is invalid, expired, or lacks permissions.
-
-**Solution:**
-1. Create a new PAT with **Code (Read)** scope
-2. Ensure PAT has access to all target projects
-3. For multi-org setups, enable "All accessible organizations"
-4. Update the PAT in your variable group or environment variable
-
-### "403 Forbidden"
-
-**Cause:** PAT lacks access to specific projects.
-
-**Solution:**
-1. Verify the PAT organization matches your target
-2. Check project-level permissions
-3. Try creating a PAT with "All accessible organizations" scope
+Use whichever installer you originally used: `pipx upgrade`, `uv tool upgrade`, or `pip install --upgrade`. Same shape for `uninstall`. If you ran `ado-insights setup-path`, undo with `ado-insights setup-path --remove` before the uninstall.
 
 ---
 
-## Extraction Issues
+## Authentication
+
+| Error | Cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | PAT invalid, expired, or wrong scope | Regenerate with **Code (Read)** scope. For multi-org setups, enable "All accessible organizations." |
+| `403 Forbidden` | PAT lacks access to the targeted project(s) | Verify the PAT's organization matches; check project-level permissions. |
+
+PAT setup canonical reference: [extension guide § Step 2](extension.md#step-2--create-a-personal-access-token-pat).
+
+---
+
+## Extraction
 
 ### "No PRs extracted" but PRs exist
 
-**Causes:**
-
-1. **End date defaults to yesterday**
-   - PRs closed today are excluded to ensure complete data
-   - Use `--end-date` or `endDate` to include today:
-     ```bash
-     # CLI
-     ado-insights extract --end-date $(date +%Y-%m-%d) ...
-
-     # Extension task
-     endDate: '2026-01-19'
-     ```
-
-2. **Only completed PRs are extracted**
-   - Active, draft, and abandoned PRs are not extracted
-   - The tool captures only successfully merged PRs
-
-3. **Timezone differences**
-   - Tool uses local dates; ADO API uses UTC
-   - A PR closed late in your timezone may appear as closed "tomorrow" in UTC
-
-4. **Project names are case-sensitive**
-   - Verify exact project names in Azure DevOps
-
-5. **Start date is too recent**
-   - First run defaults to Jan 1 of current year
-   - Use `--start-date` for historical data
+| Cause | Fix |
+|---|---|
+| End date defaults to yesterday (excludes today's PRs to ensure complete data) | Pass `--end-date $(date +%Y-%m-%d)` (CLI) or `endDate: '<today>'` (task input) |
+| Only completed (merged) PRs are extracted; active/draft/abandoned are not | By design |
+| Timezone — tool uses local dates, ADO API uses UTC | Late-day local times may roll into "tomorrow" UTC |
+| Project names are case-sensitive | Match the exact ADO project name |
+| Start date too recent (default: Jan 1 of current year) | `--start-date YYYY-MM-DD` for older data |
 
 ### Extraction hangs or is slow
 
-**Causes:**
-
-1. **Rate limiting**
-   - Check logs for retry messages
-   - Increase `rate_limit_sleep_seconds` in config
-
-2. **Large date range**
-   - Break into smaller ranges
-   - Try extracting one date at a time with debug logging
-
-3. **Network issues**
-   - Verify connectivity to `dev.azure.com`
-   - Check firewall/proxy settings
-
-**Debug:**
-```bash
-export PYTHONLOGLEVEL=DEBUG
-ado-insights extract ...
-```
-
-### "Connection timeout"
-
-**Solution:**
-1. Increase `retry_delay_seconds` in config
-2. Check network connectivity
-3. Verify proxy settings if applicable
+Check logs for retry messages (rate limiting). Increase `rate_limit_sleep_seconds` and `retry_delay_seconds` in `config.yaml`. Break a large date range into smaller chunks. Verify connectivity to `dev.azure.com`. Debug verbosely with `PYTHONLOGLEVEL=DEBUG`.
 
 ---
 
-## Comment Extraction and Backfill
+## Comment extraction & backfill
 
 ### "Backfill exited 0 but no PRs were processed"
 
-**Cause:** The database schema predates the thread storage tables.
-The subcommand logs a legacy-schema warning and exits 0 without work.
-
-**Check:** Look for the legacy-schema warning in the backfill
-`run_summary.json` artifact (`warnings` list) or the pipeline log.
-
-**Fix:** Run the extract pipeline once under the current CLI / task
-version — schema migrations add the thread tables automatically — then
-re-run backfill.
+The DB schema predates the thread storage tables. The subcommand logs `backfill-comments: skipped (legacy schema; no thread storage tables)` and exits 0 with zero work done. Run the extract pipeline once under the current CLI/task version (schema migrations add the tables automatically), then re-run backfill.
 
 ### Per-PR failures reported but the run exited 0
 
-**By design.** A per-PR extraction error leaves that PR's coverage
-marker NULL so the next invocation reselects it. The loop continues
-with the next PR, and the run exits 0 as long as the loop reached the
-end.
+By design. A per-PR error leaves that PR's coverage marker NULL so the next invocation reselects it; the loop continues with the next PR. Inspect `run_summary.json`'s `warnings` list for the normalized error message of the failing PR.
 
-**Fix:** Re-run backfill. For a persistently-failing PR, inspect its
-entry in the `run_summary.json` artifact's `warnings` list for the
-normalized error message.
+### Backfill hits pipeline timeout
 
-### "Backfill hits pipeline timeout"
-
-**Fix:** Size `--limit` (CLI) / `backfillLimit` (task) to fit inside
-your job timeout at an empirical rate of roughly ~1 PR/sec — see the
-[sizing table](extension.md#sizing-backfilllimit). Interrupted runs are
-resumable: PRs whose per-PR transaction already committed stay covered;
-the next run picks up where the previous one stopped.
+Size `--limit` (CLI) / `backfillLimit` (task) to fit your job timeout. Sizing table: [extension guide § Sizing backfillLimit](extension.md#sizing-backfilllimit). Interrupted runs are resumable: PRs already committed stay covered, the next run picks up where the previous stopped.
 
 ### "How do I know backfill is done?"
 
-See the [extension guide's observable-signals
-table](extension.md#how-to-tell-its-working). A drained backlog is a
-run whose opening log line reports an empty selection, with no per-PR
-progress lines and a zero-count closing line.
+See [extension guide § How to tell it's working](extension.md#how-to-tell-its-working). A drained backlog is a run whose opening line reports an empty selection, with no per-PR progress lines and a zero-count closing line.
 
 ---
 
-## Pipeline Issues (Extension)
+## Pipeline (Extension)
 
-### "Task not found" error
-
-**Cause:** Extension not installed or not visible to the pipeline.
-
-**Solution:**
-1. Verify extension is installed: Organization Settings → Extensions
-2. Check task name is exactly `ExtractPullRequests@3`
-3. Ensure pipeline agent can reach the marketplace
-4. Try creating a new pipeline
-
-### "Python not found" error
-
-**Cause:** Self-hosted agent missing Python.
-
-**Solution:**
-1. The extension auto-installs Python dependencies
-2. Ensure agent has internet access
-3. Verify pip is available on the agent
-4. Use `UsePythonVersion@0` task if needed
-
-### First run downloads nothing
-
-**This is expected.** The "Download Previous Database" step will show a warning on the first run because there's no prior artifact. Subsequent runs will download the previous database for incremental updates.
-
-### Pipeline succeeds but no data
-
-**Check:**
-1. Verify the pipeline published an `aggregates` artifact
-2. Ensure `run_summary.json` shows success
-3. Check that projects in the task inputs are correct
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Task not found` | Extension not installed, or pipeline can't see it | Verify install (Org Settings → Extensions); confirm task name `ExtractPullRequests@3`; ensure agent can reach the marketplace |
+| `Python not found` | Self-hosted agent missing Python | Add a `UsePythonVersion@0` step before the task |
+| First run "downloads nothing" warning | No prior artifact yet | Expected on first run; subsequent runs download the previous DB |
+| Pipeline succeeds but no data | Missing `aggregates` artifact, or wrong projects | Verify the publish step ran; cross-check `run_summary.json`; confirm project names |
 
 ---
 
-## Dashboard Issues
+## Dashboard
 
-### Dashboard not showing / "PR Insights" menu missing
+### "PR Insights" menu missing / dashboard not showing
 
-**Causes:**
+| Cause | Fix |
+|---|---|
+| No `aggregates` artifact | Confirm pipeline published it; the artifact must contain `dataset-manifest.json` |
+| Missing **Build (Read)** permission | The dashboard reads pipeline artifacts; ask an admin to grant access |
+| Artifact retention expired | Configure extended retention (90+ days) in pipeline settings |
 
-1. **No aggregates artifact**
-   - Verify the pipeline published an `aggregates` artifact
-   - Check that the artifact contains `dataset-manifest.json`
-
-2. **Permissions**
-   - You need **Build (Read)** permission on the pipeline
-   - The dashboard reads data from pipeline artifacts
-
-3. **Artifact retention**
-   - Artifacts may have expired
-   - Configure extended retention in pipeline settings
-
-**Debug:** Add `?pipelineId=<id>` to the dashboard URL to force a specific pipeline.
-
-### "No access to analytics pipeline artifacts"
-
-**Solution:** Ask an admin to grant Build Read permission on the analytics pipeline.
+Force a specific pipeline with `?pipelineId=<id>` in the dashboard URL.
 
 ### Dashboard shows wrong pipeline
 
-**Solution:**
-1. Go to **Project Settings** → **PR Insights Settings**
-2. Select the correct default pipeline
-3. Or use `?pipelineId=<id>` query parameter
+**Project Settings** → **PR Insights Settings** → select the correct default pipeline. Or use the `?pipelineId=<id>` URL parameter.
 
 ---
 
-## Data Issues
+## Data
 
 ### Duplicate PRs in database
 
-**This should not happen** — the system uses UPSERT semantics.
+Should not happen — UPSERT semantics. If they do, file an issue. Diagnose:
 
-**Debug:**
 ```sql
-SELECT pull_request_uid, COUNT(*)
-FROM pull_requests
-GROUP BY pull_request_uid
-HAVING COUNT(*) > 1
+SELECT pull_request_uid, COUNT(*) FROM pull_requests
+GROUP BY pull_request_uid HAVING COUNT(*) > 1;
 ```
-
-If duplicates exist, check if `pull_request_uid` generation is consistent. File an issue if this occurs.
 
 ### CSV has wrong columns
 
-**This is a contract violation.** The CSV schema is guaranteed stable.
-
-**Expected headers:**
-```
-pull_requests.csv: pull_request_uid,pull_request_id,organization_name,project_name,repository_id,user_id,title,status,description,creation_date,closed_date,cycle_time_minutes
-```
-
-File an issue if column order or names differ.
+The CSV schema is a stable contract. If column order or names differ, file an issue. Reference: [CSV Schema](../reference/csv-schema.md).
 
 ### Missing historical data
 
-**Solution:**
-1. Run with explicit date range:
-   ```bash
-   ado-insights extract --start-date 2024-01-01 --end-date 2024-12-31 ...
-   ```
-2. For Extension, add `startDate` and `endDate` task inputs
+Re-extract the historical range explicitly:
+
+```bash
+ado-insights extract --start-date 2024-01-01 --end-date 2024-12-31 ...
+```
+
+Extension equivalent: pass `startDate` and `endDate` task inputs.
 
 ---
 
-## Recovery Procedures
+## Recovery
 
 ### Database corruption
 
-**Option A:** Delete and re-extract
 ```bash
 rm ado-insights.sqlite
-ado-insights extract --start-date 2024-01-01 ...
+ado-insights extract --start-date YYYY-MM-DD ...
 ```
 
-**Option B:** Restore from prior artifact
-1. Go to Pipelines → Runs → [last successful run] → Artifacts
-2. Download `ado-insights-db` artifact
+Or restore from a prior pipeline artifact: **Pipelines** → **Runs** → last successful run → Artifacts → download `ado-insights-db`.
 
 ### Missing/expired pipeline artifact
 
-**Behavior:** System treats it as first-run and creates a fresh database.
-
-**Prevention:** Configure extended artifact retention (90+ days) in pipeline settings.
-
-**Recovery:** Use `--start-date` to re-extract historical data.
+The system treats it as first-run and creates a fresh database. Prevention: extended artifact retention (90+ days) in pipeline settings.
 
 ---
 
-## Logging and Debugging
+## Logging
 
-### Enable debug logging
-
-**CLI:**
 ```bash
-export PYTHONLOGLEVEL=DEBUG
-ado-insights extract ...
+PYTHONLOGLEVEL=DEBUG ado-insights extract ...           # verbose console
+ado-insights --log-format jsonl extract ...             # JSONL → run_artifacts/logs.jsonl
 ```
 
-**JSONL logging:**
-```bash
-ado-insights --log-format jsonl extract ...
-# Check run_artifacts/logs.jsonl
-```
-(`--log-format` is a global flag and must precede the subcommand — see
-[CLI Reference § Global Options](../reference/cli-reference.md#global-options).)
+`--log-format` is a global flag and must precede the subcommand — see [CLI Reference § Global Options](../reference/cli-reference.md#global-options).
 
-### Run summary location
-
-Always written to `run_artifacts/run_summary.json`, even on failure.
-
-Contains:
-- Status (success/failure)
-- Per-project results
-- First fatal error
-- Timing and counts
+`run_artifacts/run_summary.json` is always written, even on failure (status, per-project results, first fatal error, timing).
 
 ---
 
-## Getting Help
+## Getting help
 
-1. Check the [GitHub Issues](https://github.com/oddessentials/ado-git-repo-insights/issues) for known issues
-2. Open a new issue with:
-   - Command/task configuration (with PAT redacted)
-   - Error message
-   - `run_summary.json` contents
-   - Debug logs if available
+Check [existing GitHub issues](https://github.com/oddessentials/ado-git-repo-insights/issues) first. When opening a new one, include:
+
+- Command or task configuration (PAT redacted)
+- Error message
+- `run_summary.json` contents
+- Debug logs if available
+</content>


### PR DESCRIPTION
## Summary

- Makes the dev container the recommended developer setup path; demotes native setup to "advanced."
- Fills the Linux/WSL/macOS onboarding gaps surfaced during the recent local-env-bootstrap and devcontainer work — explicit `nvm install 22 && nvm use 22 && nvm alias default 22`, `git config core.autocrlf false` numbered into Quick Setup, end-with-preflight verification, WSL `which -a pnpm` ordering note, Apple Silicon multi-arch note.
- Consolidates PAT setup and the backfill-comments narrative into `docs/user-guide/extension.md` as the canonical surface; the CLI guide and troubleshooting now link there.
- Removes duplicated governance prose (testing.md and ratchets.md no longer recap `LOCAL_CI_PARITY_INVARIANTS.md` content; they point at it).
- Reduces docs by **~53%** (3,329 → 1,573 lines across 10 files) while preserving every executable command example and every test-locked content anchor.
- 73/73 doc-drift tests pass: `test_contributor_docs_use_pnpm`, `test_backfill_doc_parity`, `test_parity_doc_coverage`, `test_summary_drift_guard`, `test_sentinel_absence_in_docs_data`, `test_ci_parity_drift`.

## Commit shape

| Commit | Files | Δ lines |
|---|---|---:|
| `ed9f9e14` `docs: lead with dev container; tighten onboarding spine` | README, CONTRIBUTING, docs/development/setup.md | −345 |
| `d7a5d6eb` `docs: consolidate user guides and trim development docs` | 4 user-guide files + 3 development-docs files | −1,421 |

## Out of scope (follow-up)

- GHCR image caching for the dev container — first-clone time is still ~5 min from build; a published image would drop it to ~30 s.
- Any further onboarding polish; this PR is reduction-and-canonicalization only.

## Test plan

- [x] `pytest tests/unit/test_*doc*.py tests/unit/test_*drift*.py` — all green locally.
- [x] Cross-link grep finds zero stale anchor links into removed sections.
- [x] Pre-push preflight green on the canonical Linux gate.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)