### PR TITLE
fix(dashboard): prevent double-encoding of ADO PR hyperlinks

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -77,13 +77,19 @@
     // Git hooks: `pnpm install` (step 4) runs husky, which sets
     // `core.hooksPath` to `.husky/_` — the single, deterministic hook path
     // present in every container regardless of image build/publish timing.
-    // `entire` overwrites the `.husky/_` dispatchers on session start; the
-    // pre-commit self-heal (`repair_husky_hook_dispatchers` in
-    // scripts/run_repo_hook.py) restores them before git fires commit-msg, so
-    // the CI-parity gates run on every commit/push. See
-    // LOCAL_CI_PARITY_INVARIANTS.md row 7f. postCreateCommand does NOT repoint
-    // core.hooksPath — doing so coupled hook execution to image state and
-    // silently disabled all gates whenever the image lagged the branch.
+    // `entire` overwrites the `.husky/_` dispatchers on session start
+    // (backing each up to `<hook>.pre-entire` and chaining to it by path).
+    // The `prepare` script also runs scripts/install-githooks.cjs after husky,
+    // which writes SELF-CONTAINED `.husky/_/<hook>` dispatchers that exec the
+    // tracked `.husky/<hook>` gate by a hard-coded name — so entire's
+    // wrap-and-chain reaches the real CI-parity gate in every state, with no
+    // skip window and no runtime self-heal needed. (An earlier
+    // `repair_husky_hook_dispatchers` self-heal restored husky's basename
+    // dispatcher at pre-commit time, but that re-broke entire's chain and was
+    // removed.) See LOCAL_CI_PARITY_INVARIANTS.md row 7f. postCreateCommand
+    // does NOT repoint core.hooksPath — doing so coupled hook execution to
+    // image state and silently disabled all gates whenever the image lagged
+    // the branch.
     //
     // The chain is joined by `&&` — any failure aborts setup entirely. No
     // `|| true` or failure suppression is permitted (FR-021).

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/364-devcontainer-refactor"
+  "feature_directory": "specs/365-pr-url-double-encoding"
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 3215,
+    "min_collected": 3220,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/.test-floor-contract.json
+++ b/.test-floor-contract.json
@@ -5,7 +5,7 @@
     "authority": "scripts.check_ratchet_bump.collect_python_snapshot(apply_platform_filters=True)"
   },
   "extension": {
-    "min_collected": 3220,
+    "min_collected": 3221,
     "authority": "extension/test-results.xml parsed via measure_extension_count"
   }
 }

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -10424,13 +10424,22 @@ var PRInsightsDashboard = (() => {
   function ensureTrailingSlash(uri) {
     return uri.endsWith("/") ? uri : `${uri}/`;
   }
+  function encodePathSegmentOnce(value) {
+    let decoded;
+    try {
+      decoded = decodeURIComponent(value);
+    } catch {
+      decoded = value;
+    }
+    return encodeURIComponent(decoded);
+  }
   function resolvePrUrl(pr, repositories, webContext) {
     const base = ensureTrailingSlash(webContext.collectionUri);
     const repo = repositories?.find((r2) => r2.repository_id === pr.repository_id);
     if (repo && repo.repository_name.length > 0 && repo.project_name.length > 0) {
-      return `${base}${encodeURIComponent(repo.project_name)}/_git/${encodeURIComponent(repo.repository_name)}/pullrequest/${pr.id}`;
+      return `${base}${encodePathSegmentOnce(repo.project_name)}/_git/${encodePathSegmentOnce(repo.repository_name)}/pullrequest/${pr.id}`;
     }
-    return `${base}_git/${encodeURIComponent(pr.repository_id)}/pullrequest/${pr.id}`;
+    return `${base}_git/${encodePathSegmentOnce(pr.repository_id)}/pullrequest/${pr.id}`;
   }
 
   // ../ui/modules/drilldown/filter-support.ts

--- a/extension/tests/fixtures/broken-docs/dashboard.js
+++ b/extension/tests/fixtures/broken-docs/dashboard.js
@@ -10424,13 +10424,22 @@ var PRInsightsDashboard = (() => {
   function ensureTrailingSlash(uri) {
     return uri.endsWith("/") ? uri : `${uri}/`;
   }
+  function encodePathSegmentOnce(value) {
+    let decoded;
+    try {
+      decoded = decodeURIComponent(value);
+    } catch {
+      decoded = value;
+    }
+    return encodeURIComponent(decoded);
+  }
   function resolvePrUrl(pr, repositories, webContext) {
     const base = ensureTrailingSlash(webContext.collectionUri);
     const repo = repositories?.find((r2) => r2.repository_id === pr.repository_id);
     if (repo && repo.repository_name.length > 0 && repo.project_name.length > 0) {
-      return `${base}${encodeURIComponent(repo.project_name)}/_git/${encodeURIComponent(repo.repository_name)}/pullrequest/${pr.id}`;
+      return `${base}${encodePathSegmentOnce(repo.project_name)}/_git/${encodePathSegmentOnce(repo.repository_name)}/pullrequest/${pr.id}`;
     }
-    return `${base}_git/${encodeURIComponent(pr.repository_id)}/pullrequest/${pr.id}`;
+    return `${base}_git/${encodePathSegmentOnce(pr.repository_id)}/pullrequest/${pr.id}`;
   }
 
   // ../ui/modules/drilldown/filter-support.ts

--- a/extension/tests/modules/shared/pr-url.test.ts
+++ b/extension/tests/modules/shared/pr-url.test.ts
@@ -215,5 +215,18 @@ describe("resolvePrUrl (FR-005 / FR-005a)", () => {
         "https://dev.azure.com/acme-org/_git/weird%20id/pullrequest/81",
       );
     });
+
+    it("never throws on a malformed percent-escape; encodes it as a literal", () => {
+      // `bad%zz` is not valid percent-encoding, so decodeURIComponent throws.
+      // The encoder must fall back to encoding the value as-is (the `%` becomes
+      // `%25`) rather than propagating the error — honoring the documented
+      // "never throws; always returns a string" contract. ADO names cannot
+      // contain a literal `%`, so this input cannot occur in practice; the test
+      // exists to lock the defensive branch.
+      const pr: PrUrlPrRecord = { id: 82, repository_id: "bad%zz" };
+      expect(resolvePrUrl(pr, [], CTX)).toBe(
+        "https://dev.azure.com/acme-org/_git/bad%25zz/pullrequest/82",
+      );
+    });
   });
 });

