### PR TITLE
ci(devcontainer): publish multi-arch image to GHCR

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -30,8 +30,39 @@ works:
 - Rancher Desktop (cross-platform)
 - Podman with Dev Containers integration
 
-Image build is roughly 5 minutes from scratch and ~849 MB compressed
-(3.24 GB uncompressed).
+## Image source — GHCR by default
+
+`devcontainer.json` references the multi-arch image published to GHCR by
+the [`publish-devcontainer` CI job](../.github/workflows/ci.yml) on every
+merge to `main`:
+
+```
+ghcr.io/oddessentials/ado-git-repo-insights-dev:main
+```
+
+Fresh clones pull this image (~30s on a warm cache) instead of building
+locally (~5 min, ~849 MB compressed / 3.24 GB uncompressed). Both
+`linux/amd64` and `linux/arm64` are published, so Apple Silicon hosts
+get a native-arch image without QEMU emulation.
+
+### When to fall back to a local build
+
+Two scenarios require a local rebuild. Both involve editing
+`devcontainer.json` in your local checkout — **do not commit** these
+edits:
+
+- **GHCR unreachable or the package is private** and you don't have
+  pull access. VS Code will surface a clear pull error.
+- **Iterating on `Dockerfile`** — the `:main` tag only reflects merged
+  changes, so an in-progress Dockerfile edit will not appear there.
+
+In either case, replace the `"image"` line with:
+
+```jsonc
+"build": { "dockerfile": "Dockerfile" }
+```
+
+and rebuild via the manual recipe below.
 
 ## Ad-hoc `docker run` verification — `--user` is mandatory
 
@@ -83,7 +114,10 @@ doesn't match the running uid. The bind mount preserves host ownership,
 which `git` flags as "dubious" until you allowlist it. Inside an
 ephemeral container, this is harmless.
 
-## Build the image manually
+## Build the image manually (fallback)
+
+Use this when GHCR is unreachable or you are iterating on the
+Dockerfile (see [When to fall back to a local build](#when-to-fall-back-to-a-local-build)):
 
 ```bash
 docker build -t ado-git-repo-insights-dev:test -f .devcontainer/Dockerfile .devcontainer/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,6 @@
 {
     "name": "ado-git-repo-insights",
-    "build": {
-        "dockerfile": "Dockerfile"
-    },
+    "image": "ghcr.io/oddessentials/ado-git-repo-insights-dev:main",
     "remoteUser": "vscode",
     "workspaceFolder": "/workspaces/ado-git-repo-insights",
     // postCreateCommand runs once after the container is created, with the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1727,3 +1727,46 @@ jobs:
         run: |
           ls -la .ci-tmp/
           python .ci-tmp/verify-badge-url.py
+
+  # Tier 3 / T3-7: Publish multi-arch dev container image to GHCR.
+  # Main-only post-merge artifact publish — no local equivalent (CI infra:
+  # buildx + QEMU + registry auth). Consumed by .devcontainer/devcontainer.json
+  # via the `image:` field so a fresh clone pulls instead of building.
+  publish-devcontainer:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute short SHA
+        id: vars
+        run: echo "sha_short=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push devcontainer image
+        uses: docker/build-push-action@v6
+        with:
+          context: .devcontainer
+          file: .devcontainer/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/oddessentials/ado-git-repo-insights-dev:main
+            ghcr.io/oddessentials/ado-git-repo-insights-dev:sha-${{ steps.vars.outputs.sha_short }}
+          cache-from: type=gha,scope=devcontainer
+          cache-to: type=gha,scope=devcontainer,mode=max

--- a/LOCAL_CI_PARITY_INVARIANTS.md
+++ b/LOCAL_CI_PARITY_INVARIANTS.md
@@ -101,6 +101,7 @@ in Tier 2 above.
 | T3-4  | task-major-guard           | Requires GitHub PR context (webhook data)                                              |
 | T3-5  | badge-publish              | Main-only post-merge artifact publish                                                  |
 | T3-6  | Verify Asset Accessibility | Requires HTTP server + curl integration test                                           |
+| T3-7  | publish-devcontainer       | Main-only multi-arch image build + GHCR publish; CI infra (buildx, QEMU, registry auth) |
 
 ## External Checks (not in our control)
 


### PR DESCRIPTION
## Summary
- publishes the devcontainer image to GHCR on pushes to main
- switches devcontainer.json to consume the GHCR image by default
- keeps a documented local-build fallback for GHCR/private-package failures

## Verification
- rebuilt the devcontainer image locally
- ran full preflight inside the locally built container
- verified host checkout hygiene: clean tree, no root-owned files, no untracked files

## Follow-up after merge
- confirm publish-devcontainer succeeds on main
- if GHCR returns 403, enable Actions read/write package permissions
- after first successful publish, make the GHCR package public so fresh clones can pull without auth