### PR TITLE
fix(devcontainer): move entire agent wiring out of postCreateCommand

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -87,10 +87,18 @@ RUN curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh \
 # the vscode user without symlink gymnastics. The Dockerfile's specify pin
 # (SPECKIT_VERSION + SPECKIT_COMMIT) must match `.specify/init-options.json`
 # co-committed with this Dockerfile (FR-002 co-commit invariant).
+#
+# Version extraction uses the same `grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1`
+# pattern as the `entire --version` probe below. The previous `awk '{print $NF}'`
+# idiom worked only because Spec Kit 0.9.2 emits a single-line `specify 0.9.2`
+# — the entire CLI's multi-line output broke that exact pattern at this
+# Dockerfile site in PR #416 (CI run 26988692452, fixed in PR #417). Pre-empt
+# the same regression class for Spec Kit by extracting the first three-part
+# numeric token from anywhere in the output.
 RUN UV_TOOL_DIR=/opt/uv-tools UV_TOOL_BIN_DIR=/usr/local/bin \
         uv tool install \
             "specify-cli @ git+https://github.com/github/spec-kit.git@${SPECKIT_COMMIT}" \
-    && installed="$(specify --version 2>&1 | awk '{print $NF}')" \
+    && installed="$(specify --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" \
     && [ "$installed" = "${SPECKIT_VERSION}" ] \
        || { echo "specify version mismatch: got '$installed', expected '${SPECKIT_VERSION}'" >&2; exit 1; }
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -68,7 +68,7 @@ cd /path/to/your/checkout
 devcontainer up --workspace-folder .
 ```
 
-The CLI pulls the GHCR image (or builds locally if you've overridden `image` → `build`), applies the Node Feature, runs `onCreateCommand` (`sudo chown` of the gh + entire named volume mounts), then runs `postCreateCommand` (Corepack-pinned pnpm + `pnpm install` + `uv sync` + extension install + `entire enable --yes`). When the command returns, the container is in the same post-lifecycle state VS Code would produce.
+The CLI pulls the GHCR image (or builds locally if you've overridden `image` → `build`), applies the Node Feature, runs `onCreateCommand` (`sudo chown` of the gh + entire named volume mounts), then runs `postCreateCommand` (Corepack-pinned pnpm + `pnpm install` + `uv sync` + extension install). When the command returns, the container is in the same post-lifecycle state VS Code would produce. Agent-specific `entire` wiring (`entire enable --agent <yours>`) is intentionally **not** in `postCreateCommand` — it's a contributor-driven step documented in [Scenario E](#scenario-e--entire-first-run-login-named-volume-persistence-default).
 
 ### Run gates against the post-lifecycle container
 
@@ -316,6 +316,14 @@ State persists in the named Docker volume `ado-git-repo-insights-entire-config`.
 - Sessions are captured into the `entire/checkpoints/v1` branch IN this repo (not on entire.io's servers by default).
 - Repo-level telemetry is **explicitly disabled** via the tracked `.entire/settings.json`.
 - If you choose NOT to `entire login`, the `entire` binary is still installed and the husky hooks still fire — but no session data is captured. All commits, pushes, and PR creation succeed unchanged. External fork contributors are not required to authenticate.
+
+**Optional: wire `entire` for an installed AI agent.** Once you've installed your preferred AI agent CLI (Claude Code, Codex, gemini-cli, opencode, cursor, copilot CLI, or FactoryAI — installed via your dotfiles or `npm i -g …` inside the container, **not** shipped in this image per FR-008), run the appropriate `entire` setup command to wire agent-specific hooks beyond what `.husky/_/` already provides. Check `entire enable --help` for the current invocation — at the time of writing, the documented form is:
+
+```bash
+$ entire enable --agent <name>     # e.g. claude-code, codex, gemini-cli
+```
+
+This step is **intentionally NOT in `postCreateCommand`**. Pre-wiring tracked infrastructure for agents that aren't installed in the image was the PR #416 / #417 failure class (the publish-devcontainer CI job runs `docker build` only, so postCreateCommand never executes in CI — any agent-specific defect stays invisible until the first contributor rebuild). Each contributor wires whichever agents they actually use; skip the step entirely if you don't want agent-specific capture.
 
 **Failure remediation**: if `entire login` fails with `permission denied` writing to `/home/vscode/.entire/`, the `onCreateCommand` chown did not run or did not target the entire mount path — same remediation as Scenario A.
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -54,7 +54,7 @@
     // both the failure and the fix).
     "onCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.config/gh /home/vscode/.entire",
 
-    // postCreateCommand: FR-021 + FR-020 idempotent fail-closed chain.
+    // postCreateCommand: FR-021 idempotent fail-closed chain.
     // Step order is load-bearing:
     //
     //   1. `corepack enable` + `corepack prepare pnpm@9.15.0 --activate` —
@@ -73,14 +73,21 @@
     //   6. `pnpm --dir extension install --frozen-lockfile` — extension
     //      deps; triggers the Playwright postinstall (~110 MB Chromium
     //      download into ~/.cache/ms-playwright).
-    //   7. `entire enable --yes --agent claude-code,codex` — LAST (per
-    //      FR-020 + QG-7f). Husky's dispatcher (from step 4) is overwritten
-    //      by entire's dispatcher per the QG-7f accepted constitutional
-    //      asymmetry. CI commitlint remains authoritative.
     //
     // The chain is joined by `&&` — any failure aborts setup entirely. No
     // `|| true` or failure suppression is permitted (FR-021).
-    "postCreateCommand": "corepack enable && corepack prepare pnpm@9.15.0 --activate && [ \"$(pnpm --version)\" = \"9.15.0\" ] || { echo \"FATAL: pnpm version mismatch\" >&2; exit 1; } && git config core.autocrlf false && pnpm install --frozen-lockfile && uv sync --locked --extra dev && pnpm --dir extension install --frozen-lockfile && entire enable --yes --agent claude-code,codex",
+    //
+    // NOTE: `entire enable --agent <X>` and `entire agent add <X>` are
+    // intentionally NOT in this chain — agent wiring is contributor-driven
+    // (see README Scenario E). Agents like Claude Code and Codex aren't
+    // shipped in this image per FR-008; pre-wiring tracked infra for agents
+    // that aren't installed was the PR #416 / #417 failure class (CI runs
+    // `docker build` only, so postCreateCommand never executes in CI and
+    // runtime defects stay invisible until first contributor rebuild). The
+    // `entire` BINARY still ships in the image per FR-020, and `.husky/_/`
+    // already invokes `entire hooks git <stage>` defensively, so basic git-
+    // hook capture activates as soon as the contributor runs `entire login`.
+    "postCreateCommand": "corepack enable && corepack prepare pnpm@9.15.0 --activate && [ \"$(pnpm --version)\" = \"9.15.0\" ] || { echo \"FATAL: pnpm version mismatch\" >&2; exit 1; } && git config core.autocrlf false && pnpm install --frozen-lockfile && uv sync --locked --extra dev && pnpm --dir extension install --frozen-lockfile",
 
     "customizations": {
         "vscode": {

--- a/.devcontainer/verify-contract.py
+++ b/.devcontainer/verify-contract.py
@@ -191,8 +191,8 @@ assert "vscode:vscode" in oncreate or "vscode " in oncreate, (
 )
 
 # postCreateCommand: per FR-021, must begin with Corepack activation + pinned
-# pnpm + fail-closed validation, and per FR-020, must end with `entire enable
-# --yes --agent`. Order: corepack -> pnpm install -> entire enable.
+# pnpm + fail-closed validation. Agent-specific entire wiring is contributor-
+# driven (see README Scenario E) and MUST NOT appear in the tracked chain.
 postcreate = d.get("postCreateCommand", "")
 if isinstance(postcreate, list):
     postcreate = " && ".join(postcreate)
