### PR TITLE
fix(predictions): render only supported prediction metrics

### DIFF
--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 3215,
+    "min_collected": 3216,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 3216,
+    "min_collected": 3218,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -6956,16 +6956,17 @@ var PRInsightsDashboard = (() => {
       </div>`
       );
     }
+    const RENDERED_METRICS = /* @__PURE__ */ new Set(["cycle_time_minutes"]);
     const visibleForecasts = predictions.forecasts.filter(
-      (f2) => f2.metric !== "pr_throughput"
+      (f2) => RENDERED_METRICS.has(f2.metric)
     );
-    if (!visibleForecasts || visibleForecasts.length === 0) {
+    if (visibleForecasts.length === 0) {
+      const sourceEmitted = predictions.forecasts.length > 0;
+      const message = sourceEmitted ? `<p>No supported prediction metrics are available in this run.</p>` : `<p>No forecast data available.</p>
+         <p>Run the analytics pipeline with predictions enabled to generate forecasts.</p>`;
       appendTrustedHtml(
         content,
-        `<div class="predictions-empty-message">
-        <p>No forecast data available.</p>
-        <p>Run the analytics pipeline with predictions enabled to generate forecasts.</p>
-      </div>`
+        `<div class="predictions-empty-message">${message}</div>`
       );
       container.appendChild(content);
       return;
@@ -6982,18 +6983,6 @@ var PRInsightsDashboard = (() => {
       );
       appendTrustedHtml(content, chartHtml);
     });
-    const hasReviewTime = visibleForecasts.some(
-      (f2) => f2.metric === "review_time_minutes"
-    );
-    if (!hasReviewTime && visibleForecasts.length > 0) {
-      appendTrustedHtml(
-        content,
-        `<div class="metric-unavailable">
-        <span class="info-icon">&#x2139;</span>
-        <span class="info-text">Review time forecasts require dedicated review duration data collection, which is not currently available.</span>
-      </div>`
-      );
-    }
     const unavailable = container.querySelector(".feature-unavailable");
     if (unavailable) unavailable.classList.add("hidden");
     container.appendChild(content);

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -6956,7 +6956,10 @@ var PRInsightsDashboard = (() => {
       </div>`
       );
     }