--- a/extension/tests/modules/shared/pr-url.test.ts
+++ b/extension/tests/modules/shared/pr-url.test.ts
@@ -140,4 +140,80 @@ describe("resolvePrUrl (FR-005 / FR-005a)", () => {
       );
     });
   });
+
+  describe("idempotent encoding — no double-encoding (feature 365)", () => {
+    // Demo/sample data uses only hyphenated lowercase names, which encode to
+    // themselves, so these cases (names with spaces, and names already
+    // percent-encoded) are the only ones that can surface a double-encoding
+    // regression. See specs/365-pr-url-double-encoding/spec.md.
+
+    it("does not double-encode a project name that is already percent-encoded", () => {
+      const repo: PrUrlRepositoryEntry = {
+        repository_id: "repo-guid-enc",
+        repository_name: "consumer-tech",
+        project_name: "Consumer%20Technology",
+        organization_name: "acme-org",
+      };
+      const pr: PrUrlPrRecord = { id: 77, repository_id: "repo-guid-enc" };
+      expect(resolvePrUrl(pr, [repo], CTX)).toBe(
+        "https://dev.azure.com/acme-org/Consumer%20Technology/_git/consumer-tech/pullrequest/77",
+      );
+    });
+
+    it("does not double-encode a repository name that is already percent-encoded", () => {
+      const repo: PrUrlRepositoryEntry = {
+        repository_id: "repo-guid-enc2",
+        repository_name: "iOS%20App",
+        project_name: "Mobile Team",
+        organization_name: "acme-org",
+      };
+      const pr: PrUrlPrRecord = { id: 78, repository_id: "repo-guid-enc2" };
+      expect(resolvePrUrl(pr, [repo], CTX)).toBe(
+        "https://dev.azure.com/acme-org/Mobile%20Team/_git/iOS%20App/pullrequest/78",
+      );
+    });
+
+    it("produces an identical URL whether the name is raw or already percent-encoded", () => {
+      const raw: PrUrlRepositoryEntry = {
+        repository_id: "repo-guid-idem",
+        repository_name: "Web App",
+        project_name: "Consumer Technology",
+        organization_name: "acme-org",
+      };
+      const encoded: PrUrlRepositoryEntry = {
+        ...raw,
+        repository_name: "Web%20App",
+        project_name: "Consumer%20Technology",
+      };
+      const pr: PrUrlPrRecord = { id: 79, repository_id: "repo-guid-idem" };
+      const fromRaw = resolvePrUrl(pr, [raw], CTX);
+      const fromEncoded = resolvePrUrl(pr, [encoded], CTX);
+      expect(fromRaw).toBe(fromEncoded);
+      expect(fromRaw).toBe(
+        "https://dev.azure.com/acme-org/Consumer%20Technology/_git/Web%20App/pullrequest/79",
+      );
+    });
+
+    it("never emits a double-encoded space (%2520) for an already-encoded name", () => {
+      const repo: PrUrlRepositoryEntry = {
+        repository_id: "repo-guid-no2520",
+        repository_name: "api%20server",
+        project_name: "Back%20End",
+        organization_name: "acme-org",
+      };
+      const pr: PrUrlPrRecord = { id: 80, repository_id: "repo-guid-no2520" };
+      const url = resolvePrUrl(pr, [repo], CTX);
+      expect(url).not.toContain("%2520");
+      expect(url).toBe(
+        "https://dev.azure.com/acme-org/Back%20End/_git/api%20server/pullrequest/80",
+      );
+    });
+
+    it("single-encodes an already-encoded repository_id in the fallback form", () => {
+      const pr: PrUrlPrRecord = { id: 81, repository_id: "weird%20id" };
+      expect(resolvePrUrl(pr, [], CTX)).toBe(
+        "https://dev.azure.com/acme-org/_git/weird%20id/pullrequest/81",
+      );
+    });
+  });
 });