@@ -216,32 +216,70 @@ assert "pnpm --version" in postcreate, (
     "(FR-021 fail-closed)"
 )
 
-# FR-020: entire enable LAST
-assert "entire enable" in postcreate, (
-    "postCreateCommand must include `entire enable` per FR-020 (deterministic "
-    "entire hook wiring)"
+# FR-020 (revised 2026-06-06): the `entire` BINARY install stays in the
+# Dockerfile per FR-020. Agent-specific wiring (`entire enable --agent <X>`,
+# `entire agent add <X>`) is contributor-driven, NOT part of the tracked
+# postCreateCommand chain.
+#
+# History: PR #416 prescribed `entire enable --yes --agent claude-code,codex`
+# in postCreateCommand. That command form was invalid — entire CLI v0.7.3
+# defines `--agent` as StringVar (single value; see entireio/cli@v0.7.3/
+# cmd/entire/cli/setup.go:888), so the comma-list is treated as one agent
+# name in the registry lookup (agent/registry.go:34) and fails at runtime
+# with `unknown agent: claude-code,codex`. The first hotfix attempt swapped
+# to `entire enable --agent claude-code && entire agent add codex`, which
+# pre-wires entire for two specific agents that AREN'T installed in this
+# image (Claude Code and Codex are developer-personal per FR-008). It also
+# ships an unverified `entire agent add` subcommand into a chain CI doesn't
+# exercise (publish-devcontainer runs `docker build` only; postCreateCommand
+# never executes in CI, so runtime defects stay invisible until the first
+# contributor rebuild).
+#
+# Resolution: agent wiring moves OUT of postCreateCommand entirely. The
+# `entire` binary still ships in the image, and the repo's `.husky/_/`
+# scripts already invoke `entire hooks git <stage>` defensively, so basic
+# git-hook capture activates as soon as the contributor runs `entire login`.
+# Optional agent-specific wiring is documented as a contributor-driven step
+# in README Scenario E.
+import re
+
+# (1) Reject any tracked `entire enable` or `entire agent <subcmd>` invocation
+#     in postCreateCommand. Agent wiring belongs to contributor-driven setup,
+#     not the deterministic fail-closed chain.
+assert "entire enable" not in postcreate, (
+    "`entire enable` MUST NOT appear in postCreateCommand. Agent wiring is "
+    "contributor-driven (see README Scenario E). Re-introducing it here "
+    "couples tracked infra to a personal-agent choice and re-opens the "
+    "PR #416 / #417 failure class — CI doesn't exercise postCreateCommand, "
+    "so any agent-specific defect ships silently until first contributor "
+    "rebuild."
 )
-assert "--yes" in postcreate, (
-    "postCreateCommand's `entire enable` must use `--yes` for non-interactive run"
+assert "entire agent" not in postcreate, (
+    "`entire agent <subcommand>` MUST NOT appear in postCreateCommand. "
+    "See README Scenario E for the contributor-driven flow."
 )
 
-# Ordering invariants:
+# (2) Belt-and-braces tripwire: if a future edit reintroduces an `entire`
+#     subcommand via a different surface (e.g., list-form postCreateCommand,
+#     a flag form not caught by the substring checks above), still reject
+#     the comma-list `--agent` pattern from PR #416 with a specific error.
+for m in re.finditer(r"--agent\s+(\S+)", postcreate):
+    val = m.group(1)
+    assert "," not in val, (
+        f"entire CLI `--agent` is single-value (StringVar); saw {val!r}. "
+        "Agent wiring is contributor-driven per README Scenario E; multi-"
+        "agent setup is not expressed in tracked postCreateCommand at all."
+    )
+
+# Ordering invariant:
 #   corepack BEFORE pnpm install (Corepack must activate pnpm before any pnpm command)
-#   pnpm install BEFORE entire enable (husky's dispatcher installed first,
-#   then entire overwrites per QG-7f)
 corepack_idx = postcreate.find("corepack enable")
 pnpm_install_idx = postcreate.find("pnpm install")
-entire_idx = postcreate.find("entire enable")
 assert corepack_idx != -1, "postCreateCommand must contain `corepack enable`"
 assert pnpm_install_idx != -1, "postCreateCommand must contain `pnpm install`"
-assert entire_idx != -1, "postCreateCommand must contain `entire enable`"
 assert corepack_idx < pnpm_install_idx, (
     "postCreateCommand must run `corepack enable` BEFORE `pnpm install` "
     "(pnpm requires Corepack activation first per FR-021)"
-)
-assert pnpm_install_idx < entire_idx, (
-    "postCreateCommand must run `pnpm install` BEFORE `entire enable` "
-    "(husky dispatcher first, then entire overwrites per QG-7f)"
 )
 
 # containerEnv: no tracked PAT injection (XIX-adjacent; reserved as enterprise override per FR-007)

--- a/.devcontainer/verify-contract.py
+++ b/.devcontainer/verify-contract.py
@@ -241,7 +241,6 @@ assert "pnpm --version" in postcreate, (
 # git-hook capture activates as soon as the contributor runs `entire login`.
 # Optional agent-specific wiring is documented as a contributor-driven step
 # in README Scenario E.
-import re
 
 # (1) Reject any tracked `entire enable` or `entire agent <subcmd>` invocation
 #     in postCreateCommand. Agent wiring belongs to contributor-driven setup,


### PR DESCRIPTION
## Summary

Terminates the PR #416 / PR #417 / this-branch failure loop by removing agent-named `entire` commands from tracked `postCreateCommand` entirely. The dev container chain now ends at `pnpm --dir extension install --frozen-lockfile`; agent-specific `entire` wiring is documented as a contributor-driven step in README Scenario E.

### Why this loop kept failing

- **PR #416** shipped `entire enable --yes --agent claude-code,codex`. Invalid: entire CLI v0.7.3 defines `--agent` as `StringVar` (single value; see `entireio/cli@v0.7.3 cmd/entire/cli/setup.go:888`), so the comma-list is looked up as one agent name and fails the registry lookup at runtime with `unknown agent: claude-code,codex`.
- **PR #417** hotfixed an unrelated `entire --version` parse bug (multi-line output broke `awk '{print $NF}'`) but left the `--agent` defect untouched.
- **This branch's earlier attempt** swapped to `entire enable --agent claude-code && entire agent add codex`. That form pre-wires `entire` for two specific agents (Claude Code, Codex) that **aren't installed in the image** per FR-008, and ships an unverified `entire agent add` subcommand into a chain CI doesn't exercise.

Each iteration stayed invisible to CI because the `publish-devcontainer` job runs `docker build` only — `postCreateCommand` never executes in CI, so runtime defects only surface on first contributor rebuild.

### Resolution shape

- The `entire` **binary** install stays in the Dockerfile (image-level observability infra per FR-020 carve-out).
- The `.husky/_/` scripts already invoke `entire hooks git <stage>` defensively, so basic git-hook capture activates as soon as the contributor runs `entire login`.
- Agent-specific wiring (`entire enable --agent <name>`) becomes contributor-driven, documented as an optional sub-section in README Scenario E. Same flow shape as `gh auth login`.

### Files

- `.devcontainer/devcontainer.json` — postCreateCommand chain ends at extension install; step-7 comment block replaced with NOTE explaining why agent wiring isn't tracked.
- `.devcontainer/verify-contract.py` — FR-020 assertions flipped from require → reject (`entire enable` and `entire agent` MUST NOT appear in postCreateCommand); defensive comma-list `--agent` regex kept as belt-and-braces tripwire; ordering invariants involving `entire` dropped (corepack < pnpm install kept).
- `.devcontainer/README.md` — line-71 description trimmed; new "Optional: wire entire for an installed AI agent" sub-section in Scenario E with a forward-honest "check `entire enable --help`" pointer (no buried unverified subcommand claims).
- `.devcontainer/Dockerfile` — `specify --version` version-probe pattern adopted from the `entire` probe added in #417 (`grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1`) to pre-empt the same multi-line regression class for Spec Kit.

## Test plan

- [ ] **CI**: `publish-devcontainer` succeeds on this branch.
- [ ] **Static verifier** (any platform with Python 3): `python3 .devcontainer/verify-contract.py` exits 0 with `OK: Contract 1 static verification passed`. *Confirmed locally pre-commit.*
- [ ] **Negative verifier test**: temporarily add `entire enable --agent foo` back to `postCreateCommand`, re-run the verifier, confirm it fails with the new reject message. Revert.
- [ ] **First-rebuild smoke** (any host with the rebuilt `:main`): `devcontainer up --workspace-folder .` completes without hitting any `entire` command failure in `postCreateCommand`. The chain ends cleanly at `pnpm --dir extension install`.
- [ ] **Optional agent flow** (contributor-driven, README Scenario E): inside the rebuilt container, install Claude Code (`npm i -g @anthropic-ai/claude-code` or via dotfiles), run `entire enable --help` to confirm the documented form, then run `entire enable --agent claude-code` and confirm it succeeds. This step is intentionally outside `postCreateCommand`.

## Notes for picking this up on a different host

- **Mac-host commit posture**: this PR's commit + push were created from the maintainer's Mac mini using `--no-verify` (explicit authorization). The Mac host intentionally doesn't have project Python deps installed — running `uv sync --extra dev` there would mutate an active observability stack (kuma, grafana, prometheus). Future commits from a host with deps installed (or from inside the dev container) should run hooks normally.
- **Bind-mount drift on Mac (out of scope)**: PR #417 explicitly deferred the `esbuild` arch mismatch and `.venv/bin/python` dangling-symlink issues that recur when running `pnpm install` / `uv sync` inside the container then running pre-push hooks on the Mac host. Those remain out of scope here and need a separate design pass.
- **Gitignored spec dir intentionally not updated**: `specs/364-devcontainer-refactor/` (gitignored) still references the old `entire enable` chain in FR-020 and elsewhere. Spec-doc consistency is the maintainer's surface on their cadence; this PR focuses correctness on tracked artifacts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)