-    if (!predictions.forecasts || predictions.forecasts.length === 0) {
+    const visibleForecasts = predictions.forecasts.filter(
+      (f2) => f2.metric !== "pr_throughput"
+    );
+    if (!visibleForecasts || visibleForecasts.length === 0) {
       appendTrustedHtml(
         content,
         `<div class="predictions-empty-message">
@@ -6967,7 +6970,7 @@ var PRInsightsDashboard = (() => {
       container.appendChild(content);
       return;
     }
-    predictions.forecasts.forEach((forecast) => {
+    visibleForecasts.forEach((forecast) => {
       const historicalResult = rollups ? extractHistoricalDataResult(rollups, forecast.metric) : void 0;
       const historicalData = historicalResult?.data;
       const wasTruncated = historicalResult?.wasTruncated === true;
@@ -6979,10 +6982,10 @@ var PRInsightsDashboard = (() => {
       );
       appendTrustedHtml(content, chartHtml);
     });
-    const hasReviewTime = predictions.forecasts.some(
+    const hasReviewTime = visibleForecasts.some(
       (f2) => f2.metric === "review_time_minutes"
     );
-    if (!hasReviewTime && predictions.forecasts.length > 0) {
+    if (!hasReviewTime && visibleForecasts.length > 0) {
       appendTrustedHtml(
         content,
         `<div class="metric-unavailable">

--- a/docs/reference/dataset-contract.md
+++ b/docs/reference/dataset-contract.md
@@ -400,6 +400,8 @@ This flag is set from actual pipeline output (not from input conditions) to avoi
 - `cycle_time_minutes` — Predicted cycle time per period
 - `review_time_minutes` — Predicted review latency per period
 
+**Dashboard rendering:** `trends.json` may contain any subset of the metric enum; the dashboard currently renders cycle-time forecasts only. Downstream consumers reading the artifact directly receive every emitted metric.
+
 **Extensibility:** Unknown fields MUST be allowed for forward compatibility.
 
 ---

--- a/docs/user-guide/enable-ml-features.md
+++ b/docs/user-guide/enable-ml-features.md
@@ -2,7 +2,7 @@
 
 Two opt-in dashboard tabs:
 
-- **Predictions** — 4-week forecasts for PR throughput, cycle time, and review time. Zero-config (NumPy linear forecaster) by default; Prophet upgrades the model with seasonality detection when installed.
+- **Predictions** — 4-week cycle-time forecasts in the dashboard. Zero-config (NumPy linear forecaster) by default; Prophet upgrades the model with seasonality detection when installed. The emitted `trends.json` may contain additional metrics for downstream consumers; the dashboard currently renders cycle-time only.
 - **AI Insights** — OpenAI-generated observations on bottlenecks, trends, and anomalies. Requires an OpenAI API key.
 
 Enable per pipeline run via task inputs.
@@ -61,7 +61,7 @@ aggregates/
 
 ### `predictions/trends.json`
 
-4-week forecasts per metric (`pr_throughput`, `cycle_time_minutes`, `review_time_minutes`). Each forecast value carries `predicted`, `lower_bound`, `upper_bound`, and `period_start`. Top-level `forecaster` is `linear` or `prophet`; `data_quality` is `normal` (8+ weeks), `low_confidence` (4–7 weeks), or `insufficient` (<4 weeks → no forecasts emitted).
+4-week forecasts per metric. The artifact may contain `pr_throughput`, `cycle_time_minutes`, and `review_time_minutes` for downstream consumers; the dashboard currently renders cycle-time forecasts only. Each forecast value carries `predicted`, `lower_bound`, `upper_bound`, and `period_start`. Top-level `forecaster` is `linear` or `prophet`; `data_quality` is `normal` (8+ weeks), `low_confidence` (4–7 weeks), or `insufficient` (<4 weeks → no forecasts emitted).
 
 ### `insights/summary.json`
 

--- a/extension/overview.md
+++ b/extension/overview.md
@@ -16,7 +16,7 @@ Previously available via private share to select organizations; now in public pr
 
 ### Optional Add-Ons (requires additional pipeline configuration)
 
-- **ML Predictions** — Time-to-merge forecasting using Prophet models. Requires setting `enablePredictions: true` in the pipeline task and installing Python Prophet dependencies.
+- **ML Predictions** — Cycle-time forecasts in the dashboard. Zero-config (NumPy linear forecaster); Prophet is used automatically if installed for seasonality-aware forecasts. Requires setting `enablePredictions: true` in the pipeline task.
 - **AI-Powered Insights** — Natural language summaries of PR trends and anomalies. Requires providing an OpenAI API key via pipeline variable.
 
 ![ML Predictions panel showing cycle time forecasts and confidence intervals](screenshots/ml-predictions.png)

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -6956,16 +6956,17 @@ var PRInsightsDashboard = (() => {
       </div>`
       );
     }
+    const RENDERED_METRICS = /* @__PURE__ */ new Set(["cycle_time_minutes"]);
     const visibleForecasts = predictions.forecasts.filter(
-      (f2) => f2.metric !== "pr_throughput"
+      (f2) => RENDERED_METRICS.has(f2.metric)
     );
-    if (!visibleForecasts || visibleForecasts.length === 0) {
+    if (visibleForecasts.length === 0) {
+      const sourceEmitted = predictions.forecasts.length > 0;
+      const message = sourceEmitted ? `<p>No supported prediction metrics are available in this run.</p>` : `<p>No forecast data available.</p>
+         <p>Run the analytics pipeline with predictions enabled to generate forecasts.</p>`;
       appendTrustedHtml(
         content,
-        `<div class="predictions-empty-message">
-        <p>No forecast data available.</p>
-        <p>Run the analytics pipeline with predictions enabled to generate forecasts.</p>
-      </div>`
+        `<div class="predictions-empty-message">${message}</div>`
       );
       container.appendChild(content);
       return;
@@ -6982,18 +6983,6 @@ var PRInsightsDashboard = (() => {
       );
       appendTrustedHtml(content, chartHtml);
     });
-    const hasReviewTime = visibleForecasts.some(
-      (f2) => f2.metric === "review_time_minutes"
-    );
-    if (!hasReviewTime && visibleForecasts.length > 0) {
-      appendTrustedHtml(
-        content,
-        `<div class="metric-unavailable">
-        <span class="info-icon">&#x2139;</span>
-        <span class="info-text">Review time forecasts require dedicated review duration data collection, which is not currently available.</span>
-      </div>`
-      );
-    }
     const unavailable = container.querySelector(".feature-unavailable");
     if (unavailable) unavailable.classList.add("hidden");
     container.appendChild(content);

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -6956,7 +6956,10 @@ var PRInsightsDashboard = (() => {
       </div>`
       );
     }
-    if (!predictions.forecasts || predictions.forecasts.length === 0) {
+    const visibleForecasts = predictions.forecasts.filter(
+      (f2) => f2.metric !== "pr_throughput"
+    );
+    if (!visibleForecasts || visibleForecasts.length === 0) {
       appendTrustedHtml(
         content,
         `<div class="predictions-empty-message">
@@ -6967,7 +6970,7 @@ var PRInsightsDashboard = (() => {
       container.appendChild(content);
       return;
     }
-    predictions.forecasts.forEach((forecast) => {
+    visibleForecasts.forEach((forecast) => {
       const historicalResult = rollups ? extractHistoricalDataResult(rollups, forecast.metric) : void 0;
       const historicalData = historicalResult?.data;
       const wasTruncated = historicalResult?.wasTruncated === true;
@@ -6979,10 +6982,10 @@ var PRInsightsDashboard = (() => {
       );
       appendTrustedHtml(content, chartHtml);
     });
-    const hasReviewTime = predictions.forecasts.some(
+    const hasReviewTime = visibleForecasts.some(
       (f2) => f2.metric === "review_time_minutes"
     );
-    if (!hasReviewTime && predictions.forecasts.length > 0) {
+    if (!hasReviewTime && visibleForecasts.length > 0) {
       appendTrustedHtml(
         content,
         `<div class="metric-unavailable">

--- a/extension/tests/modules/charts/predictions.test.ts
+++ b/extension/tests/modules/charts/predictions.test.ts
@@ -345,12 +345,14 @@ describe("renderPredictionsWithCharts branch coverage", () => {
     document.body.removeChild(container);
   });
 
-  it("filters pr_throughput out of the rendered set while keeping cycle_time_minutes (PR #389 acceptance gate)", () => {
-    // Per PR #389 walk-forward backtest, the linear forecaster loses to a
-    // persistence baseline for pr_throughput at h=1, h=4, and the
-    // all-horizon aggregate. The renderer at predictions.ts:537 must filter
-    // pr_throughput before forEach so misleading throughput forecasts never
-    // reach the user-facing tab. cycle_time_minutes must still render.
+  it("renders only cycle_time_minutes from a mixed payload (allowlist)", () => {
+    // The render allowlist accepts cycle_time_minutes only. pr_throughput
+    // is excluded per PR #389's walk-forward backtest verdict;
+    // review_time_minutes is excluded because the historical-data
+    // extractor has no mapping for it, so it would render as a bare
+    // forecast band. The mixed fixture exercises both arms of the
+    // allowlist predicate: cycle_time_minutes (kept) and the other two
+    // metrics (dropped).
     const predictions: PredictionsRenderData = {
       generated_at: "2026-05-11T00:00:00Z",
       forecaster: "linear",
@@ -391,31 +393,93 @@ describe("renderPredictionsWithCharts branch coverage", () => {
             },
           ],
         },
+        {
+          metric: "review_time_minutes",
+          unit: "minutes",
+          values: [
+            {
+              period_start: "2026-05-11",
+              predicted: 120,
+              lower_bound: 90,
+              upper_bound: 150,
+            },
+            {
+              period_start: "2026-05-18",
+              predicted: 125,
+              lower_bound: 95,
+              upper_bound: 155,
+            },
+          ],
+        },
       ],
     };
 
     renderPredictionsWithCharts(container, predictions);
 
-    // Exactly one forecast chart renders — pr_throughput is suppressed.
+    // Exactly one forecast chart renders — only cycle_time_minutes is in
+    // the allowlist.
     const charts = container.querySelectorAll(".forecast-chart");
     expect(charts).toHaveLength(1);
-
-    // The surviving chart is cycle_time_minutes; its sanitized id is the
-    // metric string verbatim (sanitizeForId leaves _ and a-z alone).
     expect(container.querySelector("#chart-cycle_time_minutes")).not.toBeNull();
     expect(container.querySelector("#chart-pr_throughput")).toBeNull();
+    expect(container.querySelector("#chart-review_time_minutes")).toBeNull();
 
-    // Title-cased label visible to users.
+    // Title-cased label visible to users; suppressed metrics never appear.
     expect(container.textContent).toContain("Cycle Time Minutes");
     expect(container.textContent).not.toContain("Pr Throughput");
+    expect(container.textContent).not.toContain("Review Time Minutes");
+
+    // No supported-metrics empty state when at least one supported metric
+    // renders.
+    expect(container.querySelector(".predictions-empty-message")).toBeNull();
   });
 
-  it("suppresses the review-time unavailable message when a review_time_minutes forecast is present", () => {
-    // `hasReviewTime` true → `!hasReviewTime && predictions.forecasts.length > 0`
-    // evaluates false at the AND and the metric-unavailable notice is not
-    // emitted. This is the missing left-hand branch on line 555.
+  it("shows the supported-metrics empty state when only pr_throughput is emitted", () => {
+    // The producer emitted a forecast, but pr_throughput is not in the
+    // render allowlist. The empty-state branch must take the
+    // `sourceEmitted === true` arm and emit the "no supported prediction
+    // metrics" copy — not the "run the pipeline" copy that would be
+    // misleading because the user already ran the pipeline.
     const predictions: PredictionsRenderData = {
-      generated_at: "2026-01-28T12:00:00Z",
+      generated_at: "2026-05-11T00:00:00Z",
+      forecaster: "linear",
+      forecasts: [
+        {
+          metric: "pr_throughput",
+          unit: "count",
+          values: [
+            {
+              period_start: "2026-05-11",
+              predicted: 50,
+              lower_bound: 40,
+              upper_bound: 60,
+            },
+          ],
+        },
+      ],
+    };
+
+    renderPredictionsWithCharts(container, predictions);
+
+    expect(container.querySelectorAll(".forecast-chart")).toHaveLength(0);
+    const empty = container.querySelector(".predictions-empty-message");
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toContain(
+      "No supported prediction metrics are available in this run.",
+    );
+    // The original "run the pipeline" copy must NOT appear here — the
+    // user already ran the pipeline.
+    expect(empty?.textContent).not.toContain("Run the analytics pipeline");
+  });
+
+  it("shows the supported-metrics empty state when only review_time_minutes is emitted (no bare unsupported chart)", () => {
+    // review_time_minutes is emitted but not in the render allowlist. The
+    // tab must NOT render a bare forecast band — it must take the
+    // supported-metrics empty state instead. This guards against a
+    // regression where review_time would be allowlisted again or where
+    // the filter would accidentally pass it through.
+    const predictions: PredictionsRenderData = {
+      generated_at: "2026-05-11T00:00:00Z",
       forecaster: "linear",
       forecasts: [
         {
@@ -431,7 +495,42 @@ describe("renderPredictionsWithCharts branch coverage", () => {
 
     renderPredictionsWithCharts(container, predictions);
 
-    expect(container.querySelector(".forecast-chart")).not.toBeNull();
-    expect(container.querySelector(".metric-unavailable")).toBeNull();
+    expect(container.querySelectorAll(".forecast-chart")).toHaveLength(0);
+    expect(
+      container.querySelector("#chart-review_time_minutes"),
+    ).toBeNull();
+    const empty = container.querySelector(".predictions-empty-message");
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toContain(
+      "No supported prediction metrics are available in this run.",
+    );
+  });
+
+  it("shows the original no-data empty state when no forecasts were emitted", () => {
+    // The producer emitted zero forecasts (e.g. insufficient data quality).
+    // The empty-state branch takes the `sourceEmitted === false` arm and
+    // emits the existing "run the pipeline" copy. This case is distinct
+    // from the supported-metrics empty state and exercises the false arm
+    // of `predictions.forecasts.length > 0`.
+    const predictions: PredictionsRenderData = {
+      generated_at: "2026-05-11T00:00:00Z",
+      forecaster: "linear",
+      forecasts: [],
+    };
+
+    renderPredictionsWithCharts(container, predictions);
+
+    expect(container.querySelectorAll(".forecast-chart")).toHaveLength(0);
+    const empty = container.querySelector(".predictions-empty-message");
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toContain("No forecast data available.");
+    expect(empty?.textContent).toContain(
+      "Run the analytics pipeline with predictions enabled",
+    );
+    // The supported-metrics empty state copy must NOT appear when no
+    // forecasts were emitted at all.
+    expect(empty?.textContent).not.toContain(
+      "No supported prediction metrics are available",
+    );
   });
 });

--- a/extension/tests/modules/charts/predictions.test.ts
+++ b/extension/tests/modules/charts/predictions.test.ts
@@ -496,9 +496,7 @@ describe("renderPredictionsWithCharts branch coverage", () => {
     renderPredictionsWithCharts(container, predictions);
 
     expect(container.querySelectorAll(".forecast-chart")).toHaveLength(0);
-    expect(
-      container.querySelector("#chart-review_time_minutes"),
-    ).toBeNull();
+    expect(container.querySelector("#chart-review_time_minutes")).toBeNull();
     const empty = container.querySelector(".predictions-empty-message");
     expect(empty).not.toBeNull();
     expect(empty?.textContent).toContain(

--- a/extension/tests/modules/charts/predictions.test.ts
+++ b/extension/tests/modules/charts/predictions.test.ts
@@ -345,6 +345,71 @@ describe("renderPredictionsWithCharts branch coverage", () => {
     document.body.removeChild(container);
   });
 
+  it("filters pr_throughput out of the rendered set while keeping cycle_time_minutes (PR #389 acceptance gate)", () => {
+    // Per PR #389 walk-forward backtest, the linear forecaster loses to a
+    // persistence baseline for pr_throughput at h=1, h=4, and the
+    // all-horizon aggregate. The renderer at predictions.ts:537 must filter
+    // pr_throughput before forEach so misleading throughput forecasts never
+    // reach the user-facing tab. cycle_time_minutes must still render.
+    const predictions: PredictionsRenderData = {
+      generated_at: "2026-05-11T00:00:00Z",
+      forecaster: "linear",
+      forecasts: [
+        {
+          metric: "pr_throughput",
+          unit: "count",
+          values: [
+            {
+              period_start: "2026-05-11",
+              predicted: 50,
+              lower_bound: 40,
+              upper_bound: 60,
+            },
+            {
+              period_start: "2026-05-18",
+              predicted: 55,
+              lower_bound: 45,
+              upper_bound: 65,
+            },
+          ],
+        },
+        {
+          metric: "cycle_time_minutes",
+          unit: "minutes",
+          values: [
+            {
+              period_start: "2026-05-11",
+              predicted: 4320,
+              lower_bound: 3600,
+              upper_bound: 5040,
+            },
+            {
+              period_start: "2026-05-18",
+              predicted: 4400,
+              lower_bound: 3700,
+              upper_bound: 5100,
+            },
+          ],
+        },
+      ],
+    };
+
+    renderPredictionsWithCharts(container, predictions);
+
+    // Exactly one forecast chart renders — pr_throughput is suppressed.
+    const charts = container.querySelectorAll(".forecast-chart");
+    expect(charts).toHaveLength(1);
+
+    // The surviving chart is cycle_time_minutes; its sanitized id is the
+    // metric string verbatim (sanitizeForId leaves _ and a-z alone).
+    expect(container.querySelector("#chart-cycle_time_minutes")).not.toBeNull();
+    expect(container.querySelector("#chart-pr_throughput")).toBeNull();
+
+    // Title-cased label visible to users.
+    expect(container.textContent).toContain("Cycle Time Minutes");
+    expect(container.textContent).not.toContain("Pr Throughput");
+  });
+
   it("suppresses the review-time unavailable message when a review_time_minutes forecast is present", () => {
     // `hasReviewTime` true → `!hasReviewTime && predictions.forecasts.length > 0`
     // evaluates false at the AND and the metric-unavailable notice is not

--- a/extension/tests/modules/ml.test.ts
+++ b/extension/tests/modules/ml.test.ts
@@ -52,17 +52,20 @@ describe("renderPredictions", () => {
   });
 
   it("renders predictions content", () => {
+    // Uses cycle_time_minutes — the only metric the render allowlist
+    // accepts. The test asserts the chart-rendering path, not the
+    // specific metric.
     const predictions: PredictionsRenderData = {
       forecasts: [
         {
-          metric: "pr_count",
-          unit: "count",
+          metric: "cycle_time_minutes",
+          unit: "minutes",
           values: [
             {
               period_start: "2024-W01",
-              predicted: 10,
-              lower_bound: 8,
-              upper_bound: 12,
+              predicted: 60,
+              lower_bound: 48,
+              upper_bound: 72,
             },
           ],
         },
@@ -75,8 +78,8 @@ describe("renderPredictions", () => {
       container.querySelector(".predictions-charts-content"),
     ).not.toBeNull();
     expect(container.querySelector(".forecast-chart")).not.toBeNull();
-    expect(container.textContent).toContain("Pr Count");
-    expect(container.textContent).toContain("10");
+    expect(container.textContent).toContain("Cycle Time Minutes");
+    expect(container.textContent).toContain("60");
   });
 
   it("shows preview banner when is_stub is true", () => {
@@ -92,17 +95,21 @@ describe("renderPredictions", () => {
   });
 
   it("hides feature-unavailable element when forecasts exist", () => {
+    // Uses cycle_time_minutes so the allowlist passes through to the
+    // chart-rendering path, which is where the feature-unavailable
+    // hide step lives. A non-allowlisted metric would short-circuit to
+    // the empty-state branch and never reach the hide step.
     const predictions: PredictionsRenderData = {
       forecasts: [
         {
-          metric: "test",
-          unit: "count",
+          metric: "cycle_time_minutes",
+          unit: "minutes",
           values: [
             {
               period_start: "2024-W01",
-              predicted: 10,
-              lower_bound: 8,
-              upper_bound: 12,
+              predicted: 60,
+              lower_bound: 48,
+              upper_bound: 72,
             },
           ],
         },
@@ -115,7 +122,13 @@ describe("renderPredictions", () => {
     expect(unavailable?.classList.contains("hidden")).toBe(true);
   });
 
-  it("escapes XSS in metric names", () => {
+  it("filters non-allowlisted metric names (defense in depth against malicious metrics)", () => {
+    // The render allowlist accepts cycle_time_minutes only, so a metric
+    // name carrying an HTML/script payload is filtered out before it
+    // reaches renderForecastChart's escapeHtml call site. The allowlist
+    // is a stronger guarantee than escaping: the payload never reaches
+    // any HTML-emitting code path. renderForecastChart's escapeHtml
+    // remains the per-chart defense, exercised by predictions.test.ts.
     const predictions: PredictionsRenderData = {
       forecasts: [
         {
@@ -135,15 +148,19 @@ describe("renderPredictions", () => {
 
     renderPredictions(container, predictions);
 
-    // Script element should not be created in the DOM
+    // No chart is rendered for the malicious metric — the allowlist
+    // dropped it.
     expect(container.querySelector("script")).toBeNull();
-    // The h4 text content should contain the literal text (escaped)
-    const h4 = container.querySelector("h4");
-    expect(h4?.textContent).toContain("Script");
-    // ID attributes should be sanitized (no angle brackets)
-    const chartId = h4?.id;
-    expect(chartId).not.toContain("<");
-    expect(chartId).not.toContain(">");
+    expect(container.querySelector(".forecast-chart")).toBeNull();
+    expect(container.querySelector("h4")).toBeNull();
+
+    // The supported-metrics empty state is shown instead because the
+    // producer emitted a forecast but no metric was in the allowlist.
+    const empty = container.querySelector(".predictions-empty-message");
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toContain(
+      "No supported prediction metrics are available in this run.",
+    );
   });
 
   it("does not show partial-history badge when historical data naturally has 200 points", () => {

--- a/extension/tests/modules/ml.test.ts
+++ b/extension/tests/modules/ml.test.ts
@@ -147,17 +147,21 @@ describe("renderPredictions", () => {
   });
 
   it("does not show partial-history badge when historical data naturally has 200 points", () => {
+    // Uses cycle_time_minutes because pr_throughput is suppressed at the
+    // renderer per PR #389 backtest verdict; the truncation-badge logic
+    // is metric-agnostic but must be exercised against a metric that reaches
+    // the chart rendering path.
     const predictions: PredictionsRenderData = {
       forecasts: [
         {
-          metric: "pr_throughput",
-          unit: "count",
+          metric: "cycle_time_minutes",
+          unit: "minutes",
           values: [
             {
               period_start: "2024-W01",
-              predicted: 10,
-              lower_bound: 8,
-              upper_bound: 12,
+              predicted: 60,
+              lower_bound: 48,
+              upper_bound: 72,
             },
           ],
         },
@@ -176,17 +180,21 @@ describe("renderPredictions", () => {
   });
 
   it("shows partial-history badge when historical data exceeds 200 points", () => {
+    // Uses cycle_time_minutes because pr_throughput is suppressed at the
+    // renderer per PR #389 backtest verdict; the truncation-badge logic
+    // is metric-agnostic but must be exercised against a metric that reaches
+    // the chart rendering path.
     const predictions: PredictionsRenderData = {
       forecasts: [
         {
-          metric: "pr_throughput",
-          unit: "count",
+          metric: "cycle_time_minutes",
+          unit: "minutes",
           values: [
             {
               period_start: "2024-W01",
-              predicted: 10,
-              lower_bound: 8,
-              upper_bound: 12,
+              predicted: 60,
+              lower_bound: 48,
+              upper_bound: 72,
             },
           ],
         },
@@ -1103,19 +1111,23 @@ describe("Predictions Tab State Rendering (T017-T021)", () => {
   });
 
   it("T018: renders ready state with valid artifact", () => {
+    // Uses cycle_time_minutes because pr_throughput is suppressed at the
+    // renderer per PR #389 backtest verdict; a ready-state fixture must
+    // use a metric that survives the filter so the assertion exercises
+    // the chart-rendering path rather than the empty-message fallback.
     const state: ArtifactState = {
       type: "ready",
       data: {
         forecasts: [
           {
-            metric: "pr_throughput",
-            unit: "count",
+            metric: "cycle_time_minutes",
+            unit: "minutes",
             values: [
               {
                 period_start: "2026-01-28",
-                predicted: 15,
-                lower_bound: 12,
-                upper_bound: 18,
+                predicted: 60,
+                lower_bound: 48,
+                upper_bound: 72,
               },
             ],
           },

--- a/extension/ui/modules/charts/predictions.ts
+++ b/extension/ui/modules/charts/predictions.ts
@@ -518,31 +518,41 @@ export function renderPredictionsWithCharts(
     );
   }
 
-  // pr_throughput is filtered out before rendering: PR #389 walk-forward
-  // backtest showed the linear forecaster loses to a persistence baseline
-  // for throughput (MAE 95.70 vs 92.97, MAPE 28.7% vs 26.2% at all-horizon
-  // aggregate, decisively at h=1 and h=4). Suppressing it from the
-  // user-facing tab is the acceptance gate per the throughput-model verdict.
-  const visibleForecasts = predictions.forecasts.filter(
-    (f) => f.metric !== "pr_throughput",
+  // Render allowlist. trends.json may contain pr_throughput,
+  // cycle_time_minutes, and review_time_minutes; the dashboard currently
+  // renders cycle_time only. pr_throughput is excluded because PR #389's
+  // walk-forward backtest showed the linear forecaster loses to a
+  // persistence baseline; review_time_minutes is excluded because the
+  // historical-data extractor has no mapping for it, so it would render
+  // as a bare forecast band with no context. The model and the emitted
+  // artifact are unchanged — this filter affects the user-facing tab only.
+  const RENDERED_METRICS = new Set(["cycle_time_minutes"]);
+  const visibleForecasts = predictions.forecasts.filter((f) =>
+    RENDERED_METRICS.has(f.metric),
   );
 
-  // Check for empty forecasts
-  if (!visibleForecasts || visibleForecasts.length === 0) {
+  // Two distinct empty-state cases. `predictions.forecasts.length === 0`
+  // means the producer emitted no forecasts at all (e.g. insufficient
+  // data). `visibleForecasts.length === 0` with at least one emitted
+  // forecast means the producer emitted forecasts but the dashboard
+  // does not render any of those metrics.
+  if (visibleForecasts.length === 0) {
+    const sourceEmitted = predictions.forecasts.length > 0;
+    const message = sourceEmitted
+      ? `<p>No supported prediction metrics are available in this run.</p>`
+      : `<p>No forecast data available.</p>
+         <p>Run the analytics pipeline with predictions enabled to generate forecasts.</p>`;
     appendTrustedHtml(
       content,
-      `<div class="predictions-empty-message">
-        <p>No forecast data available.</p>
-        <p>Run the analytics pipeline with predictions enabled to generate forecasts.</p>
-      </div>`,
+      `<div class="predictions-empty-message">${message}</div>`,
     );
     container.appendChild(content);
     return;
   }
 
-  // Render each forecast as a chart with historical data. The truncation
-  // badge is emitted inline by renderForecastChart when wasTruncated is
-  // true, so no post-append querySelector step is needed.
+  // Render each supported forecast as a chart with historical data. The
+  // truncation badge is emitted inline by renderForecastChart when
+  // wasTruncated is true, so no post-append querySelector step is needed.
   visibleForecasts.forEach((forecast: Forecast) => {
     const historicalResult = rollups
       ? extractHistoricalDataResult(rollups, forecast.metric)
@@ -557,21 +567,6 @@ export function renderPredictionsWithCharts(
     );
     appendTrustedHtml(content, chartHtml);
   });
-
-  // Show informational message about review time unavailability (T016)
-  // Review time forecasts were removed because they used cycle time as a misleading proxy
-  const hasReviewTime = visibleForecasts.some(
-    (f) => f.metric === "review_time_minutes",
-  );
-  if (!hasReviewTime && visibleForecasts.length > 0) {
-    appendTrustedHtml(
-      content,
-      `<div class="metric-unavailable">
-        <span class="info-icon">&#x2139;</span>
-        <span class="info-text">Review time forecasts require dedicated review duration data collection, which is not currently available.</span>
-      </div>`,
-    );
-  }
 
   // Hide unavailable message if present
   const unavailable = container.querySelector(".feature-unavailable");

--- a/extension/ui/modules/charts/predictions.ts
+++ b/extension/ui/modules/charts/predictions.ts
@@ -518,8 +518,17 @@ export function renderPredictionsWithCharts(
     );
   }
 
+  // pr_throughput is filtered out before rendering: PR #389 walk-forward
+  // backtest showed the linear forecaster loses to a persistence baseline
+  // for throughput (MAE 95.70 vs 92.97, MAPE 28.7% vs 26.2% at all-horizon
+  // aggregate, decisively at h=1 and h=4). Suppressing it from the
+  // user-facing tab is the acceptance gate per the throughput-model verdict.
+  const visibleForecasts = predictions.forecasts.filter(
+    (f) => f.metric !== "pr_throughput",
+  );
+
   // Check for empty forecasts
-  if (!predictions.forecasts || predictions.forecasts.length === 0) {
+  if (!visibleForecasts || visibleForecasts.length === 0) {
     appendTrustedHtml(
       content,
       `<div class="predictions-empty-message">
@@ -534,7 +543,7 @@ export function renderPredictionsWithCharts(
   // Render each forecast as a chart with historical data. The truncation
   // badge is emitted inline by renderForecastChart when wasTruncated is
   // true, so no post-append querySelector step is needed.
-  predictions.forecasts.forEach((forecast: Forecast) => {
+  visibleForecasts.forEach((forecast: Forecast) => {
     const historicalResult = rollups
       ? extractHistoricalDataResult(rollups, forecast.metric)
       : undefined;
@@ -551,10 +560,10 @@ export function renderPredictionsWithCharts(
 
   // Show informational message about review time unavailability (T016)
   // Review time forecasts were removed because they used cycle time as a misleading proxy
-  const hasReviewTime = predictions.forecasts.some(
+  const hasReviewTime = visibleForecasts.some(
     (f) => f.metric === "review_time_minutes",
   );
-  if (!hasReviewTime && predictions.forecasts.length > 0) {
+  if (!hasReviewTime && visibleForecasts.length > 0) {
     appendTrustedHtml(
       content,
       `<div class="metric-unavailable">

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -6956,16 +6956,17 @@ var PRInsightsDashboard = (() => {
       </div>`
       );
     }
+    const RENDERED_METRICS = /* @__PURE__ */ new Set(["cycle_time_minutes"]);
     const visibleForecasts = predictions.forecasts.filter(
-      (f2) => f2.metric !== "pr_throughput"
+      (f2) => RENDERED_METRICS.has(f2.metric)
     );
-    if (!visibleForecasts || visibleForecasts.length === 0) {
+    if (visibleForecasts.length === 0) {
+      const sourceEmitted = predictions.forecasts.length > 0;
+      const message = sourceEmitted ? `<p>No supported prediction metrics are available in this run.</p>` : `<p>No forecast data available.</p>
+         <p>Run the analytics pipeline with predictions enabled to generate forecasts.</p>`;
       appendTrustedHtml(
         content,
-        `<div class="predictions-empty-message">
-        <p>No forecast data available.</p>
-        <p>Run the analytics pipeline with predictions enabled to generate forecasts.</p>
-      </div>`
+        `<div class="predictions-empty-message">${message}</div>`
       );
       container.appendChild(content);
       return;
@@ -6982,18 +6983,6 @@ var PRInsightsDashboard = (() => {
       );
       appendTrustedHtml(content, chartHtml);
     });
-    const hasReviewTime = visibleForecasts.some(
-      (f2) => f2.metric === "review_time_minutes"
-    );
-    if (!hasReviewTime && visibleForecasts.length > 0) {
-      appendTrustedHtml(
-        content,
-        `<div class="metric-unavailable">
-        <span class="info-icon">&#x2139;</span>
-        <span class="info-text">Review time forecasts require dedicated review duration data collection, which is not currently available.</span>
-      </div>`
-      );
-    }
     const unavailable = container.querySelector(".feature-unavailable");
     if (unavailable) unavailable.classList.add("hidden");
     container.appendChild(content);

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -6956,7 +6956,10 @@ var PRInsightsDashboard = (() => {
       </div>`
       );
     }
-    if (!predictions.forecasts || predictions.forecasts.length === 0) {
+    const visibleForecasts = predictions.forecasts.filter(
+      (f2) => f2.metric !== "pr_throughput"
+    );
+    if (!visibleForecasts || visibleForecasts.length === 0) {
       appendTrustedHtml(
         content,
         `<div class="predictions-empty-message">
@@ -6967,7 +6970,7 @@ var PRInsightsDashboard = (() => {
       container.appendChild(content);
       return;
     }
-    predictions.forecasts.forEach((forecast) => {
+    visibleForecasts.forEach((forecast) => {
       const historicalResult = rollups ? extractHistoricalDataResult(rollups, forecast.metric) : void 0;
       const historicalData = historicalResult?.data;
       const wasTruncated = historicalResult?.wasTruncated === true;
@@ -6979,10 +6982,10 @@ var PRInsightsDashboard = (() => {
       );
       appendTrustedHtml(content, chartHtml);
     });
-    const hasReviewTime = predictions.forecasts.some(
+    const hasReviewTime = visibleForecasts.some(
       (f2) => f2.metric === "review_time_minutes"
     );
-    if (!hasReviewTime && predictions.forecasts.length > 0) {
+    if (!hasReviewTime && visibleForecasts.length > 0) {
       appendTrustedHtml(
         content,
         `<div class="metric-unavailable">


### PR DESCRIPTION
Predictions tab now renders supported cycle-time forecasts only; unsupported emitted metrics are filtered; filtered-empty state is corrected; docs now match the rendered surface; no producer/model/schema/default/AI changes.