--- a/extension/ui/modules/shared/pr-url.ts
+++ b/extension/ui/modules/shared/pr-url.ts
@@ -36,6 +36,33 @@ function ensureTrailingSlash(uri: string): string {
 }
 
 /**
+ * Percent-encode a single URL path segment exactly once, idempotently.
+ *
+ * A stored project/repository name may arrive in one of two forms:
+ *   - raw, with literal spaces/special chars (e.g. `Consumer Technology`), or
+ *   - already percent-encoded (e.g. `Consumer%20Technology`) — common when a
+ *     name is copied verbatim from a browser URL during setup.
+ *
+ * Blindly calling `encodeURIComponent` on the second form double-encodes it
+ * (`%20` -> `%2520`), producing a broken link. Azure DevOps project and
+ * repository names cannot contain a literal `%`, so a valid `%NN` sequence in a
+ * stored name can only be the result of prior encoding — we therefore decode
+ * once before re-encoding, which normalizes BOTH forms to a single encoding
+ * layer. Decoding is wrapped defensively: a malformed sequence (which a legal
+ * ADO name cannot contain) falls back to encoding the value as-is rather than
+ * throwing. Pure and deterministic — no I/O, no locale/environment dependence.
+ */
+function encodePathSegmentOnce(value: string): string {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    decoded = value;
+  }
+  return encodeURIComponent(decoded);
+}
+
+/**
  * Compose the ADO web URL for a PR. Pure function — no I/O, no DOM reads.
  *
  * @param pr The PR record to link to (`id` + `repository_id`).
@@ -53,9 +80,9 @@ export function resolvePrUrl(
   const repo = repositories?.find((r) => r.repository_id === pr.repository_id);
   if (repo && repo.repository_name.length > 0 && repo.project_name.length > 0) {
     return (
-      `${base}${encodeURIComponent(repo.project_name)}/_git/` +
-      `${encodeURIComponent(repo.repository_name)}/pullrequest/${pr.id}`
+      `${base}${encodePathSegmentOnce(repo.project_name)}/_git/` +
+      `${encodePathSegmentOnce(repo.repository_name)}/pullrequest/${pr.id}`
     );
   }
-  return `${base}_git/${encodeURIComponent(pr.repository_id)}/pullrequest/${pr.id}`;
+  return `${base}_git/${encodePathSegmentOnce(pr.repository_id)}/pullrequest/${pr.id}`;
 }

--- a/src/ado_git_repo_insights/ui_bundle/dashboard.js
+++ b/src/ado_git_repo_insights/ui_bundle/dashboard.js
@@ -10424,13 +10424,22 @@ var PRInsightsDashboard = (() => {
   function ensureTrailingSlash(uri) {
     return uri.endsWith("/") ? uri : `${uri}/`;
   }
+  function encodePathSegmentOnce(value) {
+    let decoded;
+    try {
+      decoded = decodeURIComponent(value);
+    } catch {
+      decoded = value;
+    }
+    return encodeURIComponent(decoded);
+  }
   function resolvePrUrl(pr, repositories, webContext) {
     const base = ensureTrailingSlash(webContext.collectionUri);
     const repo = repositories?.find((r2) => r2.repository_id === pr.repository_id);
     if (repo && repo.repository_name.length > 0 && repo.project_name.length > 0) {
-      return `${base}${encodeURIComponent(repo.project_name)}/_git/${encodeURIComponent(repo.repository_name)}/pullrequest/${pr.id}`;
+      return `${base}${encodePathSegmentOnce(repo.project_name)}/_git/${encodePathSegmentOnce(repo.repository_name)}/pullrequest/${pr.id}`;
     }
-    return `${base}_git/${encodeURIComponent(pr.repository_id)}/pullrequest/${pr.id}`;
+    return `${base}_git/${encodePathSegmentOnce(pr.repository_id)}/pullrequest/${pr.id}`;
   }
 
   // ../ui/modules/drilldown/filter-support.ts


### PR DESCRIPTION
## Problem

The dashboard's Azure DevOps PR hyperlinks were **double percent-encoded** for tenants whose project names contain spaces — e.g. `Consumer%2520Technology` instead of `Consumer%20Technology` — producing broken links that land users on a not-found page.

**Root cause:** `resolvePrUrl` called `encodeURIComponent` on the project/repository name, but in some tenants that name is **already percent-encoded**. Project names are commonly copied verbatim from a browser URL during setup, and the extractor interpolates the name straight into ADO REST URLs (`config.example.yaml` even documents `Project%20Three`), so the pre-encoded form is what's stored and carried to the dashboard. Encoding it again turned `%20` into `%2520`. The repository-name segment (captured raw from the API) was unaffected — confirming the asymmetry.

The defect is invisible in demo/sample data because every demo name is hyphenated lowercase (`platform-services`) with no characters encoding would change.

## Fix

Encode each URL path segment **idempotently** via `encodePathSegmentOnce`: decode once, then encode once — normalizing both raw and already-encoded names to a single encoding layer. Safe and deterministic because ADO project/repository names cannot contain a literal `%`, so a `%NN` sequence can only be prior encoding; a malformed sequence falls back to encoding as-is (never throws). Render-time only — no persisted URLs, no storage/config changes (existing extracted data is fixed without re-extraction).

## Tests

Added 5 regression cases (extension test floor 3215 → 3220):
- already-encoded project name not re-encoded
- already-encoded repository name not re-encoded
- raw-vs-encoded idempotency (identical output)
- explicit no-`%2520` guard
- already-encoded `repository_id` in the fallback form

The previous `encodeURIComponent` code fails these, so the regression/failure path is covered. `jest pr-url.test.ts` → 14/14 pass; full pre-push preflight green.

Spec: `specs/365-pr-url-double-encoding/spec.md` (local).

> Note: this branch also carries two preparatory commits — stale-comment corrections in `CLAUDE.md`/`devcontainer.json` and the Spec Kit `feature.json` pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)