### PR TITLE
chore(deps): disable Dependabot version updates without removing config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,22 @@
 # Dependabot Configuration
-# Automatically creates PRs for dependency updates
 # Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+#
+# DISABLED: every ecosystem below sets `open-pull-requests-limit: 0`, which is
+# Dependabot's supported switch for turning version updates off while keeping a
+# valid config. No scheduled dependency PRs are opened. The ecosystem blocks,
+# schedules, groups, and labels are retained so re-enabling is a matter of
+# removing the limit from whichever block(s) you want back.
+#
+# Note: this only governs *version* updates. Dependabot *security* updates are a
+# repository setting (Settings -> Code security), not a file setting, and are
+# unaffected by this config.
 
 version: 2
 updates:
   # Root npm dependencies (semantic-release, repo-standards)
   - package-ecosystem: "npm"
     directory: "/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "monday"
@@ -26,6 +36,7 @@ updates:
   # Extension npm dependencies (TypeScript, Jest, ESLint, etc.)
   - package-ecosystem: "npm"
     directory: "/extension"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "monday"
@@ -52,6 +63,7 @@ updates:
   # Python dependencies (pandas, ruff, pytest, etc.)
   - package-ecosystem: "pip"
     directory: "/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "monday"
@@ -66,6 +78,7 @@ updates:
   # GitHub Actions (actions/checkout, actions/setup-node, etc.)
   - package-ecosystem: "github-actions"
     directory: "/"
+    open-pull-requests-limit: 0
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary

Dependabot was opening automatic dependency PRs every Monday across four ecosystems (root npm, `/extension` npm, pip, github-actions). This disables all of them via `open-pull-requests-limit: 0` — Dependabot's supported switch for turning version updates off — rather than deleting `.github/dependabot.yml`.

The ecosystem blocks, schedules, groups, and labels are all retained, so re-enabling any of them is a one-line removal.

## Why not just empty or delete the file

Emptying `updates:` or commenting the blocks out leaves the file failing schema validation and surfaces a Dependabot config error on the repo. The limit-based switch keeps the config valid while producing zero PRs.

## Scope

This governs **version** updates only. Dependabot **security** updates are a repository setting, not a file setting.

Checked on this repo — they are already off, so no PRs come from that channel:

- `GET /repos/oddessentials/ado-git-repo-insights/vulnerability-alerts` → `404` (alerts disabled)
- `GET /repos/oddessentials/ado-git-repo-insights/automated-security-fixes` → `{"enabled": false, "paused": false}`

No repository setting was changed by this PR.

## Verification

- `yaml.safe_load` of the committed file confirms `version: 2` and `open-pull-requests-limit: 0` on each of the four ecosystems.
- No CI job, script, or test reads this file; it is consumed only by GitHub's Dependabot service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)